### PR TITLE
Improve cleaning prompt with example to prevent LLM preamble

### DIFF
--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -33,10 +33,16 @@ Your job:
 - Preserve the speaker's intent, tone, and meaning exactly.
 
 Output rules:
-- Return ONLY the cleaned transcript text, nothing else.
+- Return ONLY the cleaned transcript text, nothing else. So NEVER output words like "Here is the cleaned transcript text:"
 - If the transcription is empty, return exactly: EMPTY
 - Do not add words, names, or content that are not in the transcription. The context is only for correcting spelling of words already spoken.
 - Do not change the meaning of what was said.
+
+Example:
+RAW_TRANSCRIPTION: "hey um so i just wanted to like follow up on the meating from yesterday i think we should definately move the dedline to next friday becuz the desine team still needs more time to finish the mock ups and um yeah let me know if that works for you ok thanks"
+
+Then your response would be ONLY the cleaned up text, so here your response is ONLY:
+"Hey, I just wanted to follow up on the meeting from yesterday. I think we should definitely move the deadline to next Friday because the design team still needs more time to finish the mockups. Let me know if that works for you. Thanks."
 """
     static let defaultSystemPromptDate = "2026-02-24"
 


### PR DESCRIPTION
## Summary
- Adds `So NEVER output words like "Here is the cleaned transcript text:"` to the output rules
- Adds a realistic dictation example (following up on a meeting) showing raw STT input with typical errors and the expected cleaned output
- This helps smaller LLMs understand they should return only the cleaned text, preventing unwanted preambles

## Context
I've been using FreeFlow for a few weeks and recently noticed the transcription cleaning model sometimes prepends phrases like "Here is the cleaned transcript text:" to its output. Adding an explicit example to the system prompt should help prevent this, especially with smaller LLMs.

## Test plan
- [x] Verify cleaned transcriptions no longer include preamble text
- [x] Test with small LLMs to confirm the example improves output consistency