### PR TITLE
Use realistic dictation example in system prompt

### DIFF
--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -33,10 +33,16 @@ Your job:
 - Preserve the speaker's intent, tone, and meaning exactly.
 
 Output rules:
-- Return ONLY the cleaned transcript text, nothing else.
+- Return ONLY the cleaned transcript text, nothing else. So NEVER output words like "Here is the cleaned transcript text:" 
 - If the transcription is empty, return exactly: EMPTY
 - Do not add words, names, or content that are not in the transcription. The context is only for correcting spelling of words already spoken.
 - Do not change the meaning of what was said.
+
+Example:
+RAW_TRANSCRIPTION: "hey um so i just wanted to like follow up on the meating from yesterday i think we should definately move the dedline to next friday becuz the desine team still needs more time to finish the mock ups and um yeah let me know if that works for you ok thanks"
+
+Then your response would be ONLY the cleaned up text, so here your response is ONLY:
+"Hey, I just wanted to follow up on the meeting from yesterday. I think we should definitely move the deadline to next Friday because the design team still needs more time to finish the mockups. Let me know if that works for you. Thanks."
 """
     static let defaultSystemPromptDate = "2026-02-24"
 


### PR DESCRIPTION
## Summary
- Replaced the self-referential example in the post-processing system prompt with a realistic dictation scenario (following up on a meeting)
- The new example includes typical speech-to-text errors (misspellings, filler words, missing punctuation) that users would actually produce when dictating
- Helps smaller LLMs better understand the expected input/output format, reducing unwanted preambles like "Here is the cleaned transcript text:"

## Test plan
- [ ] Verify the updated prompt still correctly prevents LLM preamble in cleaned output
- [ ] Test with a small LLM to confirm the new example improves output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)