### PR TITLE
Fix main actor isolation in app state and delegate

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     let appState = AppState()
     var setupWindow: NSWindow?
@@ -96,10 +97,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             object: window,
             queue: .main
         ) { [weak self] _ in
-            if self?.setupWindow == nil {
-                NSApp.setActivationPolicy(.accessory)
+            Task { @MainActor in
+                if self?.setupWindow == nil {
+                    NSApp.setActivationPolicy(.accessory)
+                }
+                self?.settingsWindow = nil
             }
-            self?.settingsWindow = nil
         }
     }
 
@@ -107,7 +110,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
 
         let setupView = SetupView(onComplete: { [weak self] in
-            self?.completeSetup()
+            Task { @MainActor in
+                self?.completeSetup()
+            }
         })
         .environmentObject(appState)
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -681,6 +681,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         hasScreenRecordingPermission = CGPreflightScreenCaptureAccess()
     }
 
+    @MainActor
     func openScreenCaptureSettings() {
         let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
         if let url = settingsURL {
@@ -923,7 +924,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             statusText = "No Accessibility"
             activeRecordingTriggerMode = nil
             shortcutSessionController.reset()
-            showAccessibilityAlert()
+            Task { @MainActor [weak self] in
+                self?.showAccessibilityAlert()
+            }
             return
         }
         os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
@@ -940,7 +943,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return true
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
-                DispatchQueue.main.async {
+                Task { @MainActor [weak self] in
                     if granted {
                         guard let self, let triggerMode = self.activeRecordingTriggerMode else { return }
                         self.beginRecording(triggerMode: triggerMode)
@@ -959,7 +962,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             statusText = "No Microphone"
             activeRecordingTriggerMode = nil
             shortcutSessionController.reset()
-            showMicrophonePermissionAlert()
+            Task { @MainActor [weak self] in
+                self?.showMicrophonePermissionAlert()
+            }
             return false
         }
     }
@@ -1049,6 +1054,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return "Failed to start recording: \(error.localizedDescription)"
     }
 
+    @MainActor
     func showMicrophonePermissionAlert() {
         let alert = NSAlert()
         alert.messageText = "Microphone Permission Required"
@@ -1067,6 +1073,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func showAccessibilityAlert() {
         let alert = NSAlert()
         alert.messageText = "Accessibility Permission Required"
@@ -1417,6 +1424,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    @MainActor
     private func handleScreenshotCaptureIssue(_ message: String?) {
         guard let message, !message.isEmpty else {
             hasShownScreenshotPermissionAlert = false
@@ -1453,6 +1461,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return lowered.contains("permission") || lowered.contains("screen recording")
     }
 
+    @MainActor
     private func showScreenshotPermissionAlert(message: String) {
         let alert = NSAlert()
         alert.messageText = "Screen Recording Permission Required"
@@ -1468,6 +1477,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func showScreenshotCaptureErrorAlert(message: String) {
         let alert = NSAlert()
         alert.messageText = "Screenshot Capture Failed"


### PR DESCRIPTION
## Summary
- Marked `AppDelegate` and several UI-facing `AppState` methods as `@MainActor` to align AppKit work with the main thread.
- Replaced direct callback UI updates with `Task { @MainActor in ... }` where asynchronous closures re-enter the main actor.
- Ensured permission and alert handling paths for microphone, accessibility, and screenshot capture execute safely on the main actor.

## Testing
- Not run (not requested).
- Reviewed affected call sites for main-thread UI operations and async callbacks.
- Verified the patch only touches `Sources/AppDelegate.swift` and `Sources/AppState.swift`.