### PR TITLE
Skip whitespace cropping for matched window screenshots

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -487,10 +487,9 @@ Selected text: \(selectedText ?? "None")
         ) else {
             return nil
         }
-        guard let croppedImage = croppedWhitespaceImage(from: image) else { return nil }
 
         if let dataURL = convertImageToDataURL(
-            croppedImage,
+            image,
             mimeType: mimeType,
             fileType: fileType,
             compression: compression,


### PR DESCRIPTION
Removes whitespace cropping from the matched-window screenshot path in AppContextService, while keeping it for the fullscreen fallback.

Why: The app was already capturing only the active window, so the extra crop pass was unnecessary and expensive.

Impact: Matched-window screenshot time dropped from roughly 400ms+ to about 40-120ms in local testing, reducing context-capture latency without changing fallback behavior. Should improve processing time significantly for short dictation runs