### PR TITLE
Migrate audio pipeline to AVCaptureSession

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ApplicationServices
 import AppKit
-import Darwin
 
 struct AppContext {
     let appName: String?
@@ -17,31 +16,6 @@ struct AppContext {
     var contextSummary: String {
         currentActivity
     }
-}
-
-private typealias CGWindowListCreateImageCompat = @convention(c) (
-    CGRect,
-    CGWindowListOption,
-    CGWindowID,
-    CGWindowImageOption
-) -> Unmanaged<CGImage>?
-
-private func cgWindowListCreateImageCompat(
-    screenBounds: CGRect,
-    listOption: CGWindowListOption,
-    windowID: CGWindowID,
-    imageOption: CGWindowImageOption
-) -> CGImage? {
-    struct Loader {
-        static let function: CGWindowListCreateImageCompat? = {
-            guard let symbol = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "CGWindowListCreateImage") else {
-                return nil
-            }
-            return unsafeBitCast(symbol, to: CGWindowListCreateImageCompat.self)
-        }()
-    }
-
-    return Loader.function?(screenBounds, listOption, windowID, imageOption)?.takeRetainedValue()
 }
 
 final class AppContextService {
@@ -475,11 +449,11 @@ Selected text: \(selectedText ?? "None")
             }
         }
 
-        guard let fullScreenImage = cgWindowListCreateImageCompat(
-            screenBounds: CGRect.infinite,
-            listOption: .optionOnScreenOnly,
-            windowID: kCGNullWindowID,
-            imageOption: [.bestResolution]
+        guard let fullScreenImage = CGWindowListCreateImage(
+            CGRect.infinite,
+            .optionOnScreenOnly,
+            kCGNullWindowID,
+            [.bestResolution]
         ) else {
             return (nil, nil, "Could not capture screenshot (screen recording permission or window access issue)")
         }
@@ -505,11 +479,11 @@ Selected text: \(selectedText ?? "None")
         compression: Double? = nil,
         maxDimension: CGFloat? = nil
     ) -> String? {
-        guard let image = cgWindowListCreateImageCompat(
-            screenBounds: .null,
-            listOption: .optionIncludingWindow,
-            windowID: windowID,
-            imageOption: [.bestResolution]
+        guard let image = CGWindowListCreateImage(
+            .null,
+            .optionIncludingWindow,
+            windowID,
+            [.bestResolution]
         ) else {
             return nil
         }

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ApplicationServices
 import AppKit
+import Darwin
 
 struct AppContext {
     let appName: String?
@@ -16,6 +17,31 @@ struct AppContext {
     var contextSummary: String {
         currentActivity
     }
+}
+
+private typealias CGWindowListCreateImageCompat = @convention(c) (
+    CGRect,
+    CGWindowListOption,
+    CGWindowID,
+    CGWindowImageOption
+) -> Unmanaged<CGImage>?
+
+private func cgWindowListCreateImageCompat(
+    screenBounds: CGRect,
+    listOption: CGWindowListOption,
+    windowID: CGWindowID,
+    imageOption: CGWindowImageOption
+) -> CGImage? {
+    struct Loader {
+        static let function: CGWindowListCreateImageCompat? = {
+            guard let symbol = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "CGWindowListCreateImage") else {
+                return nil
+            }
+            return unsafeBitCast(symbol, to: CGWindowListCreateImageCompat.self)
+        }()
+    }
+
+    return Loader.function?(screenBounds, listOption, windowID, imageOption)?.takeRetainedValue()
 }
 
 final class AppContextService {
@@ -449,11 +475,11 @@ Selected text: \(selectedText ?? "None")
             }
         }
 
-        guard let fullScreenImage = CGWindowListCreateImage(
-            CGRect.infinite,
-            .optionOnScreenOnly,
-            kCGNullWindowID,
-            [.bestResolution]
+        guard let fullScreenImage = cgWindowListCreateImageCompat(
+            screenBounds: CGRect.infinite,
+            listOption: .optionOnScreenOnly,
+            windowID: kCGNullWindowID,
+            imageOption: [.bestResolution]
         ) else {
             return (nil, nil, "Could not capture screenshot (screen recording permission or window access issue)")
         }
@@ -479,11 +505,11 @@ Selected text: \(selectedText ?? "None")
         compression: Double? = nil,
         maxDimension: CGFloat? = nil
     ) -> String? {
-        guard let image = CGWindowListCreateImage(
-            .null,
-            .optionIncludingWindow,
-            windowID,
-            [.bestResolution]
+        guard let image = cgWindowListCreateImageCompat(
+            screenBounds: .null,
+            listOption: .optionIncludingWindow,
+            windowID: windowID,
+            imageOption: [.bestResolution]
         ) else {
             return nil
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1012,6 +1012,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.playAlertSound(named: "Tink")
             }
         }
+        audioRecorder.onRecordingFailure = { [weak self] error in
+            guard let self else { return }
+            initTimer.cancel()
+            self.handleRecordingFailure(error)
+        }
 
         // Start engine on background thread so UI isn't blocked
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -1031,15 +1036,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } catch {
                 DispatchQueue.main.async {
                     initTimer.cancel()
-                    self.isRecording = false
-                    self.activeRecordingTriggerMode = nil
-                    self.shortcutSessionController.reset()
-                    self.errorMessage = self.formattedRecordingStartError(error)
-                    self.statusText = "Error"
-                    self.overlayManager.dismiss()
+                    self.handleRecordingFailure(error)
                 }
             }
         }
+    }
+
+    private func handleRecordingFailure(_ error: Error) {
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
+        audioLevelCancellable?.cancel()
+        audioLevelCancellable = nil
+        contextCaptureTask?.cancel()
+        contextCaptureTask = nil
+        capturedContext = nil
+        audioRecorder.cleanup()
+        isRecording = false
+        activeRecordingTriggerMode = nil
+        shortcutSessionController.reset()
+        errorMessage = formattedRecordingStartError(error)
+        statusText = "Error"
+        overlayManager.dismiss()
     }
 
     private func formattedRecordingStartError(_ error: Error) -> String {
@@ -1155,6 +1172,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         cancelPendingShortcutStart()
         shortcutSessionController.reset()
         activeRecordingTriggerMode = nil
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
         debugStatusMessage = "Preparing audio"
@@ -1169,151 +1188,154 @@ final class AppState: ObservableObject, @unchecked Sendable {
         lastPostProcessingPrompt = ""
         lastContextScreenshotDataURL = nil
         lastContextScreenshotStatus = "No screenshot"
-
-        guard let fileURL = audioRecorder.stopRecording() else {
-            audioRecorder.cleanup()
-            errorMessage = "No audio recorded"
-            isRecording = false
-            statusText = "Error"
-            overlayManager.dismiss()
-            return
-        }
-        let savedAudioFile = Self.saveAudioFile(from: fileURL)
-        let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
         isRecording = false
-        isTranscribing = true
-        statusText = "Transcribing..."
-        debugStatusMessage = "Transcribing audio"
+        statusText = "Preparing audio..."
         errorMessage = nil
         playAlertSound(named: "Pop")
         overlayManager.slideUpToNotch { }
+        audioRecorder.stopRecording { [weak self] fileURL in
+            guard let self else { return }
+            guard let fileURL else {
+                self.audioRecorder.cleanup()
+                self.errorMessage = "No audio recorded"
+                self.statusText = "Error"
+                self.overlayManager.dismiss()
+                return
+            }
 
-        transcribingIndicatorTask?.cancel()
-        let indicatorDelay = transcribingIndicatorDelay
-        transcribingIndicatorTask = Task { [weak self] in
-            do {
-                try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
-                let shouldShowTranscribing = self?.isTranscribing ?? false
-                guard shouldShowTranscribing else { return }
-                await MainActor.run { [weak self] in
-                    self?.overlayManager.showTranscribing()
-                }
-            } catch {}
-        }
+            let savedAudioFile = Self.saveAudioFile(from: fileURL)
+            let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
+            self.isTranscribing = true
+            self.statusText = "Transcribing..."
+            self.debugStatusMessage = "Transcribing audio"
 
-        let transcriptionService = TranscriptionService(
-            apiKey: apiKey,
-            baseURL: apiBaseURL,
-            forceHTTP2: forceHTTP2Transcription
-        )
-        let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
+            self.transcribingIndicatorTask?.cancel()
+            let indicatorDelay = self.transcribingIndicatorDelay
+            self.transcribingIndicatorTask = Task { [weak self] in
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
+                    let shouldShowTranscribing = self?.isTranscribing ?? false
+                    guard shouldShowTranscribing else { return }
+                    await MainActor.run { [weak self] in
+                        self?.overlayManager.showTranscribing()
+                    }
+                } catch {}
+            }
 
-        Task {
-            do {
-                async let transcript = transcriptionService.transcribe(fileURL: transcriptionFileURL)
-                let rawTranscript = try await transcript
-                let appContext: AppContext
-                if let sessionContext {
-                    appContext = sessionContext
-                } else if let inFlightContext = await inFlightContextTask?.value {
-                    appContext = inFlightContext
-                } else {
-                    appContext = fallbackContextAtStop()
-                }
-                await MainActor.run { [weak self] in
-                    self?.debugStatusMessage = "Running post-processing"
-                }
-                let (finalTranscript, processingStatus, postProcessingPrompt) = await processTranscript(
-                    rawTranscript,
-                    context: appContext,
-                    postProcessingService: postProcessingService,
-                    customVocabulary: customVocabulary,
-                    customSystemPrompt: customSystemPrompt
-                )
+            let transcriptionService = TranscriptionService(
+                apiKey: self.apiKey,
+                baseURL: self.apiBaseURL,
+                forceHTTP2: self.forceHTTP2Transcription
+            )
+            let postProcessingService = PostProcessingService(apiKey: self.apiKey, baseURL: self.apiBaseURL)
 
-                await MainActor.run {
-                    self.lastContextSummary = appContext.contextSummary
-                    self.lastContextScreenshotDataURL = appContext.screenshotDataURL
-                    self.lastContextScreenshotStatus = appContext.screenshotError
-                        ?? "available (\(appContext.screenshotMimeType ?? "image"))"
-                    let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let trimmedFinalTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                    self.lastPostProcessingPrompt = postProcessingPrompt
-                    self.lastRawTranscript = trimmedRawTranscript
-                    self.lastPostProcessedTranscript = trimmedFinalTranscript
-                    self.lastPostProcessingStatus = processingStatus
-                    self.recordPipelineHistoryEntry(
-                        rawTranscript: trimmedRawTranscript,
-                        postProcessedTranscript: trimmedFinalTranscript,
-                        postProcessingPrompt: postProcessingPrompt,
-                        context: appContext,
-                        processingStatus: processingStatus,
-                        audioFileName: savedAudioFile?.fileName
-                    )
-                    self.transcribingIndicatorTask?.cancel()
-                    self.transcribingIndicatorTask = nil
-                    self.lastTranscript = trimmedFinalTranscript
-                    self.isTranscribing = false
-                    self.debugStatusMessage = "Done"
-                    let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
-
-                    if trimmedFinalTranscript.isEmpty {
-                        self.statusText = "Nothing to transcribe"
-                        self.overlayManager.dismiss()
+            Task {
+                do {
+                    async let transcript = transcriptionService.transcribe(fileURL: transcriptionFileURL)
+                    let rawTranscript = try await transcript
+                    let appContext: AppContext
+                    if let sessionContext {
+                        appContext = sessionContext
+                    } else if let inFlightContext = await inFlightContextTask?.value {
+                        appContext = inFlightContext
                     } else {
-                        self.statusText = completionStatusText
-                        self.overlayManager.showDone()
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                            self.overlayManager.dismiss()
-                        }
-
-                        let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
-                        self.pasteAtCursorWhenShortcutReleased {
-                            self.restoreClipboardIfNeeded(pendingClipboardRestore)
-                        }
+                        appContext = self.fallbackContextAtStop()
                     }
-
-                    self.audioRecorder.cleanup()
-
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        if self.statusText == completionStatusText || self.statusText == "Nothing to transcribe" {
-                            self.statusText = "Ready"
-                        }
+                    await MainActor.run { [weak self] in
+                        self?.debugStatusMessage = "Running post-processing"
                     }
-                }
-            } catch {
-                let resolvedContext: AppContext
-                if let sessionContext {
-                    resolvedContext = sessionContext
-                } else if let inFlightContext = await inFlightContextTask?.value {
-                    resolvedContext = inFlightContext
-                } else {
-                    resolvedContext = fallbackContextAtStop()
-                }
-                await MainActor.run {
-                    self.transcribingIndicatorTask?.cancel()
-                    self.transcribingIndicatorTask = nil
-                    self.errorMessage = error.localizedDescription
-                    self.isTranscribing = false
-                    self.statusText = "Error"
-                    self.audioRecorder.cleanup()
-                    self.overlayManager.dismiss()
-                    self.lastPostProcessedTranscript = ""
-                    self.lastRawTranscript = ""
-                    self.lastContextSummary = ""
-                    self.lastPostProcessingStatus = "Error: \(error.localizedDescription)"
-                    self.lastPostProcessingPrompt = ""
-                    self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
-                    self.lastContextScreenshotStatus = resolvedContext.screenshotError
-                        ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
-                    self.recordPipelineHistoryEntry(
-                        rawTranscript: "",
-                        postProcessedTranscript: "",
-                        postProcessingPrompt: "",
-                        context: resolvedContext,
-                        processingStatus: "Error: \(error.localizedDescription)",
-                        audioFileName: savedAudioFile?.fileName
+                    let (finalTranscript, processingStatus, postProcessingPrompt) = await self.processTranscript(
+                        rawTranscript,
+                        context: appContext,
+                        postProcessingService: postProcessingService,
+                        customVocabulary: self.customVocabulary,
+                        customSystemPrompt: self.customSystemPrompt
                     )
+
+                    await MainActor.run {
+                        self.lastContextSummary = appContext.contextSummary
+                        self.lastContextScreenshotDataURL = appContext.screenshotDataURL
+                        self.lastContextScreenshotStatus = appContext.screenshotError
+                            ?? "available (\(appContext.screenshotMimeType ?? "image"))"
+                        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let trimmedFinalTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        self.lastPostProcessingPrompt = postProcessingPrompt
+                        self.lastRawTranscript = trimmedRawTranscript
+                        self.lastPostProcessedTranscript = trimmedFinalTranscript
+                        self.lastPostProcessingStatus = processingStatus
+                        self.recordPipelineHistoryEntry(
+                            rawTranscript: trimmedRawTranscript,
+                            postProcessedTranscript: trimmedFinalTranscript,
+                            postProcessingPrompt: postProcessingPrompt,
+                            context: appContext,
+                            processingStatus: processingStatus,
+                            audioFileName: savedAudioFile?.fileName
+                        )
+                        self.transcribingIndicatorTask?.cancel()
+                        self.transcribingIndicatorTask = nil
+                        self.lastTranscript = trimmedFinalTranscript
+                        self.isTranscribing = false
+                        self.debugStatusMessage = "Done"
+                        let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
+
+                        if trimmedFinalTranscript.isEmpty {
+                            self.statusText = "Nothing to transcribe"
+                            self.overlayManager.dismiss()
+                        } else {
+                            self.statusText = completionStatusText
+                            self.overlayManager.showDone()
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                                self.overlayManager.dismiss()
+                            }
+
+                            let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
+                            self.pasteAtCursorWhenShortcutReleased {
+                                self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                            }
+                        }
+
+                        self.audioRecorder.cleanup()
+
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            if self.statusText == completionStatusText || self.statusText == "Nothing to transcribe" {
+                                self.statusText = "Ready"
+                            }
+                        }
+                    }
+                } catch {
+                    let resolvedContext: AppContext
+                    if let sessionContext {
+                        resolvedContext = sessionContext
+                    } else if let inFlightContext = await inFlightContextTask?.value {
+                        resolvedContext = inFlightContext
+                    } else {
+                        resolvedContext = self.fallbackContextAtStop()
+                    }
+                    await MainActor.run {
+                        self.transcribingIndicatorTask?.cancel()
+                        self.transcribingIndicatorTask = nil
+                        self.errorMessage = error.localizedDescription
+                        self.isTranscribing = false
+                        self.statusText = "Error"
+                        self.audioRecorder.cleanup()
+                        self.overlayManager.dismiss()
+                        self.lastPostProcessedTranscript = ""
+                        self.lastRawTranscript = ""
+                        self.lastContextSummary = ""
+                        self.lastPostProcessingStatus = "Error: \(error.localizedDescription)"
+                        self.lastPostProcessingPrompt = ""
+                        self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
+                        self.lastContextScreenshotStatus = resolvedContext.screenshotError
+                            ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
+                        self.recordPipelineHistoryEntry(
+                            rawTranscript: "",
+                            postProcessedTranscript: "",
+                            postProcessingPrompt: "",
+                            context: resolvedContext,
+                            processingStatus: "Error: \(error.localizedDescription)",
+                            audioFileName: savedAudioFile?.fileName
+                        )
+                    }
                 }
             }
         }
@@ -1448,7 +1470,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             hasShownScreenshotPermissionAlert = true
 
             // Permission errors are fatal — stop recording
-            _ = audioRecorder.stopRecording()
+            audioRecorder.cancelRecording()
             audioRecorder.cleanup()
             audioLevelCancellable?.cancel()
             audioLevelCancellable = nil

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1054,6 +1054,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         capturedContext = nil
         audioRecorder.cleanup()
         isRecording = false
+        isTranscribing = false
         activeRecordingTriggerMode = nil
         shortcutSessionController.reset()
         errorMessage = formattedRecordingStartError(error)
@@ -1191,6 +1192,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         lastContextScreenshotDataURL = nil
         lastContextScreenshotStatus = "No screenshot"
         isRecording = false
+        isTranscribing = true
         statusText = "Preparing audio..."
         errorMessage = nil
         playAlertSound(named: "Pop")
@@ -1198,6 +1200,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioRecorder.stopRecording { [weak self] fileURL in
             guard let self else { return }
             guard let fileURL else {
+                self.isTranscribing = false
                 self.audioRecorder.cleanup()
                 self.errorMessage = "No audio recorded"
                 self.statusText = "Error"
@@ -1207,7 +1210,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
             let savedAudioFile = Self.saveAudioFile(from: fileURL)
             let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
-            self.isTranscribing = true
             self.statusText = "Transcribing..."
             self.debugStatusMessage = "Transcribing audio"
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1013,9 +1013,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         }
         audioRecorder.onRecordingFailure = { [weak self] error in
-            guard let self else { return }
-            initTimer.cancel()
-            self.handleRecordingFailure(error)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                initTimer.cancel()
+                self.handleRecordingFailure(error)
+            }
         }
 
         // Start engine on background thread so UI isn't blocked

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1475,7 +1475,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
             // Permission errors are fatal — stop recording
             audioRecorder.cancelRecording()
-            audioRecorder.cleanup()
             audioLevelCancellable?.cancel()
             audioLevelCancellable = nil
             contextCaptureTask?.cancel()

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -134,6 +134,7 @@ enum AudioRecorderError: LocalizedError {
 }
 
 final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputSampleBufferDelegate, AVCaptureFileOutputRecordingDelegate {
+    private static let sessionQueueKey = DispatchSpecificKey<UInt8>()
     private var captureSession: AVCaptureSession?
     private var currentInput: AVCaptureDeviceInput?
     private var audioFileOutput: AVCaptureAudioFileOutput?
@@ -149,6 +150,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private var pendingStopCompletion: ((URL?) -> Void)?
     private var shouldDiscardRecording = false
     private var isSessionInterrupted = false
+    private var hasFileRecordingStarted = false
+    private var shouldStopOnceFileRecordingStarts = false
 
     @Published var isRecording = false
     private let _recording = OSAllocatedUnfairLock(initialState: false)
@@ -162,10 +165,21 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private static let watchdogTimeout: TimeInterval = 2.0
     private static let sampleRateLogLimit = 40
 
+    override init() {
+        super.init()
+        sessionQueue.setSpecific(key: Self.sessionQueueKey, value: 1)
+    }
+
     deinit {
-        sessionQueue.sync {
+        let cleanup = {
             self.cancelWatchdog()
             self.teardownSessionLocked()
+        }
+
+        if DispatchQueue.getSpecific(key: Self.sessionQueueKey) != nil {
+            cleanup()
+        } else {
+            sessionQueue.sync(execute: cleanup)
         }
     }
 
@@ -260,6 +274,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private func teardownSessionLocked() {
         removeSessionObservers()
         isSessionInterrupted = false
+        hasFileRecordingStarted = false
+        shouldStopOnceFileRecordingStarts = false
 
         audioDataOutput?.setSampleBufferDelegate(nil, queue: nil)
         if let session = captureSession, session.isRunning {
@@ -328,6 +344,19 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private func cancelWatchdog() {
         watchdogTimer?.cancel()
         watchdogTimer = nil
+    }
+
+    private func stopFileOutputIfPossibleLocked() -> Bool {
+        guard let fileOutput = audioFileOutput else { return false }
+
+        if hasFileRecordingStarted || fileOutput.isRecording {
+            fileOutput.stopRecording()
+        } else {
+            shouldStopOnceFileRecordingStarts = true
+            os_log(.info, log: recordingLog, "stop requested before file output started — waiting for didStart callback")
+        }
+
+        return true
     }
 
     private func handleSessionInterrupted(_ notification: Notification) {
@@ -435,6 +464,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         failureReported = false
         shouldDiscardRecording = false
         pendingStopCompletion = nil
+        hasFileRecordingStarted = false
+        shouldStopOnceFileRecordingStarts = false
         smoothedLevel = 0.0
 
         os_log(.info, log: recordingLog, "startRecording() entered")
@@ -472,8 +503,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             self.pendingStopCompletion = completion
             self.shouldDiscardRecording = false
 
-            if let fileOutput = self.audioFileOutput, fileOutput.isRecording {
-                fileOutput.stopRecording()
+            if self.stopFileOutputIfPossibleLocked() {
+                return
             } else {
                 let outputURL = self.tempFileURL
                 self.pendingStopCompletion = nil
@@ -494,8 +525,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             self.pendingStopCompletion = nil
             self.shouldDiscardRecording = true
 
-            if let fileOutput = self.audioFileOutput, fileOutput.isRecording {
-                fileOutput.stopRecording()
+            if self.stopFileOutputIfPossibleLocked() {
+                return
             } else {
                 let discardURL = self.tempFileURL
                 self.tempFileURL = nil
@@ -592,7 +623,15 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         didStartRecordingTo outputFileURL: URL,
         from connections: [AVCaptureConnection]
     ) {
-        os_log(.info, log: recordingLog, "file output started writing to %{public}@", outputFileURL.path)
+        sessionQueue.async {
+            self.hasFileRecordingStarted = true
+            os_log(.info, log: recordingLog, "file output started writing to %{public}@", outputFileURL.path)
+
+            guard self.shouldStopOnceFileRecordingStarts else { return }
+
+            self.shouldStopOnceFileRecordingStarts = false
+            output.stopRecording()
+        }
     }
 
     func fileOutput(

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import CoreAudio
+import CoreMedia
 import Foundation
 import os.log
 
@@ -9,6 +10,29 @@ struct AudioDevice: Identifiable {
     let id: AudioDeviceID
     let uid: String
     let name: String
+
+    private static func stringProperty(
+        deviceID: AudioDeviceID,
+        selector: AudioObjectPropertySelector
+    ) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        let raw = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(size),
+            alignment: MemoryLayout<CFString?>.alignment
+        )
+        defer { raw.deallocate() }
+
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, raw) == noErr,
+              let ref = raw.load(as: CFString?.self) else {
+            return nil
+        }
+        return ref as String
+    }
 
     static func availableInputDevices() -> [AudioDevice] {
         var propertyAddress = AudioObjectPropertyAddress(
@@ -39,7 +63,6 @@ struct AudioDevice: Identifiable {
 
         var devices: [AudioDevice] = []
         for deviceID in deviceIDs {
-            // Check if device has input streams
             var inputStreamAddress = AudioObjectPropertyAddress(
                 mSelector: kAudioDevicePropertyStreamConfiguration,
                 mScope: kAudioDevicePropertyScopeInput,
@@ -61,39 +84,12 @@ struct AudioDevice: Identifiable {
             let inputChannels = bufferList.reduce(0) { $0 + Int($1.mNumberChannels) }
             guard inputChannels > 0 else { continue }
 
-            // Get device UID
-            var uidAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioDevicePropertyDeviceUID,
-                mScope: kAudioObjectPropertyScopeGlobal,
-                mElement: kAudioObjectPropertyElementMain
-            )
-            var uidSize = UInt32(MemoryLayout<CFString?>.size)
-            let uidRaw = UnsafeMutableRawPointer.allocate(
-                byteCount: Int(uidSize),
-                alignment: MemoryLayout<CFString?>.alignment
-            )
-            defer { uidRaw.deallocate() }
-            guard AudioObjectGetPropertyData(deviceID, &uidAddress, 0, nil, &uidSize, uidRaw) == noErr else { continue }
-            guard let uidRef = uidRaw.load(as: CFString?.self) else { continue }
-            let uid = uidRef as String
-            guard !uid.isEmpty else { continue }
-
-            // Get device name
-            var nameAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioObjectPropertyName,
-                mScope: kAudioObjectPropertyScopeGlobal,
-                mElement: kAudioObjectPropertyElementMain
-            )
-            var nameSize = UInt32(MemoryLayout<CFString?>.size)
-            let nameRaw = UnsafeMutableRawPointer.allocate(
-                byteCount: Int(nameSize),
-                alignment: MemoryLayout<CFString?>.alignment
-            )
-            defer { nameRaw.deallocate() }
-            guard AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, nameRaw) == noErr else { continue }
-            guard let nameRef = nameRaw.load(as: CFString?.self) else { continue }
-            let name = nameRef as String
-            guard !name.isEmpty else { continue }
+            guard let uid = stringProperty(deviceID: deviceID, selector: kAudioDevicePropertyDeviceUID),
+                  !uid.isEmpty,
+                  let name = stringProperty(deviceID: deviceID, selector: kAudioObjectPropertyName),
+                  !name.isEmpty else {
+                continue
+            }
 
             devices.append(AudioDevice(id: deviceID, uid: uid, name: name))
         }
@@ -101,14 +97,23 @@ struct AudioDevice: Identifiable {
     }
 
     static func deviceID(forUID uid: String) -> AudioDeviceID? {
-        // Look up through the enumerated devices to avoid CFString pointer issues
-        return availableInputDevices().first(where: { $0.uid == uid })?.id
+        availableInputDevices().first(where: { $0.uid == uid })?.id
+    }
+
+    static func description(forID deviceID: AudioDeviceID) -> String {
+        let name = stringProperty(deviceID: deviceID, selector: kAudioObjectPropertyName) ?? "Unknown"
+        let uid = stringProperty(deviceID: deviceID, selector: kAudioDevicePropertyDeviceUID) ?? "unknown-uid"
+        return "\(name) [id=\(deviceID), uid=\(uid)]"
     }
 }
 
 enum AudioRecorderError: LocalizedError {
     case invalidInputFormat(String)
     case missingInputDevice
+    case noAudioBuffersReceived
+    case failedToCreateCaptureInput(String)
+    case failedToStartCaptureSession(String)
+    case failedToBeginFileRecording(String)
 
     var errorDescription: String? {
         switch self {
@@ -116,206 +121,178 @@ enum AudioRecorderError: LocalizedError {
             return "Invalid input format: \(details)"
         case .missingInputDevice:
             return "No audio input device available."
+        case .noAudioBuffersReceived:
+            return "No audio buffers were received from the selected microphone."
+        case .failedToCreateCaptureInput(let details):
+            return "Could not open the selected microphone: \(details)"
+        case .failedToStartCaptureSession(let details):
+            return "Could not start the capture session: \(details)"
+        case .failedToBeginFileRecording(let details):
+            return "Could not begin recording audio: \(details)"
         }
     }
 }
 
-class AudioRecorder: NSObject, ObservableObject {
-    private var audioEngine: AVAudioEngine?
-    private var audioFile: AVAudioFile?
+final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputSampleBufferDelegate, AVCaptureFileOutputRecordingDelegate {
+    private var captureSession: AVCaptureSession?
+    private var currentInput: AVCaptureDeviceInput?
+    private var audioFileOutput: AVCaptureAudioFileOutput?
+    private var audioDataOutput: AVCaptureAudioDataOutput?
+    private var sessionObservers: [NSObjectProtocol] = []
     private var tempFileURL: URL?
-    private let audioFileQueue = DispatchQueue(label: "com.zachlatta.freeflow.audiofile")
     private var recordingStartTime: CFAbsoluteTime = 0
-    private var firstBufferLogged = false
     private let _bufferCount = OSAllocatedUnfairLock(initialState: 0)
     private var currentDeviceUID: String?
-    private var storedInputFormat: AVAudioFormat?
-
-    private var configChangeObserver: NSObjectProtocol?
     private var watchdogTimer: DispatchSourceTimer?
-    private var rebuildAttempt = 0
-    private static let maxRebuildAttempts = 2
-    private static let watchdogTimeout: TimeInterval = 2.0
+    private let sessionQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.session")
+    private let sampleBufferQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.samples")
+    private var pendingStopCompletion: ((URL?) -> Void)?
+    private var shouldDiscardRecording = false
 
     @Published var isRecording = false
-    /// Thread-safe flag read from the audio tap callback.
     private let _recording = OSAllocatedUnfairLock(initialState: false)
     @Published var audioLevel: Float = 0.0
     private var smoothedLevel: Float = 0.0
 
-    /// Called on the audio thread when the first non-silent buffer arrives.
     var onRecordingReady: (() -> Void)?
+    var onRecordingFailure: ((Error) -> Void)?
     private var readyFired = false
-
-    override init() {
-        super.init()
-        configChangeObserver = NotificationCenter.default.addObserver(
-            forName: .AVAudioEngineConfigurationChange,
-            object: nil,
-            queue: nil
-        ) { [weak self] notification in
-            self?.handleEngineConfigChange(notification)
-        }
-    }
+    private var failureReported = false
+    private static let watchdogTimeout: TimeInterval = 2.0
+    private static let sampleRateLogLimit = 40
 
     deinit {
-        if let observer = configChangeObserver {
+        sessionQueue.sync {
+            self.cancelWatchdog()
+            self.teardownSessionLocked()
+        }
+    }
+
+    private static func captureDevices() -> [AVCaptureDevice] {
+        let deviceTypes: [AVCaptureDevice.DeviceType]
+        if #available(macOS 14.0, *) {
+            deviceTypes = [.microphone, .external]
+        } else {
+            deviceTypes = [.builtInMicrophone, .externalUnknown]
+        }
+
+        return AVCaptureDevice.DiscoverySession(
+            deviceTypes: deviceTypes,
+            mediaType: .audio,
+            position: .unspecified
+        ).devices
+    }
+
+    private static func captureDevice(forUID uid: String) -> AVCaptureDevice? {
+        captureDevices().first(where: { $0.uniqueID == uid })
+    }
+
+    private static func defaultCaptureDevice() -> AVCaptureDevice? {
+        AVCaptureDevice.default(for: .audio) ?? captureDevices().first
+    }
+
+    private func preferredCaptureDevice(
+        for requestedDeviceUID: String?,
+        reason: String
+    ) -> AVCaptureDevice? {
+        guard let requestedDeviceUID, !requestedDeviceUID.isEmpty, requestedDeviceUID != "default" else {
+            let device = Self.defaultCaptureDevice()
+            if let device {
+                os_log(.info, log: recordingLog, "%{public}@ — using system default device: %{public}@", reason, device.localizedName)
+            }
+            return device
+        }
+
+        if let device = Self.captureDevice(forUID: requestedDeviceUID) {
+            os_log(.info, log: recordingLog, "%{public}@ — keeping selected device: %{public}@ [uid=%{public}@]", reason, device.localizedName, device.uniqueID)
+            return device
+        }
+
+        let fallbackDevice = Self.defaultCaptureDevice()
+        if let fallbackDevice {
+            os_log(.info, log: recordingLog, "%{public}@ — selected device unavailable, falling back to system default: %{public}@ [uid=%{public}@]", reason, fallbackDevice.localizedName, fallbackDevice.uniqueID)
+        }
+        return fallbackDevice
+    }
+
+    private func installSessionObservers(for session: AVCaptureSession) {
+        removeSessionObservers()
+
+        let runtimeObserver = NotificationCenter.default.addObserver(
+            forName: AVCaptureSession.runtimeErrorNotification,
+            object: session,
+            queue: nil
+        ) { [weak self] notification in
+            let error = notification.userInfo?[AVCaptureSessionErrorKey] as? NSError
+            let wrapped = error.map { AudioRecorderError.failedToStartCaptureSession($0.localizedDescription) }
+                ?? AudioRecorderError.failedToStartCaptureSession("Unknown runtime error")
+            self?.reportRecordingFailure(wrapped)
+        }
+        sessionObservers.append(runtimeObserver)
+
+        let interruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVCaptureSession.wasInterruptedNotification,
+            object: session,
+            queue: nil
+        ) { [weak self] notification in
+            _ = notification
+            self?.reportRecordingFailure(AudioRecorderError.failedToStartCaptureSession("Capture session interrupted."))
+        }
+        sessionObservers.append(interruptionObserver)
+    }
+
+    private func removeSessionObservers() {
+        for observer in sessionObservers {
             NotificationCenter.default.removeObserver(observer)
         }
-        cancelWatchdog()
+        sessionObservers.removeAll()
     }
 
-    // MARK: - Engine lifecycle
+    private func teardownSessionLocked() {
+        removeSessionObservers()
 
-    private func invalidateEngine() {
-        audioEngine?.inputNode.removeTap(onBus: 0)
-        audioEngine?.stop()
-        audioEngine = nil
-        storedInputFormat = nil
+        audioDataOutput?.setSampleBufferDelegate(nil, queue: nil)
+        if let session = captureSession, session.isRunning {
+            session.stopRunning()
+        }
+
+        captureSession = nil
+        currentInput = nil
+        audioFileOutput = nil
+        audioDataOutput = nil
+        currentDeviceUID = nil
     }
 
-    private func buildAndStartEngine(deviceUID: String?) throws {
-        invalidateEngine()
+    private func reportRecordingFailure(_ error: Error) {
+        sessionQueue.async {
+            guard !self.failureReported else { return }
+            self.failureReported = true
+            self.cancelWatchdog()
+            self._recording.withLock { $0 = false }
 
-        let t0 = CFAbsoluteTimeGetCurrent()
-        let engine = AVAudioEngine()
-        os_log(.info, log: recordingLog, "AVAudioEngine created: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        // Set specific input device if requested
-        if let uid = deviceUID, !uid.isEmpty, uid != "default",
-           let deviceID = AudioDevice.deviceID(forUID: uid) {
-            os_log(.info, log: recordingLog, "device lookup resolved to %d: %.3fms", deviceID, (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-            let inputUnit = engine.inputNode.audioUnit!
-            var id = deviceID
-            AudioUnitSetProperty(
-                inputUnit,
-                kAudioOutputUnitProperty_CurrentDevice,
-                kAudioUnitScope_Global,
-                0,
-                &id,
-                UInt32(MemoryLayout<AudioDeviceID>.size)
-            )
-        }
-
-        let inputNode = engine.inputNode
-        os_log(.info, log: recordingLog, "inputNode accessed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-        os_log(.info, log: recordingLog, "inputFormat retrieved (rate=%.0f, ch=%d): %.3fms", inputFormat.sampleRate, inputFormat.channelCount, (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        guard inputFormat.sampleRate > 0 else {
-            throw AudioRecorderError.invalidInputFormat("Invalid sample rate: \(inputFormat.sampleRate)")
-        }
-        guard inputFormat.channelCount > 0 else {
-            throw AudioRecorderError.invalidInputFormat("No input channels available")
-        }
-
-        storedInputFormat = inputFormat
-        _bufferCount.withLock { $0 = 0 }
-        readyFired = false
-
-        // Install tap — checks isRecording and audioFile dynamically
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            guard let self, self._recording.withLock({ $0 }) else { return }
-
-            let count = self._bufferCount.withLock { val -> Int in
-                val += 1
-                return val
+            let completion = self.pendingStopCompletion
+            self.pendingStopCompletion = nil
+            let discardURL = self.tempFileURL
+            self.shouldDiscardRecording = false
+            self.teardownSessionLocked()
+            self.tempFileURL = nil
+            if let discardURL {
+                try? FileManager.default.removeItem(at: discardURL)
             }
 
-            // Check if this buffer has real audio
-            var rms: Float = 0
-            let frames = Int(buffer.frameLength)
-            if frames > 0, let channelData = buffer.floatChannelData {
-                let samples = channelData[0]
-                var sum: Float = 0
-                for i in 0..<frames { sum += samples[i] * samples[i] }
-                rms = sqrtf(sum / Float(frames))
+            DispatchQueue.main.async {
+                self.isRecording = false
+                self.audioLevel = 0.0
+                self.onRecordingFailure?(error)
+                completion?(nil)
             }
-
-            if count <= 40 {
-                let elapsed = (CFAbsoluteTimeGetCurrent() - self.recordingStartTime) * 1000
-                os_log(.info, log: recordingLog, "buffer #%d at %.3fms, frames=%d, rms=%.6f", count, elapsed, buffer.frameLength, rms)
-            }
-
-            // Fire ready callback on first non-silent buffer
-            if !self.readyFired && rms > 0 {
-                self.readyFired = true
-                let elapsed = (CFAbsoluteTimeGetCurrent() - self.recordingStartTime) * 1000
-                os_log(.info, log: recordingLog, "FIRST non-silent buffer at %.3fms — recording ready", elapsed)
-                self.onRecordingReady?()
-            }
-
-            self.audioFileQueue.sync {
-                if let file = self.audioFile {
-                    do {
-                        try file.write(from: buffer)
-                    } catch {
-                        self.audioFile = nil
-                    }
-                }
-            }
-            self.computeAudioLevel(from: buffer)
-        }
-        os_log(.info, log: recordingLog, "tap installed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        engine.prepare()
-        os_log(.info, log: recordingLog, "engine prepared: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        self.audioEngine = engine
-        self.currentDeviceUID = deviceUID
-
-        try engine.start()
-        os_log(.info, log: recordingLog, "engine started: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-    }
-
-    // MARK: - Configuration change handling
-
-    private func handleEngineConfigChange(_ notification: Notification) {
-        guard let engine = notification.object as? AVAudioEngine,
-              engine === self.audioEngine else { return }
-
-        os_log(.info, log: recordingLog, "AVAudioEngineConfigurationChange — invalidating engine")
-        invalidateEngine()
-
-        if _recording.withLock({ $0 }) {
-            os_log(.info, log: recordingLog, "was recording — attempting transparent restart")
-            restartRecording()
         }
     }
-
-    private func restartRecording() {
-        rebuildAttempt += 1
-        if rebuildAttempt > Self.maxRebuildAttempts {
-            os_log(.error, log: recordingLog, "exceeded max rebuild attempts (%d) — giving up", Self.maxRebuildAttempts)
-            _recording.withLock { $0 = false }
-            DispatchQueue.main.async { self.isRecording = false }
-            return
-        }
-
-        // On second attempt, fall back to system default device
-        let deviceToUse: String?
-        if rebuildAttempt >= Self.maxRebuildAttempts {
-            os_log(.info, log: recordingLog, "rebuild attempt %d — falling back to system default device", rebuildAttempt)
-            deviceToUse = nil
-        } else {
-            deviceToUse = currentDeviceUID
-        }
-
-        do {
-            try buildAndStartEngine(deviceUID: deviceToUse)
-            startBufferWatchdog()
-            os_log(.info, log: recordingLog, "transparent restart succeeded (attempt %d)", rebuildAttempt)
-        } catch {
-            os_log(.error, log: recordingLog, "transparent restart failed: %{public}@", error.localizedDescription)
-            _recording.withLock { $0 = false }
-            DispatchQueue.main.async { self.isRecording = false }
-        }
-    }
-
-    // MARK: - Buffer watchdog
 
     private func startBufferWatchdog() {
         cancelWatchdog()
-        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .userInitiated))
+
+        let timer = DispatchSource.makeTimerSource(queue: sessionQueue)
         timer.schedule(deadline: .now() + Self.watchdogTimeout)
         timer.setEventHandler { [weak self] in
             guard let self else { return }
@@ -323,13 +300,10 @@ class AudioRecorder: NSObject, ObservableObject {
 
             let count = self._bufferCount.withLock { $0 }
             if count == 0 {
-                os_log(.error, log: recordingLog,
-                       "watchdog: 0 buffers after %.1fs (attempt %d) — rebuilding engine",
-                       Self.watchdogTimeout, self.rebuildAttempt)
-                self.restartRecording()
+                os_log(.error, log: recordingLog, "watchdog: 0 buffers after %.1fs — giving up", Self.watchdogTimeout)
+                self.reportRecordingFailure(AudioRecorderError.noAudioBuffersReceived)
             } else {
-                os_log(.info, log: recordingLog, "watchdog: %d buffers after %.1fs — healthy, resetting rebuild counter", count, Self.watchdogTimeout)
-                self.rebuildAttempt = 0
+                os_log(.info, log: recordingLog, "watchdog: %d buffers after %.1fs — healthy", count, Self.watchdogTimeout)
             }
         }
         timer.resume()
@@ -341,119 +315,202 @@ class AudioRecorder: NSObject, ObservableObject {
         watchdogTimer = nil
     }
 
-    // MARK: - Public API
+    private func makeSession(deviceUID: String?, outputURL: URL) throws {
+        teardownSessionLocked()
+
+        guard let device = preferredCaptureDevice(for: deviceUID, reason: "initial start") else {
+            throw AudioRecorderError.missingInputDevice
+        }
+
+        let session = AVCaptureSession()
+        let fileOutput = AVCaptureAudioFileOutput()
+        let dataOutput = AVCaptureAudioDataOutput()
+        dataOutput.audioSettings = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        dataOutput.setSampleBufferDelegate(self, queue: sampleBufferQueue)
+
+        let input: AVCaptureDeviceInput
+        do {
+            input = try AVCaptureDeviceInput(device: device)
+        } catch {
+            throw AudioRecorderError.failedToCreateCaptureInput(error.localizedDescription)
+        }
+
+        session.beginConfiguration()
+        var needsCommitConfiguration = true
+        defer {
+            if needsCommitConfiguration {
+                session.commitConfiguration()
+            }
+        }
+
+        guard session.canAddInput(input) else {
+            throw AudioRecorderError.failedToCreateCaptureInput("Session rejected device input for \(device.localizedName).")
+        }
+        session.addInput(input)
+
+        guard session.canAddOutput(fileOutput) else {
+            throw AudioRecorderError.failedToBeginFileRecording("Session rejected audio file output.")
+        }
+        session.addOutput(fileOutput)
+
+        guard session.canAddOutput(dataOutput) else {
+            throw AudioRecorderError.failedToStartCaptureSession("Session rejected audio data output.")
+        }
+        session.addOutput(dataOutput)
+
+        session.commitConfiguration()
+        needsCommitConfiguration = false
+
+        captureSession = session
+        currentInput = input
+        audioFileOutput = fileOutput
+        audioDataOutput = dataOutput
+        currentDeviceUID = device.uniqueID
+        installSessionObservers(for: session)
+
+        os_log(.info, log: recordingLog, "configured capture session with device %{public}@ [uid=%{public}@]", device.localizedName, device.uniqueID)
+
+        session.startRunning()
+        guard session.isRunning else {
+            throw AudioRecorderError.failedToStartCaptureSession("Session failed to enter running state.")
+        }
+
+        os_log(.info, log: recordingLog, "capture session running with device %{public}@ [uid=%{public}@]", device.localizedName, device.uniqueID)
+
+        let availableFileTypes = type(of: fileOutput).availableOutputFileTypes()
+        guard availableFileTypes.contains(.wav) else {
+            throw AudioRecorderError.failedToBeginFileRecording("WAV output is not supported by AVCaptureAudioFileOutput.")
+        }
+
+        fileOutput.startRecording(to: outputURL, outputFileType: .wav, recordingDelegate: self)
+    }
 
     func startRecording(deviceUID: String? = nil) throws {
         let t0 = CFAbsoluteTimeGetCurrent()
         recordingStartTime = t0
-        firstBufferLogged = false
         _bufferCount.withLock { $0 = 0 }
         readyFired = false
-        rebuildAttempt = 0
+        failureReported = false
+        shouldDiscardRecording = false
+        pendingStopCompletion = nil
+        smoothedLevel = 0.0
 
         os_log(.info, log: recordingLog, "startRecording() entered")
 
-        guard AVCaptureDevice.default(for: .audio) != nil else {
-            throw AudioRecorderError.missingInputDevice
-        }
-        os_log(.info, log: recordingLog, "AVCaptureDevice check: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        let engineNeedsRebuild = audioEngine == nil || currentDeviceUID != deviceUID || !(audioEngine?.isRunning ?? false)
-
-        if engineNeedsRebuild {
-            try buildAndStartEngine(deviceUID: deviceUID)
-        } else if let engine = audioEngine, !engine.isRunning {
-            try engine.start()
-            os_log(.info, log: recordingLog, "engine restarted: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        }
-
-        guard let inputFormat = storedInputFormat else {
-            throw AudioRecorderError.invalidInputFormat("No stored input format")
-        }
-
-        // Create a temp file to write audio to
         let tempDir = FileManager.default.temporaryDirectory
-        let fileURL = tempDir.appendingPathComponent(UUID().uuidString + ".wav")
-        self.tempFileURL = fileURL
+        let outputURL = tempDir.appendingPathComponent(UUID().uuidString + ".wav")
+        tempFileURL = outputURL
 
-        // Try the input format first to avoid conversion issues, then fall back to 16-bit PCM.
-        let newAudioFile: AVAudioFile
         do {
-            newAudioFile = try AVAudioFile(forWriting: fileURL, settings: inputFormat.settings)
+            try sessionQueue.sync {
+                try self.makeSession(deviceUID: deviceUID, outputURL: outputURL)
+                self._recording.withLock { $0 = true }
+                self.startBufferWatchdog()
+            }
         } catch {
-            let fallbackSettings: [String: Any] = [
-                AVFormatIDKey: kAudioFormatLinearPCM,
-                AVSampleRateKey: inputFormat.sampleRate,
-                AVNumberOfChannelsKey: inputFormat.channelCount,
-                AVLinearPCMBitDepthKey: 16,
-                AVLinearPCMIsFloatKey: false,
-                AVLinearPCMIsBigEndianKey: false,
-                AVLinearPCMIsNonInterleaved: inputFormat.isInterleaved ? 0 : 1,
-            ]
-            newAudioFile = try AVAudioFile(
-                forWriting: fileURL,
-                settings: fallbackSettings,
-                commonFormat: .pcmFormatInt16,
-                interleaved: inputFormat.isInterleaved
-            )
+            tempFileURL = nil
+            throw error
         }
-        os_log(.info, log: recordingLog, "audio file created: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
 
-        audioFileQueue.sync { self.audioFile = newAudioFile }
-        _recording.withLock { $0 = true }
-        self.isRecording = true
-
-        startBufferWatchdog()
-
+        DispatchQueue.main.async {
+            self.isRecording = true
+            self.audioLevel = 0.0
+        }
         os_log(.info, log: recordingLog, "startRecording() complete: %.3fms total", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
     }
 
-    func stopRecording() -> URL? {
+    func stopRecording(completion: @escaping (URL?) -> Void) {
         let count = _bufferCount.withLock { $0 }
         let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
         os_log(.info, log: recordingLog, "stopRecording() called: %.3fms after start, %d buffers received", elapsed, count)
 
-        cancelWatchdog()
-        _recording.withLock { $0 = false }
-        audioFileQueue.sync { audioFile = nil }
-        isRecording = false
-        smoothedLevel = 0.0
-        DispatchQueue.main.async { self.audioLevel = 0.0 }
+        sessionQueue.async {
+            self.cancelWatchdog()
+            self._recording.withLock { $0 = false }
+            self.pendingStopCompletion = completion
+            self.shouldDiscardRecording = false
 
-        // Stop engine so mic indicator goes away — keep engine object for fast restart
-        audioEngine?.stop()
-        os_log(.info, log: recordingLog, "engine stopped (mic indicator off)")
-
-        return tempFileURL
+            if let fileOutput = self.audioFileOutput, fileOutput.isRecording {
+                fileOutput.stopRecording()
+            } else {
+                let outputURL = self.tempFileURL
+                self.pendingStopCompletion = nil
+                self.teardownSessionLocked()
+                DispatchQueue.main.async {
+                    self.isRecording = false
+                    self.audioLevel = 0.0
+                    completion(outputURL)
+                }
+            }
+        }
     }
 
-    private func computeAudioLevel(from buffer: AVAudioPCMBuffer) {
-        let frames = Int(buffer.frameLength)
-        guard frames > 0 else { return }
+    func cancelRecording() {
+        sessionQueue.async {
+            self.cancelWatchdog()
+            self._recording.withLock { $0 = false }
+            self.pendingStopCompletion = nil
+            self.shouldDiscardRecording = true
 
-        var sumOfSquares: Float = 0.0
-        if let channelData = buffer.floatChannelData {
-            let samples = channelData[0]
-            for i in 0..<frames {
-                let sample = samples[i]
-                sumOfSquares += sample * sample
+            if let fileOutput = self.audioFileOutput, fileOutput.isRecording {
+                fileOutput.stopRecording()
+            } else {
+                let discardURL = self.tempFileURL
+                self.tempFileURL = nil
+                self.teardownSessionLocked()
+                if let discardURL {
+                    try? FileManager.default.removeItem(at: discardURL)
+                }
+                DispatchQueue.main.async {
+                    self.isRecording = false
+                    self.audioLevel = 0.0
+                }
             }
-        } else if let channelData = buffer.int16ChannelData {
-            let samples = channelData[0]
-            for i in 0..<frames {
-                let sample = Float(samples[i]) / Float(Int16.max)
-                sumOfSquares += sample * sample
-            }
-        } else {
-            return
+        }
+    }
+
+    func cleanup() {
+        if let url = tempFileURL {
+            try? FileManager.default.removeItem(at: url)
+            tempFileURL = nil
+        }
+    }
+
+    private func updateAudioLevel(from sampleBuffer: CMSampleBuffer) -> Float {
+        guard let dataBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return 0 }
+
+        var lengthAtOffset = 0
+        var totalLength = 0
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        let status = CMBlockBufferGetDataPointer(
+            dataBuffer,
+            atOffset: 0,
+            lengthAtOffsetOut: &lengthAtOffset,
+            totalLengthOut: &totalLength,
+            dataPointerOut: &dataPointer
+        )
+
+        guard status == kCMBlockBufferNoErr, totalLength > 0, let dataPointer else { return 0 }
+
+        let sampleCount = totalLength / MemoryLayout<Float>.size
+        guard sampleCount > 0 else { return 0 }
+
+        let floatPointer = UnsafeRawPointer(dataPointer).assumingMemoryBound(to: Float.self)
+        var sumOfSquares: Float = 0
+        for index in 0..<sampleCount {
+            let sample = floatPointer[index]
+            sumOfSquares += sample * sample
         }
 
-        let rms = sqrtf(sumOfSquares / Float(frames))
-
-        // Scale RMS (~0.01-0.1 for speech) to 0-1 range
+        let rms = sqrtf(sumOfSquares / Float(sampleCount))
         let scaled = min(rms * 10.0, 1.0)
 
-        // Fast attack, slower release — follows speech dynamics closely
         if scaled > smoothedLevel {
             smoothedLevel = smoothedLevel * 0.3 + scaled * 0.7
         } else {
@@ -463,12 +520,84 @@ class AudioRecorder: NSObject, ObservableObject {
         DispatchQueue.main.async {
             self.audioLevel = self.smoothedLevel
         }
+        return rms
     }
 
-    func cleanup() {
-        if let url = tempFileURL {
-            try? FileManager.default.removeItem(at: url)
-            tempFileURL = nil
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        guard _recording.withLock({ $0 }) else { return }
+
+        let count = _bufferCount.withLock { value -> Int in
+            value += 1
+            return value
+        }
+
+        let rms = updateAudioLevel(from: sampleBuffer)
+        if count <= Self.sampleRateLogLimit {
+            let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
+            os_log(.info, log: recordingLog, "buffer #%d at %.3fms, rms=%.6f", count, elapsed, rms)
+        }
+
+        if !readyFired && rms > 0 {
+            readyFired = true
+            let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
+            os_log(.info, log: recordingLog, "FIRST non-silent buffer at %.3fms — recording ready", elapsed)
+            DispatchQueue.main.async {
+                self.onRecordingReady?()
+            }
+        }
+    }
+
+    func fileOutput(
+        _ output: AVCaptureFileOutput,
+        didStartRecordingTo outputFileURL: URL,
+        from connections: [AVCaptureConnection]
+    ) {
+        os_log(.info, log: recordingLog, "file output started writing to %{public}@", outputFileURL.path)
+    }
+
+    func fileOutput(
+        _ output: AVCaptureFileOutput,
+        didFinishRecordingTo outputFileURL: URL,
+        from connections: [AVCaptureConnection],
+        error: Error?
+    ) {
+        sessionQueue.async {
+            let completion = self.pendingStopCompletion
+            self.pendingStopCompletion = nil
+            let shouldDiscardRecording = self.shouldDiscardRecording
+            self.shouldDiscardRecording = false
+            self.cancelWatchdog()
+            self.teardownSessionLocked()
+
+            DispatchQueue.main.async {
+                self.isRecording = false
+                self.audioLevel = 0.0
+            }
+
+            if let error {
+                if !shouldDiscardRecording {
+                    os_log(.error, log: recordingLog, "file output finished with error: %{public}@", error.localizedDescription)
+                    self.reportRecordingFailure(AudioRecorderError.failedToBeginFileRecording(error.localizedDescription))
+                } else {
+                    try? FileManager.default.removeItem(at: outputFileURL)
+                }
+                return
+            }
+
+            if shouldDiscardRecording {
+                try? FileManager.default.removeItem(at: outputFileURL)
+                self.tempFileURL = nil
+                return
+            }
+
+            self.tempFileURL = outputFileURL
+            DispatchQueue.main.async {
+                completion?(outputFileURL)
+            }
         }
     }
 }

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -263,14 +263,14 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         currentDeviceUID = nil
     }
 
-    private func reportRecordingFailure(_ error: Error) {
+    private func reportRecordingFailure(_ error: Error, completion: ((URL?) -> Void)? = nil) {
         sessionQueue.async {
             guard !self.failureReported else { return }
             self.failureReported = true
             self.cancelWatchdog()
             self._recording.withLock { $0 = false }
 
-            let completion = self.pendingStopCompletion
+            let completion = completion ?? self.pendingStopCompletion
             self.pendingStopCompletion = nil
             let discardURL = self.tempFileURL
             self.shouldDiscardRecording = false
@@ -571,21 +571,31 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             let shouldDiscardRecording = self.shouldDiscardRecording
             self.shouldDiscardRecording = false
             self.cancelWatchdog()
+
+            if let error {
+                if !shouldDiscardRecording {
+                    os_log(.error, log: recordingLog, "file output finished with error: %{public}@", error.localizedDescription)
+                    self.reportRecordingFailure(
+                        AudioRecorderError.failedToBeginFileRecording(error.localizedDescription),
+                        completion: completion
+                    )
+                } else {
+                    self.teardownSessionLocked()
+                    self.tempFileURL = nil
+                    try? FileManager.default.removeItem(at: outputFileURL)
+                    DispatchQueue.main.async {
+                        self.isRecording = false
+                        self.audioLevel = 0.0
+                    }
+                }
+                return
+            }
+
             self.teardownSessionLocked()
 
             DispatchQueue.main.async {
                 self.isRecording = false
                 self.audioLevel = 0.0
-            }
-
-            if let error {
-                if !shouldDiscardRecording {
-                    os_log(.error, log: recordingLog, "file output finished with error: %{public}@", error.localizedDescription)
-                    self.reportRecordingFailure(AudioRecorderError.failedToBeginFileRecording(error.localizedDescription))
-                } else {
-                    try? FileManager.default.removeItem(at: outputFileURL)
-                }
-                return
             }
 
             if shouldDiscardRecording {

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -148,6 +148,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private let sampleBufferQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.samples")
     private var pendingStopCompletion: ((URL?) -> Void)?
     private var shouldDiscardRecording = false
+    private var isSessionInterrupted = false
 
     @Published var isRecording = false
     private let _recording = OSAllocatedUnfairLock(initialState: false)
@@ -235,10 +236,18 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             object: session,
             queue: nil
         ) { [weak self] notification in
-            _ = notification
-            self?.reportRecordingFailure(AudioRecorderError.failedToStartCaptureSession("Capture session interrupted."))
+            self?.handleSessionInterrupted(notification)
         }
         sessionObservers.append(interruptionObserver)
+
+        let interruptionEndedObserver = NotificationCenter.default.addObserver(
+            forName: AVCaptureSession.interruptionEndedNotification,
+            object: session,
+            queue: nil
+        ) { [weak self] notification in
+            self?.handleSessionInterruptionEnded(notification)
+        }
+        sessionObservers.append(interruptionEndedObserver)
     }
 
     private func removeSessionObservers() {
@@ -250,6 +259,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
     private func teardownSessionLocked() {
         removeSessionObservers()
+        isSessionInterrupted = false
 
         audioDataOutput?.setSampleBufferDelegate(nil, queue: nil)
         if let session = captureSession, session.isRunning {
@@ -290,6 +300,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     }
 
     private func startBufferWatchdog() {
+        let baselineCount = _bufferCount.withLock { $0 }
         cancelWatchdog()
 
         let timer = DispatchSource.makeTimerSource(queue: sessionQueue)
@@ -297,13 +308,17 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         timer.setEventHandler { [weak self] in
             guard let self else { return }
             guard self._recording.withLock({ $0 }) else { return }
+            guard !self.isSessionInterrupted else {
+                os_log(.info, log: recordingLog, "watchdog suspended while capture session is interrupted")
+                return
+            }
 
             let count = self._bufferCount.withLock { $0 }
-            if count == 0 {
-                os_log(.error, log: recordingLog, "watchdog: 0 buffers after %.1fs — giving up", Self.watchdogTimeout)
+            if count == baselineCount {
+                os_log(.error, log: recordingLog, "watchdog: no new buffers after %.1fs — giving up", Self.watchdogTimeout)
                 self.reportRecordingFailure(AudioRecorderError.noAudioBuffersReceived)
             } else {
-                os_log(.info, log: recordingLog, "watchdog: %d buffers after %.1fs — healthy", count, Self.watchdogTimeout)
+                os_log(.info, log: recordingLog, "watchdog: %d new buffers after %.1fs — healthy", count - baselineCount, Self.watchdogTimeout)
             }
         }
         timer.resume()
@@ -313,6 +328,26 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private func cancelWatchdog() {
         watchdogTimer?.cancel()
         watchdogTimer = nil
+    }
+
+    private func handleSessionInterrupted(_ notification: Notification) {
+        _ = notification
+        sessionQueue.async {
+            guard self._recording.withLock({ $0 }) else { return }
+            self.isSessionInterrupted = true
+            self.cancelWatchdog()
+            os_log(.info, log: recordingLog, "capture session interrupted — waiting for recovery")
+        }
+    }
+
+    private func handleSessionInterruptionEnded(_ notification: Notification) {
+        _ = notification
+        sessionQueue.async {
+            guard self._recording.withLock({ $0 }) else { return }
+            self.isSessionInterrupted = false
+            os_log(.info, log: recordingLog, "capture session interruption ended — restarting watchdog")
+            self.startBufferWatchdog()
+        }
     }
 
     private func makeSession(deviceUID: String?, outputURL: URL) throws {
@@ -372,6 +407,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         audioFileOutput = fileOutput
         audioDataOutput = dataOutput
         currentDeviceUID = device.uniqueID
+        isSessionInterrupted = false
         installSessionObservers(for: session)
 
         os_log(.info, log: recordingLog, "configured capture session with device %{public}@ [uid=%{public}@]", device.localizedName, device.uniqueID)
@@ -571,8 +607,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             let shouldDiscardRecording = self.shouldDiscardRecording
             self.shouldDiscardRecording = false
             self.cancelWatchdog()
+            let recordingSuccessfullyFinished = (error as NSError?)?.userInfo[AVErrorRecordingSuccessfullyFinishedKey] as? Bool ?? false
 
-            if let error {
+            if let error, !recordingSuccessfullyFinished {
                 if !shouldDiscardRecording {
                     os_log(.error, log: recordingLog, "file output finished with error: %{public}@", error.localizedDescription)
                     self.reportRecordingFailure(
@@ -589,6 +626,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
                     }
                 }
                 return
+            }
+
+            if let error {
+                os_log(.info, log: recordingLog, "file output finished with recoverable stop status: %{public}@", error.localizedDescription)
             }
 
             self.teardownSessionLocked()

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -248,7 +248,6 @@ Model: \(model)
         }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
-
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PostProcessingError.invalidResponse("No HTTP response")

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1046,7 +1046,6 @@ struct SetupView: View {
         testAudioLevelCancellable = nil
         if let recorder = testAudioRecorder, recorder.isRecording {
             recorder.cancelRecording()
-            recorder.cleanup()
         }
         testAudioRecorder = nil
     }
@@ -1063,7 +1062,6 @@ struct SetupView: View {
             if recorder.isRecording {
                 recorder.cancelRecording()
             }
-            recorder.cleanup()
             testAudioRecorder = nil
         }
     }

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -962,7 +962,8 @@ struct SetupView: View {
                 }
                 do {
                     let recorder = AudioRecorder()
-                    recorder.onRecordingFailure = { error in
+                    recorder.onRecordingFailure = { [weak recorder] error in
+                        guard let recorder else { return }
                         testAudioLevelCancellable?.cancel()
                         testAudioLevelCancellable = nil
                         testAudioLevel = 0.0

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -962,8 +962,21 @@ struct SetupView: View {
                 }
                 do {
                     let recorder = AudioRecorder()
+                    recorder.onRecordingFailure = { error in
+                        testAudioLevelCancellable?.cancel()
+                        testAudioLevelCancellable = nil
+                        testAudioLevel = 0.0
+                        testHotkeyHarness.isTranscribing = false
+                        testAudioRecorder = nil
+                        testError = error.localizedDescription
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                            testPhase = .done
+                        }
+                        recorder.cleanup()
+                    }
                     try recorder.startRecording(deviceUID: appState.selectedMicrophoneID)
                     testAudioRecorder = recorder
+                    testError = nil
                     testAudioLevelCancellable = recorder.$audioLevel
                         .receive(on: DispatchQueue.main)
                         .sink { level in
@@ -993,7 +1006,10 @@ struct SetupView: View {
                 recorder.stopRecording { url in
                     guard let url else {
                         testHotkeyHarness.isTranscribing = false
-                        testError = "No audio file was created."
+                        testAudioRecorder = nil
+                        if testError == nil {
+                            testError = "No audio file was created."
+                        }
                         withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                             testPhase = .done
                         }
@@ -1011,6 +1027,7 @@ struct SetupView: View {
                             let transcript = try await service.transcribe(fileURL: url)
                             await MainActor.run {
                                 testHotkeyHarness.isTranscribing = false
+                                testAudioRecorder = nil
                                 testTranscript = transcript
                                 withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
                                     testPhase = .done
@@ -1019,6 +1036,7 @@ struct SetupView: View {
                         } catch {
                             await MainActor.run {
                                 testHotkeyHarness.isTranscribing = false
+                                testAudioRecorder = nil
                                 testError = error.localizedDescription
                                 withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
                                     testPhase = .done

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -997,6 +997,7 @@ struct SetupView: View {
                         withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                             testPhase = .done
                         }
+                        recorder.cleanup()
                         return
                     }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -982,7 +982,6 @@ struct SetupView: View {
 
             case .stop:
                 guard testPhase == .recording, let recorder = testAudioRecorder else { return }
-                let fileURL = recorder.stopRecording()
                 testAudioLevelCancellable?.cancel()
                 testAudioLevelCancellable = nil
                 testAudioLevel = 0.0
@@ -991,41 +990,42 @@ struct SetupView: View {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                     testPhase = .transcribing
                 }
-
-                guard let url = fileURL else {
-                    testHotkeyHarness.isTranscribing = false
-                    testError = "No audio file was created."
-                    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                        testPhase = .done
+                recorder.stopRecording { url in
+                    guard let url else {
+                        testHotkeyHarness.isTranscribing = false
+                        testError = "No audio file was created."
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                            testPhase = .done
+                        }
+                        return
                     }
-                    return
-                }
 
-                Task {
-                    do {
-                        let service = TranscriptionService(
-                            apiKey: appState.apiKey,
-                            baseURL: appState.apiBaseURL,
-                            forceHTTP2: appState.forceHTTP2Transcription
-                        )
-                        let transcript = try await service.transcribe(fileURL: url)
-                        await MainActor.run {
-                            testHotkeyHarness.isTranscribing = false
-                            testTranscript = transcript
-                            withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
-                                testPhase = .done
+                    Task {
+                        do {
+                            let service = TranscriptionService(
+                                apiKey: appState.apiKey,
+                                baseURL: appState.apiBaseURL,
+                                forceHTTP2: appState.forceHTTP2Transcription
+                            )
+                            let transcript = try await service.transcribe(fileURL: url)
+                            await MainActor.run {
+                                testHotkeyHarness.isTranscribing = false
+                                testTranscript = transcript
+                                withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+                                    testPhase = .done
+                                }
+                            }
+                        } catch {
+                            await MainActor.run {
+                                testHotkeyHarness.isTranscribing = false
+                                testError = error.localizedDescription
+                                withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+                                    testPhase = .done
+                                }
                             }
                         }
-                    } catch {
-                        await MainActor.run {
-                            testHotkeyHarness.isTranscribing = false
-                            testError = error.localizedDescription
-                            withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
-                                testPhase = .done
-                            }
-                        }
+                        recorder.cleanup()
                     }
-                    recorder.cleanup()
                 }
 
             case .switchedToToggle:
@@ -1044,7 +1044,7 @@ struct SetupView: View {
         testAudioLevelCancellable?.cancel()
         testAudioLevelCancellable = nil
         if let recorder = testAudioRecorder, recorder.isRecording {
-            _ = recorder.stopRecording()
+            recorder.cancelRecording()
             recorder.cleanup()
         }
         testAudioRecorder = nil
@@ -1060,7 +1060,7 @@ struct SetupView: View {
         testHotkeyHarness.resetSession()
         if let recorder = testAudioRecorder {
             if recorder.isRecording {
-                _ = recorder.stopRecording()
+                recorder.cancelRecording()
             }
             recorder.cleanup()
             testAudioRecorder = nil


### PR DESCRIPTION
## Summary

This PR migrates FreeFlow’s audio recording pipeline from `AVAudioEngine` to `AVCaptureSession`.

The new flow uses `AVCaptureAudioFileOutput` for WAV recording and `AVCaptureAudioDataOutput` for live sample monitoring, which gives us a more reliable lifecycle for recording start, readiness detection, stop/finalization, and failure handling. In practice, recording has also felt noticeably more stable with faster startup.

## Why

Recording is one of the most critical parts of the app, and the old `AVAudioEngine` path was doing too much manual lifecycle management. That made the flow more fragile around device selection, missing buffers, stop timing, and cleanup.

This migration gives us a capture pipeline that better matches what the app needs and should make recording behavior more predictable and responsive.

## What Changed

- replaced the `AVAudioEngine` recording path with `AVCaptureSession`
- switched file recording to `AVCaptureAudioFileOutput`
- added live sample monitoring for audio levels and recording readiness
- improved recorder error handling and selected-device fallback
- moved recording failure cleanup into a single `AppState` path
- made stop recording completion-based so transcription waits for file finalization
- updated setup/test recording flows to use the new stop/cancel behavior

## Testing

Manual testing:
- record with the default microphone
- record with a non-default microphone
- verify fallback when the selected mic is unavailable
- verify setup-flow test recording still records and transcribes
- verify cancelled recordings clean up correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated recording-failure handling with clearer error messages, reliable cleanup, and improved interruption/retry behavior
  * Ensures "Transcribing…" status displays at the correct time and avoids orphaned state when no audio is recorded
  * Improved test-recording teardown to prevent leftover subscriptions or missing recordings

* **New Features**
  * Asynchronous stop API (callback-based) for reliable post-recording processing
  * Immediate cancel capability for in-progress recordings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->