### PR TITLE
Change default processing to gpt-oss-20b with fallback to llama-4-scout

### DIFF
--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -88,7 +88,8 @@ Output hygiene:
 
     private let apiKey: String
     private let baseURL: String
-    private let defaultModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    private let defaultModel = "openai/gpt-oss-20b"
+    private let fallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let postProcessingTimeoutSeconds: TimeInterval = 20
 
     init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1") {
@@ -110,10 +111,9 @@ Output hygiene:
                 guard let self else {
                     throw PostProcessingError.invalidResponse("Post-processing service deallocated")
                 }
-                return try await self.process(
+                return try await self.processWithFallback(
                     transcript: transcript,
                     contextSummary: context.contextSummary,
-                    model: defaultModel,
                     customVocabulary: vocabularyTerms,
                     customSystemPrompt: customSystemPrompt
                 )
@@ -135,6 +135,35 @@ Output hygiene:
                 throw error
             }
         }
+    }
+
+    private func processWithFallback(
+        transcript: String,
+        contextSummary: String,
+        customVocabulary: [String],
+        customSystemPrompt: String = ""
+    ) async throws -> PostProcessingResult {
+        do {
+            return try await process(
+                transcript: transcript,
+                contextSummary: contextSummary,
+                model: defaultModel,
+                customVocabulary: customVocabulary,
+                customSystemPrompt: customSystemPrompt
+            )
+        } catch let error as PostProcessingError {
+            guard case .requestFailed(let statusCode, _) = error, statusCode == 429 else {
+                throw error
+            }
+        }
+
+        return try await process(
+            transcript: transcript,
+            contextSummary: contextSummary,
+            model: fallbackModel,
+            customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt
+        )
     }
 
     private func process(


### PR DESCRIPTION
This changes the default post-processing model from llama-4-scout to gpt-oss-20b.

## Why:

gpt-oss-20b performs materially better in our prompt evals, especially on cleanup quality and anti-hallucination behavior.
It also appears to handle non-Latin dictation better, including cases like Japanese where we were more likely to get empty output.
Because the free-plan token limit for gpt-oss-20b is lower than Llama, this also adds an automatic fallback to llama-4-scout when post-processing hits HTTP 429 rate-limit responses. That keeps the higher-quality default while reducing the risk of degraded behavior once users exhaust the GPT daily cap.

## Scope:

Context model remains unchanged.
Only the post-processing default is updated.
Fallback is server-side and automatic; no UI changes.

Closes #64 