### PR TITLE
Use checkbox style for HTTP/2 transcription toggle

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -463,7 +463,7 @@ struct GeneralSettingsView: View {
 
             Divider()
 
-            Toggle(isOn: $appState.forceHTTP2Transcription) {
+            HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Force HTTP/2 for Transcription")
                         .font(.caption.weight(.semibold))
@@ -471,8 +471,13 @@ struct GeneralSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
+                Spacer(minLength: 0)
+
+                Toggle("", isOn: $appState.forceHTTP2Transcription)
+                    .toggleStyle(.checkbox)
+                    .labelsHidden()
             }
-            .toggleStyle(.switch)
         }
     }
 


### PR DESCRIPTION
Small PR to fix the UI appearance. Seems I forgot to push this commit on the original branch that got merged
- Replace the switch-style toggle with a right-aligned checkbox

Before

<img width="581" height="131" alt="image" src="https://github.com/user-attachments/assets/9d831e3b-2096-47fa-af42-1f581d27be84" />

After

<img width="571" height="102" alt="image" src="https://github.com/user-attachments/assets/04ebad4f-8a7e-4361-8a52-c244e2df804c" />
