### PR TITLE
Filter 'thank you' hallucinations using whisper no_speech_prob

### DIFF
--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -9,6 +9,7 @@ class TranscriptionService {
     private let baseURL: String
     private let forceHTTP2: Bool
     private let transcriptionModel = "whisper-large-v3"
+    private let transcriptionResponseFormat = "verbose_json"
     private let transcriptionTimeoutSeconds: TimeInterval = 20
     private let uploadSampleRate = 16_000.0
     private let uploadChannelCount: AVAudioChannelCount = 1
@@ -83,6 +84,7 @@ class TranscriptionService {
             audioData: audioData,
             fileName: fileURL.lastPathComponent,
             model: transcriptionModel,
+            responseFormat: transcriptionResponseFormat,
             boundary: boundary
         )
 
@@ -128,7 +130,7 @@ class TranscriptionService {
     }
 
     private func transcribeAudioWithCurl(fileURL: URL) async throws -> String {
-        try await Task.detached(priority: .userInitiated) { [apiKey, transcriptionModel] in
+        try await Task.detached(priority: .userInitiated) { [apiKey, transcriptionModel, transcriptionResponseFormat] in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
             process.arguments = [
@@ -140,6 +142,7 @@ class TranscriptionService {
                 "\(self.baseURL)/audio/transcriptions",
                 "-H", "Authorization: Bearer \(apiKey)",
                 "-F", "model=\(transcriptionModel)",
+                "-F", "response_format=\(transcriptionResponseFormat)",
                 "-F", "file=@\(fileURL.path);type=\(self.audioContentType(for: fileURL.lastPathComponent))"
             ]
 
@@ -194,7 +197,13 @@ class TranscriptionService {
         return (attributes?[.size] as? NSNumber)?.int64Value ?? -1
     }
 
-    private func makeMultipartBody(audioData: Data, fileName: String, model: String, boundary: String) -> Data {
+    private func makeMultipartBody(
+        audioData: Data,
+        fileName: String,
+        model: String,
+        responseFormat: String,
+        boundary: String
+    ) -> Data {
         var body = Data()
 
         func append(_ value: String) {
@@ -204,6 +213,10 @@ class TranscriptionService {
         append("--\(boundary)\r\n")
         append("Content-Disposition: form-data; name=\"model\"\r\n\r\n")
         append("\(model)\r\n")
+
+        append("--\(boundary)\r\n")
+        append("Content-Disposition: form-data; name=\"response_format\"\r\n\r\n")
+        append("\(responseFormat)\r\n")
 
         append("--\(boundary)\r\n")
         append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n")
@@ -240,9 +253,26 @@ class TranscriptionService {
             && format.commonFormat == .pcmFormatInt16
     }
 
+    // Whisper-large-v3 hallucinates common short phrases on silence/background
+    // noise. Drop them when whisper itself reports a high no_speech_prob.
+    // Add a new (phrase, minNoSpeechProb) pair here to filter more hallucinations.
+    //
+    // Thresholds tuned on ~500 samples from quiet and noisy environments, including
+    // both positive cases (real "thank you" speech) and empty-audio cases. Kept
+    // conservative to minimize false positives (filtering real user speech).
+    // Normal speech included audios have very low no_speech_prob.
+    private let hallucinationPhrases: [(phrase: String, minNoSpeechProb: Double)] = [
+        ("thank you", 0.06),
+        ("thank you very much", 0.06),
+        ("thank you so much", 0.06)
+    ]
+
     private func parseTranscript(from data: Data) throws -> String {
         if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
            let text = json["text"] as? String {
+            if isHallucination(text: text, json: json) {
+                return ""
+            }
             return text
         }
 
@@ -256,6 +286,20 @@ class TranscriptionService {
         }
 
         return text
+    }
+
+    private func isHallucination(text: String, json: [String: Any]) -> Bool {
+        let normalized = text
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet.punctuationCharacters.union(.whitespacesAndNewlines))
+        guard let match = hallucinationPhrases.first(where: { $0.phrase == normalized }) else {
+            return false
+        }
+        guard let segments = json["segments"] as? [[String: Any]],
+              let noSpeechProb = segments.first?["no_speech_prob"] as? Double else {
+            return false
+        }
+        return noSpeechProb >= match.minNoSpeechProb
     }
 }
 

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -261,11 +261,14 @@ class TranscriptionService {
     // both positive cases (real "thank you" speech) and empty-audio cases. Kept
     // conservative to minimize false positives (filtering real user speech).
     // Normal speech included audios have very low no_speech_prob.
-    private let hallucinationPhrases: [(phrase: String, minNoSpeechProb: Double)] = [
-        ("thank you", 0.06),
-        ("thank you very much", 0.06),
-        ("thank you so much", 0.06)
+    private let hallucinationPhrases = [
+        "thank you",
+        "thank you very much",
+        "thank you so much",
+        "you"
     ]
+
+    private let hallucinationNoSpeechThreshold = 0.1
 
     private func parseTranscript(from data: Data) throws -> String {
         if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -292,14 +295,14 @@ class TranscriptionService {
         let normalized = text
             .lowercased()
             .trimmingCharacters(in: CharacterSet.punctuationCharacters.union(.whitespacesAndNewlines))
-        guard let match = hallucinationPhrases.first(where: { $0.phrase == normalized }) else {
+        guard hallucinationPhrases.contains(normalized) else {
             return false
         }
         guard let segments = json["segments"] as? [[String: Any]],
               let noSpeechProb = segments.first?["no_speech_prob"] as? Double else {
             return false
         }
-        return noSpeechProb >= match.minNoSpeechProb
+        return noSpeechProb >= hallucinationNoSpeechThreshold
     }
 }
 


### PR DESCRIPTION
Issue: https://github.com/zachlatta/freeflow/issues/68

`whisper-large-v3` model often outputs random phrases for the audio with no speech, especially "thank you" / "thank you very much". Using `no_speech_prob` value from the model, we can filter these cases out.

## Changes

- Request `response_format=verbose_json` from Groq so the response includes `segments[].no_speech_prob`.
- If the normalized text matches a known hallucination phrase (2 phrases right now, but can expand) *and* `no_speech_prob` clears that phrase's threshold, return empty.
- The current threshold `0.06` is fine-tuned on a private dataset (size ~500) recorded from different environments  (quiet + noisy, real speech + silence). Real speech that say 'thank you' clustered well below it (<0.02)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intelligent hallucination detection now automatically identifies and filters out false or incorrectly generated transcriptions, improving overall accuracy and reliability
  * Enhanced transcription responses now utilize verbose JSON format with more comprehensive and structured data for detailed analysis and processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->