### PR TITLE
feat: add Fn+Space toggle dictation alongside hold-to-talk

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -95,6 +95,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     let audioRecorder = AudioRecorder()
     let hotkeyManager = HotkeyManager()
+    let toggleHotkeyManager = ToggleHotkeyManager()
     let overlayManager = RecordingOverlayManager()
     private var accessibilityTimer: Timer?
     private var audioLevelCancellable: AnyCancellable?
@@ -313,6 +314,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         }
         hotkeyManager.start(option: selectedHotkey)
+
+        toggleHotkeyManager.onToggle = { [weak self] in
+            DispatchQueue.main.async {
+                self?.handleToggleHotkey()
+            }
+        }
+        toggleHotkeyManager.start()
     }
 
     private func restartHotkeyMonitoring() {
@@ -328,6 +336,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func handleHotkeyUp() {
         guard isRecording else { return }
         stopAndTranscribe()
+    }
+
+    private func handleToggleHotkey() {
+        os_log(.info, log: recordingLog, "handleToggleHotkey() fired, isRecording=%{public}d, isTranscribing=%{public}d", isRecording, isTranscribing)
+        guard !isTranscribing else { return }
+        if isRecording {
+            stopAndTranscribe()
+        } else {
+            startRecording()
+        }
     }
 
     func toggleRecording() {

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -136,3 +136,41 @@ class HotkeyManager {
         stop()
     }
 }
+
+class ToggleHotkeyManager {
+    private var globalKeyDownMonitor: Any?
+    private var localKeyDownMonitor: Any?
+
+    var onToggle: (() -> Void)?
+
+    func start() {
+        stop()
+
+        globalKeyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyDown(event: event)
+        }
+        localKeyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyDown(event: event)
+            return event
+        }
+    }
+
+    private func handleKeyDown(event: NSEvent) {
+        // Space = keyCode 49, must have Fn/Globe modifier active
+        guard event.keyCode == 49,
+              event.modifierFlags.contains(.function),
+              !event.isARepeat else { return }
+        onToggle?()
+    }
+
+    func stop() {
+        if let m = globalKeyDownMonitor { NSEvent.removeMonitor(m) }
+        if let m = localKeyDownMonitor { NSEvent.removeMonitor(m) }
+        globalKeyDownMonitor = nil
+        localKeyDownMonitor = nil
+    }
+
+    deinit {
+        stop()
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -449,6 +449,21 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.orange)
             }
+
+            Divider()
+                .padding(.vertical, 4)
+
+            HStack(spacing: 8) {
+                Image(systemName: "keyboard.badge.ellipsis")
+                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Toggle Dictation: Fn + Space")
+                        .font(.caption.weight(.medium))
+                    Text("Press to start recording, press again to stop. Works alongside hold-to-talk.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #4

## What this does

Adds a dedicated **Fn+Space** keyboard shortcut that toggles dictation on/off, working alongside the existing hold-to-talk key.

- **Fn+Space** → start recording; press again → stop and transcribe
- **Hold-to-talk** → unchanged (hold key to record, release to transcribe)

Both work simultaneously. No configuration needed — the toggle shortcut is always available.

## Changes

- **HotkeyManager.swift**: Added `ToggleHotkeyManager` class that monitors for Space (keyCode 49) while Fn modifier is active.
- **AppState.swift**: Wired up toggle hotkey manager alongside existing hold-to-talk. Added `handleToggleHotkey()` method.
- **SettingsView.swift**: Added info line about Fn+Space toggle shortcut in Push-to-Talk settings section.
- **MenuBarView.swift**: No changes needed (already shows original status text).

## How to test

1. Build: `make run CODESIGN_IDENTITY=-`
2. Hold your push-to-talk key → recording starts, release → transcribes (unchanged)
3. Press Fn+Space → recording starts
4. Press Fn+Space again → recording stops and transcribes

**Note:** If your push-to-talk key is Fn (Globe), pressing Fn will start hold-to-talk recording, and then pressing Space will trigger the toggle to stop it. For the cleanest toggle experience, use Right Option or F5 as your hold-to-talk key.