### PR TITLE
Raise macOS minimum to 15.2 and update SwiftUI handlers

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>LSMinimumSystemVersion</key>
-    <string>13.0</string>
+    <string>15.2</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSMicrophoneUsageDescription</key>

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ ifeq ($(ARCH),universal)
 		-parse-as-library \
 		-o "$(MACOS_DIR)/$(APP_NAME)-arm64" \
 		-sdk $(shell xcrun --show-sdk-path) \
-		-target arm64-apple-macosx13.0 \
+		-target arm64-apple-macosx15.2 \
 		$(SOURCES)
 	swiftc \
 		-parse-as-library \
 		-o "$(MACOS_DIR)/$(APP_NAME)-x86_64" \
 		-sdk $(shell xcrun --show-sdk-path) \
-		-target x86_64-apple-macosx13.0 \
+		-target x86_64-apple-macosx15.2 \
 		$(SOURCES)
 	lipo -create -output "$(MACOS_DIR)/$(APP_NAME)" \
 		"$(MACOS_DIR)/$(APP_NAME)-arm64" \
@@ -44,7 +44,7 @@ else
 		-parse-as-library \
 		-o "$(MACOS_DIR)/$(APP_NAME)" \
 		-sdk $(shell xcrun --show-sdk-path) \
-		-target $(ARCH)-apple-macosx13.0 \
+		-target $(ARCH)-apple-macosx15.2 \
 		$(SOURCES)
 endif
 	@cp Info.plist "$(CONTENTS)/"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg"><b>⬇ Download FreeFlow.dmg</b></a><br>
-  <sub>Works on all Macs (Apple Silicon + Intel)</sub>
+  <sub>Requires macOS 15.2 or later. Works on Apple Silicon and Intel Macs.</sub>
 </p>
 
 ---
@@ -32,6 +32,8 @@ It's called FreeFlow. Here's how it works:
 1. Download the app from above or [click here](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg)
 2. Get a free Groq API key from [groq.com](https://groq.com/)
 3. Hold `Fn` to talk, or tap `Command-Fn` to start and stop dictation, and have whatever you say pasted into the current text field
+
+Minimum OS version: macOS 15.2
 
 You can also customize both shortcuts. If your toggle shortcut extends your hold shortcut, you can start in hold mode and press the extra modifier keys to latch into tap mode without stopping the recording.
 

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ApplicationServices
 import AppKit
+import ScreenCaptureKit
 
 struct AppContext {
     let appName: String?
@@ -64,7 +65,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
 
         let windowTitle = focusedWindowTitle(from: appElement) ?? appName
         let selectedText = selectedText(from: appElement)
-        let screenshot = captureActiveWindowScreenshot(
+        let screenshot = await captureActiveWindowScreenshot(
             processIdentifier: frontmostApp.processIdentifier,
             appElement: appElement,
             focusedWindowTitle: windowTitle
@@ -289,7 +290,7 @@ Selected text: \(selectedText ?? "None")
               CFGetTypeID(rawValue) == AXUIElementGetTypeID() else {
             return nil
         }
-        return unsafeBitCast(rawValue, to: AXUIElement.self)
+        return unsafeDowncast(rawValue, to: AXUIElement.self)
     }
 
     private func accessibilityString(from element: AXUIElement, attribute: CFString) -> String? {
@@ -308,7 +309,7 @@ Selected text: \(selectedText ?? "None")
             return nil
         }
 
-        let axValue = unsafeBitCast(rawValue, to: AXValue.self)
+        let axValue = unsafeDowncast(rawValue, to: AXValue.self)
         var point = CGPoint.zero
         guard AXValueGetValue(axValue, .cgPoint, &point) else { return nil }
         return point
@@ -323,7 +324,7 @@ Selected text: \(selectedText ?? "None")
             return nil
         }
 
-        let axValue = unsafeBitCast(rawValue, to: AXValue.self)
+        let axValue = unsafeDowncast(rawValue, to: AXValue.self)
         var size = CGSize.zero
         guard AXValueGetValue(axValue, .cgSize, &size) else { return nil }
         return size
@@ -333,7 +334,7 @@ Selected text: \(selectedText ?? "None")
         processIdentifier: pid_t,
         appElement: AXUIElement,
         focusedWindowTitle: String?
-    ) -> (dataURL: String?, mimeType: String?, error: String?) {
+    ) async -> (dataURL: String?, mimeType: String?, error: String?) {
         if !CGPreflightScreenCaptureAccess() {
             return (
                 nil,
@@ -403,7 +404,7 @@ Selected text: \(selectedText ?? "None")
                     return lhs.0.layer < rhs.0.layer
                 })
                     .first?.0 {
-                if let dataURL = captureWindowImage(
+                if let dataURL = await captureWindowImage(
                     windowID: activeWindow.id,
                     fileType: .jpeg,
                     mimeType: "image/jpeg",
@@ -437,7 +438,7 @@ Selected text: \(selectedText ?? "None")
                        return lhs.layer < rhs.layer
                    })
                    .first {
-                if let dataURL = captureWindowImage(
+                if let dataURL = await captureWindowImage(
                     windowID: activeWindow.id,
                     fileType: .jpeg,
                     mimeType: "image/jpeg",
@@ -449,12 +450,11 @@ Selected text: \(selectedText ?? "None")
             }
         }
 
-        guard let fullScreenImage = CGWindowListCreateImage(
-            CGRect.infinite,
-            .optionOnScreenOnly,
-            kCGNullWindowID,
-            [.bestResolution]
-        ) else {
+        let fullScreenImage = await captureFallbackDisplayImage(
+            focusedWindowBounds: focusedWindowBounds(from: appElement)
+        )
+
+        guard let fullScreenImage else {
             return (nil, nil, "Could not capture screenshot (screen recording permission or window access issue)")
         }
 
@@ -478,13 +478,21 @@ Selected text: \(selectedText ?? "None")
         mimeType: String,
         compression: Double? = nil,
         maxDimension: CGFloat? = nil
-    ) -> String? {
-        guard let image = CGWindowListCreateImage(
-            .null,
-            .optionIncludingWindow,
-            windowID,
-            [.bestResolution]
-        ) else {
+    ) async -> String? {
+        guard let shareableContent = await currentShareableContent(),
+              let window = shareableContent.windows.first(where: { $0.windowID == windowID }) else {
+            return nil
+        }
+
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let windowSize = window.frame.size
+        let image = await captureImage(
+            using: filter,
+            contentRect: CGRect(origin: .zero, size: windowSize),
+            scaleFactor: displayScaleFactor(containing: window.frame)
+        )
+
+        guard let image else {
             return nil
         }
 
@@ -499,6 +507,62 @@ Selected text: \(selectedText ?? "None")
         }
 
         return nil
+    }
+
+    private func captureFallbackDisplayImage(focusedWindowBounds: CGRect?) async -> CGImage? {
+        guard let shareableContent = await currentShareableContent() else {
+            return nil
+        }
+
+        let candidateRects = [focusedWindowBounds].compactMap { $0 } + shareableContent.displays.map(\.frame)
+        let unionRect = candidateRects.reduce(CGRect.null) { partial, rect in
+            partial.isNull ? rect : partial.union(rect)
+        }
+        guard !unionRect.isNull else {
+            return nil
+        }
+        return await captureImage(in: unionRect)
+    }
+
+    private func currentShareableContent() async -> SCShareableContent? {
+        await withCheckedContinuation { continuation in
+            SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: true) { content, _ in
+                continuation.resume(returning: content)
+            }
+        }
+    }
+
+    private func captureImage(
+        using filter: SCContentFilter,
+        contentRect: CGRect,
+        scaleFactor: CGFloat
+    ) async -> CGImage? {
+        let config = SCStreamConfiguration()
+        config.width = max(1, Int(contentRect.width * scaleFactor))
+        config.height = max(1, Int(contentRect.height * scaleFactor))
+        config.showsCursor = false
+        config.scalesToFit = true
+
+        return await withCheckedContinuation { continuation in
+            SCScreenshotManager.captureImage(contentFilter: filter, configuration: config) { image, _ in
+                continuation.resume(returning: image)
+            }
+        }
+    }
+
+    private func captureImage(in rect: CGRect) async -> CGImage? {
+        await withCheckedContinuation { continuation in
+            SCScreenshotManager.captureImage(in: rect) { image, _ in
+                continuation.resume(returning: image)
+            }
+        }
+    }
+
+    private func displayScaleFactor(containing rect: CGRect) -> CGFloat {
+        if let screen = NSScreen.screens.first(where: { $0.frame.intersects(rect) }) {
+            return max(1, screen.backingScaleFactor)
+        }
+        return max(1, NSScreen.main?.backingScaleFactor ?? 2)
     }
 
     private func boundsValue(_ value: Any?) -> CGSize? {

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -514,14 +514,14 @@ Selected text: \(selectedText ?? "None")
             return nil
         }
 
-        let candidateRects = [focusedWindowBounds].compactMap { $0 } + shareableContent.displays.map(\.frame)
-        let unionRect = candidateRects.reduce(CGRect.null) { partial, rect in
-            partial.isNull ? rect : partial.union(rect)
-        }
-        guard !unionRect.isNull else {
+        guard let display = relevantDisplay(
+            from: shareableContent.displays,
+            focusedWindowBounds: focusedWindowBounds
+        ) else {
             return nil
         }
-        return await captureImage(in: unionRect)
+
+        return await captureImage(in: display.frame)
     }
 
     private func currentShareableContent() async -> SCShareableContent? {
@@ -556,6 +556,65 @@ Selected text: \(selectedText ?? "None")
                 continuation.resume(returning: image)
             }
         }
+    }
+
+    private func relevantDisplay(
+        from displays: [SCDisplay],
+        focusedWindowBounds: CGRect?
+    ) -> SCDisplay? {
+        guard !displays.isEmpty else {
+            return nil
+        }
+
+        if let focusedWindowBounds, !focusedWindowBounds.isNull {
+            let focusedCenter = CGPoint(
+                x: focusedWindowBounds.midX,
+                y: focusedWindowBounds.midY
+            )
+
+            if let containingDisplay = displays.first(where: { $0.frame.contains(focusedCenter) }) {
+                return containingDisplay
+            }
+
+            return displays.min {
+                distanceSquared(from: focusedCenter, to: $0.frame) < distanceSquared(from: focusedCenter, to: $1.frame)
+            }
+        }
+
+        if let mainDisplay = displays.first(where: { $0.displayID == CGMainDisplayID() }) {
+            return mainDisplay
+        }
+
+        let cursorLocation = NSEvent.mouseLocation
+        if let cursorDisplay = displays.first(where: { $0.frame.contains(cursorLocation) }) {
+            return cursorDisplay
+        }
+
+        return displays.min {
+            distanceSquared(from: cursorLocation, to: $0.frame) < distanceSquared(from: cursorLocation, to: $1.frame)
+        }
+    }
+
+    private func distanceSquared(from point: CGPoint, to rect: CGRect) -> CGFloat {
+        let deltaX: CGFloat
+        if point.x < rect.minX {
+            deltaX = rect.minX - point.x
+        } else if point.x > rect.maxX {
+            deltaX = point.x - rect.maxX
+        } else {
+            deltaX = 0
+        }
+
+        let deltaY: CGFloat
+        if point.y < rect.minY {
+            deltaY = rect.minY - point.y
+        } else if point.y > rect.maxY {
+            deltaY = point.y - rect.maxY
+        } else {
+            deltaY = 0
+        }
+
+        return (deltaX * deltaX) + (deltaY * deltaY)
     }
 
     private func displayScaleFactor(containing rect: CGRect) -> CGFloat {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -417,7 +417,7 @@ struct GeneralSettingsView: View {
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .disabled(isValidatingKey)
-                    .onChange(of: apiKeyInput) { _ in
+                    .onChange(of: apiKeyInput) {
                         keyValidationError = nil
                         keyValidationSuccess = false
                     }
@@ -451,7 +451,7 @@ struct GeneralSettingsView: View {
                 TextField("https://api.groq.com/openai/v1", text: $apiBaseURLInput)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
-                    .onChange(of: apiBaseURLInput) { newValue in
+                    .onChange(of: apiBaseURLInput) { _, newValue in
                         let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                         if !trimmed.isEmpty {
                             appState.apiBaseURL = trimmed
@@ -627,7 +627,7 @@ struct GeneralSettingsView: View {
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customVocabularyInput) { newValue in
+                .onChange(of: customVocabularyInput) { _, newValue in
                     appState.customVocabulary = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
 
@@ -841,7 +841,7 @@ struct PromptsSettingsView: View {
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customSystemPromptInput) { newValue in
+                .onChange(of: customSystemPromptInput) { _, newValue in
                     let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                     let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
                     if trimmed == defaultTrimmed || trimmed.isEmpty {
@@ -1062,7 +1062,7 @@ struct PromptsSettingsView: View {
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customContextPromptInput) { newValue in
+                .onChange(of: customContextPromptInput) { _, newValue in
                     let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                     let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
                     if trimmed == defaultTrimmed || trimmed.isEmpty {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -152,7 +152,7 @@ struct SetupView: View {
             screenRecordingTimer?.invalidate()
             appState.resumeHotkeyMonitoringAfterShortcutCapture()
         }
-        .onChange(of: isCapturingShortcut) { isCapturing in
+        .onChange(of: isCapturingShortcut) { _, isCapturing in
             if isCapturing {
                 appState.suspendHotkeyMonitoringForShortcutCapture()
             } else {
@@ -348,7 +348,7 @@ struct SetupView: View {
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
                         .disabled(isValidatingKey)
-                        .onChange(of: apiKeyInput) { _ in
+                        .onChange(of: apiKeyInput) {
                             keyValidationError = nil
                         }
 

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -60,7 +60,7 @@ struct DictationShortcutEditor: View {
                     .foregroundStyle(.orange)
             }
         }
-        .onChange(of: activeCaptureRole) { role in
+        .onChange(of: activeCaptureRole) { _, role in
             onCaptureStateChange?(role != nil)
         }
         .onDisappear {


### PR DESCRIPTION
## Summary
- Raise the macOS deployment target to 15.2 in the build target and update the README to reflect the new minimum OS requirement.
- Switch app context screenshot capture to ScreenCaptureKit and modernize related unsafe casts.
- Update SwiftUI `onChange` handlers to the new two-parameter signature for compatibility with the newer SDK.

## Testing
- Not run (not requested).
- Verified the patch updates the build target, documentation, and SwiftUI handler signatures consistently across touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum macOS requirement to 15.2 or later for both Apple Silicon and Intel Macs.
  * Modernized screenshot capture implementation for improved reliability.
  * Refactored UI event handlers for improved code compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->