### PR TITLE
Add configurable sound volume setting

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -49,6 +49,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let customContextPromptLastModifiedStorageKey = "custom_context_prompt_last_modified"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let forceHTTP2TranscriptionStorageKey = "force_http2_transcription"
+    private let soundVolumeStorageKey = "sound_volume"
     private let transcribingIndicatorDelay: TimeInterval = 1.0
     let maxPipelineHistoryCount = 20
 
@@ -141,6 +142,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var soundVolume: Float {
+        didSet {
+            UserDefaults.standard.set(soundVolume, forKey: soundVolumeStorageKey)
+        }
+    }
+
     @Published var isRecording = false
     @Published var isTranscribing = false
     @Published var lastTranscript: String = ""
@@ -209,6 +216,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let customContextPromptLastModified = UserDefaults.standard.string(forKey: customContextPromptLastModifiedStorageKey) ?? ""
         let shortcutStartDelay = max(0, UserDefaults.standard.double(forKey: shortcutStartDelayStorageKey))
         let forceHTTP2Transcription = UserDefaults.standard.bool(forKey: forceHTTP2TranscriptionStorageKey)
+        let soundVolume: Float = UserDefaults.standard.object(forKey: soundVolumeStorageKey) != nil
+            ? UserDefaults.standard.float(forKey: soundVolumeStorageKey) : 1.0
         let initialAccessibility = AXIsProcessTrusted()
         let initialScreenCapturePermission = CGPreflightScreenCaptureAccess()
         var removedAudioFileNames: [String] = []
@@ -239,6 +248,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.customContextPromptLastModified = customContextPromptLastModified
         self.shortcutStartDelay = shortcutStartDelay
         self.forceHTTP2Transcription = forceHTTP2Transcription
+        self.soundVolume = soundVolume
         self.pipelineHistory = savedHistory
         self.hasAccessibility = initialAccessibility
         self.hasScreenRecordingPermission = initialScreenCapturePermission
@@ -767,7 +777,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     self.overlayManager.showRecording(mode: self.activeRecordingTriggerMode ?? triggerMode)
                 }
                 overlayShown = true
-                NSSound(named: "Tink")?.play()
+                let s = NSSound(named: "Tink"); s?.volume = self.soundVolume; s?.play()
             }
         }
 
@@ -885,7 +895,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         statusText = "Transcribing..."
         debugStatusMessage = "Transcribing audio"
         errorMessage = nil
-        NSSound(named: "Pop")?.play()
+        let s = NSSound(named: "Pop"); s?.volume = soundVolume; s?.play()
         overlayManager.slideUpToNotch { }
 
         transcribingIndicatorTask?.cancel()
@@ -1170,7 +1180,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             statusText = "Screenshot Required"
             overlayManager.dismiss()
 
-            NSSound(named: "Basso")?.play()
+            let s = NSSound(named: "Basso"); s?.volume = soundVolume; s?.play()
             showScreenshotPermissionAlert(message: message)
         }
         // Non-permission errors (transient failures) — continue recording without context

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -237,6 +237,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("Microphone", icon: "mic.fill") {
                     microphoneSection
                 }
+                SettingsCard("Sound Volume", icon: "speaker.wave.2.fill") {
+                    soundVolumeSection
+                }
                 SettingsCard("Custom Vocabulary", icon: "text.book.closed.fill") {
                     vocabularySection
                 }
@@ -553,6 +556,35 @@ struct GeneralSettingsView: View {
         }
         .onAppear {
             appState.refreshAvailableMicrophones()
+        }
+    }
+
+    // MARK: Sound Volume
+
+    private var soundVolumeSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Adjust the volume of feedback sounds.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Image(systemName: "speaker.fill")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                Slider(value: $appState.soundVolume, in: 0...1, step: 0.1)
+                Image(systemName: "speaker.wave.3.fill")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                Text("\(Int(appState.soundVolume * 100))%")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 36, alignment: .trailing)
+            }
+
+            Button("Preview") {
+                let s = NSSound(named: "Tink"); s?.volume = appState.soundVolume; s?.play()
+            }
+            .font(.caption)
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a **Sound Volume** slider to Settings > General that controls the volume of all feedback sounds (recording start, stop, and error)
- Volume is adjustable from 0% to 100% in 10% increments, with a Preview button to test
- Defaults to 100% for new users; persisted across launches via UserDefaults

## Test plan
- [x] Open Settings > General and verify the Sound Volume card appears between Microphone and Custom Vocabulary
- [x] Drag the slider and click Preview to confirm volume changes
- [x] Start and stop a dictation to confirm feedback sounds play at the selected volume
- [x] Quit and relaunch to confirm the setting persists