### PR TITLE
Add alert sound disable toggle

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -127,6 +127,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
     private let forceHTTP2TranscriptionStorageKey = "force_http2_transcription"
+    private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
     private let voiceMacrosStorageKey = "voice_macros"
     private let transcribingIndicatorDelay: TimeInterval = 1.0
@@ -228,6 +229,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var alertSoundsEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(alertSoundsEnabled, forKey: alertSoundsEnabledStorageKey)
+        }
+    }
+
     @Published var soundVolume: Float {
         didSet {
             UserDefaults.standard.set(soundVolume, forKey: soundVolumeStorageKey)
@@ -319,6 +326,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let forceHTTP2Transcription = UserDefaults.standard.bool(forKey: forceHTTP2TranscriptionStorageKey)
         let soundVolume: Float = UserDefaults.standard.object(forKey: soundVolumeStorageKey) != nil
             ? UserDefaults.standard.float(forKey: soundVolumeStorageKey) : 1.0
+        let alertSoundsEnabled = UserDefaults.standard.object(forKey: alertSoundsEnabledStorageKey) != nil
+            ? UserDefaults.standard.bool(forKey: alertSoundsEnabledStorageKey)
+            : soundVolume > 0
         
         let initialMacros: [VoiceMacro]
         if let data = UserDefaults.standard.data(forKey: "voice_macros"),
@@ -359,6 +369,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
         self.forceHTTP2Transcription = forceHTTP2Transcription
+        self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
         self.pipelineHistory = savedHistory
@@ -998,7 +1009,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     self.overlayManager.showRecording(mode: self.activeRecordingTriggerMode ?? triggerMode)
                 }
                 overlayShown = true
-                let s = NSSound(named: "Tink"); s?.volume = self.soundVolume; s?.play()
+                self.playAlertSound(named: "Tink")
             }
         }
 
@@ -1097,6 +1108,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return strippedPunctuation.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    func playAlertSound(named name: String) {
+        guard alertSoundsEnabled else { return }
+
+        let sound = NSSound(named: name)
+        sound?.volume = soundVolume
+        sound?.play()
+    }
+
     private func findMatchingMacro(for transcript: String) -> VoiceMacro? {
         let normalizedTranscript = normalize(transcript)
         guard !normalizedTranscript.isEmpty else { return nil }
@@ -1166,7 +1185,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         statusText = "Transcribing..."
         debugStatusMessage = "Transcribing audio"
         errorMessage = nil
-        let s = NSSound(named: "Pop"); s?.volume = soundVolume; s?.play()
+        playAlertSound(named: "Pop")
         overlayManager.slideUpToNotch { }
 
         transcribingIndicatorTask?.cancel()
@@ -1442,7 +1461,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             statusText = "Screenshot Required"
             overlayManager.dismiss()
 
-            let s = NSSound(named: "Basso"); s?.volume = soundVolume; s?.play()
+            playAlertSound(named: "Basso")
             showScreenshotPermissionAlert(message: message)
         }
         // Non-permission errors (transient failures) — continue recording without context

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -587,9 +587,7 @@ struct GeneralSettingsView: View {
 
     private var soundVolumeSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Adjust the volume of feedback sounds.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            Toggle("Play alert sounds", isOn: $appState.alertSoundsEnabled)
 
             HStack(spacing: 12) {
                 Image(systemName: "speaker.fill")
@@ -604,11 +602,14 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 36, alignment: .trailing)
             }
+            .disabled(!appState.alertSoundsEnabled)
+            .opacity(appState.alertSoundsEnabled ? 1 : 0.5)
 
             Button("Preview") {
-                let s = NSSound(named: "Tink"); s?.volume = appState.soundVolume; s?.play()
+                appState.playAlertSound(named: "Tink")
             }
             .font(.caption)
+            .disabled(!appState.alertSoundsEnabled)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a new `Play alert sounds` setting that persists in `UserDefaults`.
- Route all alert sound playback through a shared helper so sounds respect the new toggle.
- Disable and dim the volume controls and preview action when alert sounds are turned off.
- Preserve existing behavior for users by defaulting the new setting based on the current sound volume.

## Testing
- Not run
- Verified the change set updates both settings UI and playback paths consistently
- Verified the new preference is persisted and restored from `UserDefaults`