### PR TITLE
feat: Add toggle dictation mode (tap to start/stop)

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -65,7 +65,9 @@ struct MenuBarView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 6)
             } else {
-                Text("Hold \(appState.selectedHotkey.displayName) to dictate")
+                Text(appState.useToggleMode
+                    ? "Press \(appState.selectedHotkey.displayName) to toggle dictation"
+                    : "Hold \(appState.selectedHotkey.displayName) to dictate")
                     .foregroundStyle(.secondary)
                     .font(.caption)
                     .padding(.horizontal, 16)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -428,7 +428,11 @@ struct GeneralSettingsView: View {
 
     private var hotkeySection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Hold this key to record, release to transcribe.")
+            Toggle("Toggle mode (tap to start/stop)", isOn: $appState.useToggleMode)
+
+            Text(appState.useToggleMode
+                ? "Press the key to start recording, press again to stop and transcribe."
+                : "Hold this key to record, release to transcribe.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 


### PR DESCRIPTION
Closes #4

## What this does

Adds an optional **toggle dictation mode** where pressing the hotkey starts recording and pressing it again stops and transcribes. No need to hold the key down.

## Changes

- **AppState.swift**: Added `useToggleMode` setting (persisted via UserDefaults). Modified `handleHotkeyDown()` to toggle recording on/off in toggle mode, and `handleHotkeyUp()` to no-op in toggle mode.
- **SettingsView.swift**: Added a Toggle switch in the Push-to-Talk section. Description text updates dynamically based on mode.
- **MenuBarView.swift**: Status text reflects current mode ("Press" vs "Hold").

## How to test

1. Open FreeFlow > Settings > Push-to-Talk Key section
2. Enable "Toggle mode (tap to start/stop)"
3. Press your hotkey once → recording starts
4. Press it again → recording stops and transcription begins
5. Disable toggle mode → hold-to-record behavior returns

No breaking changes — defaults to off (existing hold-to-record behavior preserved).