### PR TITLE
Route API requests through optional HTTP/2 curl transport

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -31,16 +31,24 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     private let apiKey: String
     private let baseURL: String
     private let customContextPrompt: String
+    private let forceHTTP2: Bool
     private let fallbackTextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let visionModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let maxScreenshotDataURILength = 500_000
     private let screenshotCompressionPrimary = 0.5
     private let screenshotMaxDimension: CGFloat = 1024
+    private let requestTimeoutSeconds: TimeInterval = 20
 
-    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1", customContextPrompt: String = "") {
+    init(
+        apiKey: String,
+        baseURL: String = "https://api.groq.com/openai/v1",
+        customContextPrompt: String = "",
+        forceHTTP2: Bool = false
+    ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.customContextPrompt = customContextPrompt
+        self.forceHTTP2 = forceHTTP2
     }
 
     func collectContext() async -> AppContext {
@@ -157,6 +165,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
             request.httpMethod = "POST"
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.timeoutInterval = requestTimeoutSeconds
 
             let metadata = """
 App: \(appName ?? "Unknown")
@@ -204,13 +213,33 @@ Selected text: \(selectedText ?? "None")
                 ]
             ]
 
-            request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return nil
-            }
-            guard httpResponse.statusCode == 200 else {
-                return nil
+            let requestBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+            request.httpBody = requestBody
+
+            let data: Data
+            if forceHTTP2 {
+                let response = try await HTTP2CurlTransport.sendJSONRequest(
+                    url: request.url!.absoluteString,
+                    headers: [
+                        "Authorization: Bearer \(apiKey)",
+                        "Content-Type: application/json"
+                    ],
+                    body: requestBody,
+                    timeoutSeconds: requestTimeoutSeconds
+                )
+                guard response.statusCode == 200 else {
+                    return nil
+                }
+                data = response.data
+            } else {
+                let (responseData, response) = try await URLSession.shared.data(for: request)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    return nil
+                }
+                guard httpResponse.statusCode == 200 else {
+                    return nil
+                }
+                data = responseData
             }
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let choices = json["choices"] as? [[String: Any]],

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -12,9 +12,27 @@ struct AppContext {
     let screenshotDataURL: String?
     let screenshotMimeType: String?
     let screenshotError: String?
+    let inferenceError: String?
 
     var contextSummary: String {
         currentActivity
+    }
+}
+
+enum AppContextInferenceError: LocalizedError {
+    case transportFailed(String)
+    case requestFailed(Int, String)
+    case invalidResponse(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .transportFailed(let details):
+            return "Context inference transport failed: \(details)"
+        case .requestFailed(let statusCode, let details):
+            return "Context inference failed with status \(statusCode): \(details)"
+        case .invalidResponse(let details):
+            return "Context inference returned an invalid response: \(details)"
+        }
     }
 }
 
@@ -62,7 +80,8 @@ Return only two sentences, no labels, no markdown, no extra commentary.
                 contextPrompt: nil,
                 screenshotDataURL: nil,
                 screenshotMimeType: nil,
-                screenshotError: "No frontmost application"
+                screenshotError: "No frontmost application",
+                inferenceError: nil
             )
         }
 
@@ -79,17 +98,31 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         )
         let currentActivity: String
         let contextPrompt: String?
+        let inferenceError: String?
         if !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            if let result = await inferActivityWithLLM(
-                appName: appName,
-                bundleIdentifier: bundleIdentifier,
-                windowTitle: windowTitle,
-                selectedText: selectedText,
-                screenshotDataURL: screenshot.dataURL
-            ) {
-                currentActivity = result.activity
-                contextPrompt = result.prompt
-            } else {
+            do {
+                if let result = try await inferActivityWithLLM(
+                    appName: appName,
+                    bundleIdentifier: bundleIdentifier,
+                    windowTitle: windowTitle,
+                    selectedText: selectedText,
+                    screenshotDataURL: screenshot.dataURL
+                ) {
+                    currentActivity = result.activity
+                    contextPrompt = result.prompt
+                    inferenceError = nil
+                } else {
+                    currentActivity = fallbackCurrentActivity(
+                        appName: appName,
+                        bundleIdentifier: bundleIdentifier,
+                        selectedText: selectedText,
+                        windowTitle: windowTitle,
+                        screenshotAvailable: screenshot.dataURL != nil
+                    )
+                    contextPrompt = nil
+                    inferenceError = nil
+                }
+            } catch {
                 currentActivity = fallbackCurrentActivity(
                     appName: appName,
                     bundleIdentifier: bundleIdentifier,
@@ -98,6 +131,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
                     screenshotAvailable: screenshot.dataURL != nil
                 )
                 contextPrompt = nil
+                inferenceError = error.localizedDescription
             }
         } else {
             currentActivity = fallbackCurrentActivity(
@@ -108,6 +142,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
                 screenshotAvailable: screenshot.dataURL != nil
             )
             contextPrompt = nil
+            inferenceError = nil
         }
 
         return AppContext(
@@ -119,7 +154,8 @@ Return only two sentences, no labels, no markdown, no extra commentary.
             contextPrompt: contextPrompt,
             screenshotDataURL: screenshot.dataURL,
             screenshotMimeType: screenshot.mimeType,
-            screenshotError: screenshot.error
+            screenshotError: screenshot.error,
+            inferenceError: inferenceError
         )
     }
 
@@ -129,26 +165,32 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         windowTitle: String?,
         selectedText: String?,
         screenshotDataURL: String?
-    ) async -> (activity: String, prompt: String)? {
+    ) async throws -> (activity: String, prompt: String)? {
         let modelsToTry = [
             screenshotDataURL != nil ? visionModel : fallbackTextModel,
             fallbackTextModel
         ]
+        var lastError: Error?
 
         for model in modelsToTry {
             let screenshotPayload = model == visionModel ? screenshotDataURL : nil
-            if let inferred = await inferActivityWithLLM(
-                appName: appName,
-                bundleIdentifier: bundleIdentifier,
-                windowTitle: windowTitle,
-                selectedText: selectedText,
-                screenshotDataURL: screenshotPayload,
-                model: model
-            ) {
-                return inferred
+            do {
+                return try await inferActivityWithLLM(
+                    appName: appName,
+                    bundleIdentifier: bundleIdentifier,
+                    windowTitle: windowTitle,
+                    selectedText: selectedText,
+                    screenshotDataURL: screenshotPayload,
+                    model: model
+                )
+            } catch {
+                lastError = error
             }
         }
 
+        if let lastError {
+            throw lastError
+        }
         return nil
     }
 
@@ -159,102 +201,113 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         selectedText: String?,
         screenshotDataURL: String?,
         model: String
-    ) async -> (activity: String, prompt: String)? {
-        do {
-            var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
-            request.httpMethod = "POST"
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.timeoutInterval = requestTimeoutSeconds
+    ) async throws -> (activity: String, prompt: String) {
+        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = requestTimeoutSeconds
 
-            let metadata = """
+        let metadata = """
 App: \(appName ?? "Unknown")
 Bundle ID: \(bundleIdentifier ?? "Unknown")
 Window: \(windowTitle ?? "Unknown")
 Selected text: \(selectedText ?? "None")
 """
 
-            let systemPrompt = customContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ? Self.defaultContextPrompt
-                : customContextPrompt
+        let systemPrompt = customContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? Self.defaultContextPrompt
+            : customContextPrompt
 
-            let textOnlyPrompt = "Analyze the context and infer the user's current activity in exactly two sentences.\n\n\(metadata)"
-            var userMessageDescription: String
-            var userMessage: Any = textOnlyPrompt
+        let textOnlyPrompt = "Analyze the context and infer the user's current activity in exactly two sentences.\n\n\(metadata)"
+        var userMessageDescription: String
+        var userMessage: Any = textOnlyPrompt
 
-            if let screenshotDataURL {
-                userMessageDescription = "[screenshot attached]\nAnalyze the screenshot plus metadata to infer current activity.\n\(metadata)"
-                userMessage = [
-                    [
-                        "type": "text",
-                        "text": "Analyze the screenshot plus metadata to infer current activity."
-                    ],
-                    [
-                        "type": "text",
-                        "text": metadata
-                    ],
-                    [
-                        "type": "image_url",
-                        "image_url": ["url": screenshotDataURL]
-                    ]
-                ]
-            } else {
-                userMessageDescription = textOnlyPrompt
-            }
-
-            let fullPrompt = "Model: \(model)\n\n[System]\n\(systemPrompt)\n[User]\n\(userMessageDescription)"
-
-            let payload: [String: Any] = [
-                "model": model,
-                "temperature": 0.2,
-                "messages": [
-                    ["role": "system", "content": systemPrompt],
-                    ["role": "user", "content": userMessage]
+        if let screenshotDataURL {
+            userMessageDescription = "[screenshot attached]\nAnalyze the screenshot plus metadata to infer current activity.\n\(metadata)"
+            userMessage = [
+                [
+                    "type": "text",
+                    "text": "Analyze the screenshot plus metadata to infer current activity."
+                ],
+                [
+                    "type": "text",
+                    "text": metadata
+                ],
+                [
+                    "type": "image_url",
+                    "image_url": ["url": screenshotDataURL]
                 ]
             ]
+        } else {
+            userMessageDescription = textOnlyPrompt
+        }
 
-            let requestBody = try JSONSerialization.data(withJSONObject: payload, options: [])
-            request.httpBody = requestBody
+        let fullPrompt = "Model: \(model)\n\n[System]\n\(systemPrompt)\n[User]\n\(userMessageDescription)"
 
-            let data: Data
-            if forceHTTP2 {
-                let response = try await HTTP2CurlTransport.sendJSONRequest(
-                    url: request.url!.absoluteString,
-                    headers: [
-                        "Authorization: Bearer \(apiKey)",
-                        "Content-Type: application/json"
-                    ],
-                    body: requestBody,
-                    timeoutSeconds: requestTimeoutSeconds
+        let payload: [String: Any] = [
+            "model": model,
+            "temperature": 0.2,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userMessage]
+            ]
+        ]
+
+        let requestBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+        request.httpBody = requestBody
+
+        let data: Data
+        if forceHTTP2 {
+            let response = try await HTTP2CurlTransport.sendJSONRequest(
+                url: request.url!.absoluteString,
+                headers: [
+                    "Authorization: Bearer \(apiKey)",
+                    "Content-Type: application/json"
+                ],
+                body: requestBody,
+                timeoutSeconds: requestTimeoutSeconds
+            )
+            guard response.statusCode == 200 else {
+                throw AppContextInferenceError.requestFailed(
+                    response.statusCode,
+                    responseBodyDescription(from: response.data)
                 )
-                guard response.statusCode == 200 else {
-                    return nil
-                }
-                data = response.data
-            } else {
+            }
+            data = response.data
+        } else {
+            do {
                 let (responseData, response) = try await URLSession.shared.data(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
-                    return nil
+                    throw AppContextInferenceError.invalidResponse("No HTTP response")
                 }
                 guard httpResponse.statusCode == 200 else {
-                    return nil
+                    throw AppContextInferenceError.requestFailed(
+                        httpResponse.statusCode,
+                        responseBodyDescription(from: responseData)
+                    )
                 }
                 data = responseData
+            } catch let error as AppContextInferenceError {
+                throw error
+            } catch {
+                throw AppContextInferenceError.transportFailed(error.localizedDescription)
             }
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let choices = json["choices"] as? [[String: Any]],
-                  let firstChoice = choices.first,
-                  let message = firstChoice["message"] as? [String: Any],
-                  let content = message["content"] as? String else {
-                return nil
-            }
-
-            let cleaned = content.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !cleaned.isEmpty else { return nil }
-            return (activity: normalizedActivitySummary(cleaned), prompt: fullPrompt)
-        } catch {
-            return nil
         }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw AppContextInferenceError.invalidResponse("Missing choices[0].message.content")
+        }
+
+        let cleaned = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else {
+            throw AppContextInferenceError.invalidResponse("Model returned empty content")
+        }
+        return (activity: normalizedActivitySummary(cleaned), prompt: fullPrompt)
     }
 
     private func normalizedActivitySummary(_ value: String) -> String {
@@ -269,6 +322,12 @@ Selected text: \(selectedText ?? "None")
 
         let firstTwo = sentences.prefix(2)
         return firstTwo.joined(separator: ". ") + "."
+    }
+
+    private func responseBodyDescription(from data: Data) -> String {
+        let responseText = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return responseText.isEmpty ? "<empty response body>" : responseText
     }
 
     private func fallbackCurrentActivity(

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -582,7 +582,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextPrompt: item.contextPrompt,
             screenshotDataURL: item.contextScreenshotDataURL,
             screenshotMimeType: item.contextScreenshotDataURL != nil ? "image/jpeg" : nil,
-            screenshotError: nil
+            screenshotError: nil,
+            inferenceError: nil
         )
 
         let transcriptionService = TranscriptionService(
@@ -1393,7 +1394,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.lastContextScreenshotDataURL = context.screenshotDataURL
                 self.lastContextScreenshotStatus = context.screenshotError
                     ?? "available (\(context.screenshotMimeType ?? "image"))"
-                self.lastPostProcessingStatus = "App context captured"
+                self.lastPostProcessingStatus = context.inferenceError.map {
+                    "App context fallback used: \($0)"
+                } ?? "App context captured"
                 self.handleScreenshotCaptureIssue(context.screenshotError)
             }
             return context
@@ -1412,7 +1415,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextPrompt: nil,
             screenshotDataURL: nil,
             screenshotMimeType: nil,
-            screenshotError: "No app context captured before stop"
+            screenshotError: "No app context captured before stop",
+            inferenceError: nil
         )
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -143,14 +143,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var apiKey: String {
         didSet {
             persistAPIKey(apiKey)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
         }
     }
 
     @Published var apiBaseURL: String {
         didSet {
             persistAPIBaseURL(apiBaseURL)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
         }
     }
 
@@ -195,7 +195,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var customContextPrompt: String {
         didSet {
             UserDefaults.standard.set(customContextPrompt, forKey: customContextPromptStorageKey)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
         }
     }
 
@@ -226,6 +226,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var forceHTTP2Transcription: Bool {
         didSet {
             UserDefaults.standard.set(forceHTTP2Transcription, forKey: forceHTTP2TranscriptionStorageKey)
+            rebuildContextService()
         }
     }
 
@@ -353,7 +354,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
 
-        self.contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+        self.contextService = AppContextService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            customContextPrompt: customContextPrompt,
+            forceHTTP2: forceHTTP2Transcription
+        )
         self.hasCompletedSetup = hasCompletedSetup
         self.apiKey = apiKey
         self.apiBaseURL = apiBaseURL
@@ -477,6 +483,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func rebuildContextService() {
+        contextService = AppContextService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            customContextPrompt: customContextPrompt,
+            forceHTTP2: forceHTTP2Transcription
+        )
+    }
+
     private func persistShortcut(_ binding: ShortcutBinding, key: String) {
         guard let data = try? JSONEncoder().encode(binding) else { return }
         UserDefaults.standard.set(data, forKey: key)
@@ -575,7 +590,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             baseURL: apiBaseURL,
             forceHTTP2: forceHTTP2Transcription
         )
-        let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
+        let postProcessingService = PostProcessingService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            forceHTTP2: forceHTTP2Transcription
+        )
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
 
@@ -1206,7 +1225,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             baseURL: apiBaseURL,
             forceHTTP2: forceHTTP2Transcription
         )
-        let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
+        let postProcessingService = PostProcessingService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            forceHTTP2: forceHTTP2Transcription
+        )
 
         Task {
             do {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -91,14 +91,16 @@ Output hygiene:
 
     private let apiKey: String
     private let baseURL: String
+    private let forceHTTP2: Bool
     private let defaultModel = "openai/gpt-oss-20b"
     private let fallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let postProcessingMaxCompletionTokens = 4096
     private let postProcessingTimeoutSeconds: TimeInterval = 20
 
-    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1") {
+    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1", forceHTTP2: Bool = false) {
         self.apiKey = apiKey
         self.baseURL = baseURL
+        self.forceHTTP2 = forceHTTP2
     }
 
     func postProcess(
@@ -247,16 +249,35 @@ Model: \(model)
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
         }
 
-        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+        let requestBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+        request.httpBody = requestBody
 
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw PostProcessingError.invalidResponse("No HTTP response")
+        let data: Data
+        let statusCode: Int
+        if forceHTTP2 {
+            let response = try await HTTP2CurlTransport.sendJSONRequest(
+                url: request.url!.absoluteString,
+                headers: [
+                    "Authorization: Bearer \(apiKey)",
+                    "Content-Type: application/json"
+                ],
+                body: requestBody,
+                timeoutSeconds: postProcessingTimeoutSeconds
+            )
+            data = response.data
+            statusCode = response.statusCode
+        } else {
+            let (responseData, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw PostProcessingError.invalidResponse("No HTTP response")
+            }
+            data = responseData
+            statusCode = httpResponse.statusCode
         }
 
-        guard httpResponse.statusCode == 200 else {
+        guard statusCode == 200 else {
             let message = String(data: data, encoding: .utf8) ?? ""
-            throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
+            throw PostProcessingError.requestFailed(statusCode, message)
         }
 
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -469,9 +469,9 @@ struct GeneralSettingsView: View {
 
             HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Force HTTP/2 for Transcription")
+                    Text("Force HTTP/2 for API Requests")
                         .font(.caption.weight(.semibold))
-                    Text("Uses `curl --http2` for audio transcription uploads. Leave this off unless the default transport is failing.")
+                    Text("Uses `curl --http2` for transcription uploads, context inference, and post-processing. Leave this off unless the default transport is failing.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -960,7 +960,11 @@ struct PromptsSettingsView: View {
         systemTestError = nil
         systemTestPrompt = nil
 
-        let service = PostProcessingService(apiKey: appState.apiKey, baseURL: appState.apiBaseURL)
+        let service = PostProcessingService(
+            apiKey: appState.apiKey,
+            baseURL: appState.apiBaseURL,
+            forceHTTP2: appState.forceHTTP2Transcription
+        )
         let input = systemTestInput
         let customPrompt = appState.customSystemPrompt
         let vocabulary = appState.customVocabulary
@@ -1176,7 +1180,8 @@ struct PromptsSettingsView: View {
         let service = AppContextService(
             apiKey: appState.apiKey,
             baseURL: appState.apiBaseURL,
-            customContextPrompt: appState.customContextPrompt
+            customContextPrompt: appState.customContextPrompt,
+            forceHTTP2: appState.forceHTTP2Transcription
         )
 
         Task {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -978,7 +978,8 @@ struct PromptsSettingsView: View {
             contextPrompt: nil,
             screenshotDataURL: nil,
             screenshotMimeType: nil,
-            screenshotError: nil
+            screenshotError: nil,
+            inferenceError: nil
         )
 
         Task {
@@ -1191,7 +1192,8 @@ struct PromptsSettingsView: View {
                     contextTestOutput = context.contextSummary
                     contextTestPrompt = prompt
                 } else {
-                    contextTestError = "Context inference returned no result. This may be a permissions issue or the API could not be reached."
+                    contextTestError = context.inferenceError
+                        ?? "Context inference returned no result. This may be a permissions issue or the API could not be reached."
                     contextTestOutput = context.contextSummary
                 }
                 contextTestRunning = false

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -4,6 +4,169 @@ import os.log
 
 private let transcriptionLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Transcription")
 
+struct HTTP2CurlResponse {
+    let data: Data
+    let statusCode: Int
+}
+
+enum HTTP2CurlTransportError: LocalizedError {
+    case executionFailed(Int32, String)
+    case invalidStatusCode(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .executionFailed(let exitCode, let details):
+            return "curl transport failed with exit \(exitCode): \(details)"
+        case .invalidStatusCode(let value):
+            return "curl transport returned an invalid HTTP status code: \(value)"
+        }
+    }
+}
+
+private final class PipeDataBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    func snapshot() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
+    }
+}
+
+enum HTTP2CurlTransport {
+    private static func runProcessAndCollectOutput(
+        _ process: Process,
+        stdout: Pipe,
+        stderr: Pipe
+    ) throws -> (terminationStatus: Int32, statusData: Data, errorData: Data) {
+        let statusDataBuffer = PipeDataBuffer()
+        let errorDataBuffer = PipeDataBuffer()
+        let statusEOF = DispatchSemaphore(value: 0)
+        let errorEOF = DispatchSemaphore(value: 0)
+
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                statusEOF.signal()
+                return
+            }
+            statusDataBuffer.append(chunk)
+        }
+
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                errorEOF.signal()
+                return
+            }
+            errorDataBuffer.append(chunk)
+        }
+
+        defer {
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+        }
+
+        try process.run()
+        process.waitUntilExit()
+
+        statusEOF.wait()
+        errorEOF.wait()
+
+        return (
+            terminationStatus: process.terminationStatus,
+            statusData: statusDataBuffer.snapshot(),
+            errorData: errorDataBuffer.snapshot()
+        )
+    }
+
+    static func sendJSONRequest(
+        url: String,
+        method: String = "POST",
+        headers: [String],
+        body: Data,
+        timeoutSeconds: TimeInterval
+    ) async throws -> HTTP2CurlResponse {
+        try await Task.detached(priority: .userInitiated) {
+            let fileManager = FileManager.default
+            let tempDirectory = fileManager.temporaryDirectory
+            let requestBodyURL = tempDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("json")
+            let responseBodyURL = tempDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("json")
+
+            defer {
+                try? fileManager.removeItem(at: requestBodyURL)
+                try? fileManager.removeItem(at: responseBodyURL)
+            }
+
+            try body.write(to: requestBodyURL, options: .atomic)
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
+
+            var arguments = [
+                "--silent",
+                "--show-error",
+                "--http2",
+                "--request", method,
+                "--max-time", String(Int(ceil(timeoutSeconds))),
+                "--output", responseBodyURL.path,
+                "--write-out", "%{http_code}",
+                url
+            ]
+            for header in headers {
+                arguments.append(contentsOf: ["-H", header])
+            }
+            arguments.append(contentsOf: ["--data-binary", "@\(requestBodyURL.path)"])
+            process.arguments = arguments
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            let result = try runProcessAndCollectOutput(process, stdout: stdout, stderr: stderr)
+            let statusData = result.statusData
+            let errorData = result.errorData
+            let errorText = String(data: errorData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            guard result.terminationStatus == 0 else {
+                throw HTTP2CurlTransportError.executionFailed(result.terminationStatus, errorText)
+            }
+
+            let statusText = String(data: statusData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard let statusCode = Int(statusText) else {
+                throw HTTP2CurlTransportError.invalidStatusCode(statusText)
+            }
+
+            let responseData: Data
+            do {
+                responseData = try Data(contentsOf: responseBodyURL)
+            } catch {
+                throw HTTP2CurlTransportError.executionFailed(
+                    -1,
+                    "Failed to read response file: \(error.localizedDescription)"
+                )
+            }
+            return HTTP2CurlResponse(data: responseData, statusCode: statusCode)
+        }.value
+    }
+}
+
 class TranscriptionService {
     private let apiKey: String
     private let baseURL: String

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -41,24 +41,27 @@ private final class PipeDataBuffer: @unchecked Sendable {
 }
 
 enum HTTP2CurlTransport {
+    private static let httpStatusMarker = "FREEFLOW_HTTP_STATUS:"
+
     private static func runProcessAndCollectOutput(
         _ process: Process,
+        stdinData: Data? = nil,
         stdout: Pipe,
         stderr: Pipe
-    ) throws -> (terminationStatus: Int32, statusData: Data, errorData: Data) {
-        let statusDataBuffer = PipeDataBuffer()
+    ) throws -> (terminationStatus: Int32, outputData: Data, errorData: Data) {
+        let outputDataBuffer = PipeDataBuffer()
         let errorDataBuffer = PipeDataBuffer()
-        let statusEOF = DispatchSemaphore(value: 0)
+        let outputEOF = DispatchSemaphore(value: 0)
         let errorEOF = DispatchSemaphore(value: 0)
 
         stdout.fileHandleForReading.readabilityHandler = { handle in
             let chunk = handle.availableData
             if chunk.isEmpty {
                 handle.readabilityHandler = nil
-                statusEOF.signal()
+                outputEOF.signal()
                 return
             }
-            statusDataBuffer.append(chunk)
+            outputDataBuffer.append(chunk)
         }
 
         stderr.fileHandleForReading.readabilityHandler = { handle in
@@ -77,16 +80,40 @@ enum HTTP2CurlTransport {
         }
 
         try process.run()
+        if let stdinPipe = process.standardInput as? Pipe, let stdinData {
+            defer { stdinPipe.fileHandleForWriting.closeFile() }
+            do {
+                try stdinPipe.fileHandleForWriting.write(contentsOf: stdinData)
+            } catch {
+                throw HTTP2CurlTransportError.executionFailed(
+                    -1,
+                    "Failed to write request body: \(error.localizedDescription)"
+                )
+            }
+        }
         process.waitUntilExit()
 
-        statusEOF.wait()
+        outputEOF.wait()
         errorEOF.wait()
 
         return (
             terminationStatus: process.terminationStatus,
-            statusData: statusDataBuffer.snapshot(),
+            outputData: outputDataBuffer.snapshot(),
             errorData: errorDataBuffer.snapshot()
         )
+    }
+
+    private static func extractStatusAndError(from errorData: Data) -> (statusText: String?, errorText: String) {
+        let stderrText = String(data: errorData, encoding: .utf8) ?? ""
+        guard let markerRange = stderrText.range(of: httpStatusMarker, options: .backwards) else {
+            return (nil, stderrText.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        let errorText = String(stderrText[..<markerRange.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let statusText = String(stderrText[markerRange.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (statusText, errorText)
     }
 
     static func sendJSONRequest(
@@ -96,73 +123,59 @@ enum HTTP2CurlTransport {
         body: Data,
         timeoutSeconds: TimeInterval
     ) async throws -> HTTP2CurlResponse {
-        try await Task.detached(priority: .userInitiated) {
-            let fileManager = FileManager.default
-            let tempDirectory = fileManager.temporaryDirectory
-            let requestBodyURL = tempDirectory
-                .appendingPathComponent(UUID().uuidString)
-                .appendingPathExtension("json")
-            let responseBodyURL = tempDirectory
-                .appendingPathComponent(UUID().uuidString)
-                .appendingPathExtension("json")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
 
-            defer {
-                try? fileManager.removeItem(at: requestBodyURL)
-                try? fileManager.removeItem(at: responseBodyURL)
-            }
+        var arguments = [
+            "--silent",
+            "--show-error",
+            "--http2",
+            "--request", method,
+            "--max-time", String(Int(ceil(timeoutSeconds))),
+            "--write-out", "%{stderr}\(httpStatusMarker)%{http_code}",
+            url
+        ]
+        for header in headers {
+            arguments.append(contentsOf: ["-H", header])
+        }
+        arguments.append(contentsOf: ["--data-binary", "@-"])
+        process.arguments = arguments
 
-            try body.write(to: requestBodyURL, options: .atomic)
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
 
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
-
-            var arguments = [
-                "--silent",
-                "--show-error",
-                "--http2",
-                "--request", method,
-                "--max-time", String(Int(ceil(timeoutSeconds))),
-                "--output", responseBodyURL.path,
-                "--write-out", "%{http_code}",
-                url
-            ]
-            for header in headers {
-                arguments.append(contentsOf: ["-H", header])
-            }
-            arguments.append(contentsOf: ["--data-binary", "@\(requestBodyURL.path)"])
-            process.arguments = arguments
-
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
-
-            let result = try runProcessAndCollectOutput(process, stdout: stdout, stderr: stderr)
-            let statusData = result.statusData
-            let errorData = result.errorData
-            let errorText = String(data: errorData, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            guard result.terminationStatus == 0 else {
-                throw HTTP2CurlTransportError.executionFailed(result.terminationStatus, errorText)
-            }
-
-            let statusText = String(data: statusData, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard let statusCode = Int(statusText) else {
-                throw HTTP2CurlTransportError.invalidStatusCode(statusText)
-            }
-
-            let responseData: Data
-            do {
-                responseData = try Data(contentsOf: responseBodyURL)
-            } catch {
-                throw HTTP2CurlTransportError.executionFailed(
-                    -1,
-                    "Failed to read response file: \(error.localizedDescription)"
+        return try await Task {
+            try await withTaskCancellationHandler {
+                try Task.checkCancellation()
+                let result = try runProcessAndCollectOutput(
+                    process,
+                    stdinData: body,
+                    stdout: stdout,
+                    stderr: stderr
                 )
+                try Task.checkCancellation()
+
+                let outputData = result.outputData
+                let (statusText, errorText) = extractStatusAndError(from: result.errorData)
+                guard result.terminationStatus == 0 else {
+                    throw HTTP2CurlTransportError.executionFailed(result.terminationStatus, errorText)
+                }
+                guard let statusText else {
+                    throw HTTP2CurlTransportError.invalidStatusCode("missing HTTP status")
+                }
+                guard let statusCode = Int(statusText) else {
+                    throw HTTP2CurlTransportError.invalidStatusCode(statusText)
+                }
+                return HTTP2CurlResponse(data: outputData, statusCode: statusCode)
+            } onCancel: {
+                if process.isRunning {
+                    process.terminate()
+                }
             }
-            return HTTP2CurlResponse(data: responseData, statusCode: statusCode)
         }.value
     }
 }
@@ -293,52 +306,59 @@ class TranscriptionService {
     }
 
     private func transcribeAudioWithCurl(fileURL: URL) async throws -> String {
-        try await Task.detached(priority: .userInitiated) { [apiKey, transcriptionModel, transcriptionResponseFormat] in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
-            process.arguments = [
-                "--silent",
-                "--show-error",
-                "--fail",
-                "--http2",
-                "--max-time", String(Int(self.transcriptionTimeoutSeconds)),
-                "\(self.baseURL)/audio/transcriptions",
-                "-H", "Authorization: Bearer \(apiKey)",
-                "-F", "model=\(transcriptionModel)",
-                "-F", "response_format=\(transcriptionResponseFormat)",
-                "-F", "file=@\(fileURL.path);type=\(self.audioContentType(for: fileURL.lastPathComponent))"
-            ]
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
+        process.arguments = [
+            "--silent",
+            "--show-error",
+            "--fail",
+            "--http2",
+            "--max-time", String(Int(self.transcriptionTimeoutSeconds)),
+            "\(self.baseURL)/audio/transcriptions",
+            "-H", "Authorization: Bearer \(apiKey)",
+            "-F", "model=\(transcriptionModel)",
+            "-F", "response_format=\(transcriptionResponseFormat)",
+            "-F", "file=@\(fileURL.path);type=\(self.audioContentType(for: fileURL.lastPathComponent))"
+        ]
 
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
 
-            try process.run()
-            process.waitUntilExit()
+        return try await Task {
+            try await withTaskCancellationHandler {
+                try Task.checkCancellation()
+                let result = try HTTP2CurlTransport.runProcessAndCollectOutput(process, stdout: stdout, stderr: stderr)
+                try Task.checkCancellation()
 
-            let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
-            let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
-            let errorText = String(data: errorData, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let outputData = result.outputData
+                let errorData = result.errorData
+                let errorText = String(data: errorData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-            guard process.terminationStatus == 0 else {
-                os_log(
-                    .error,
-                    log: transcriptionLog,
-                    "curl upload failed for %{public}@ (transport=%{public}@, bytes=%{public}lld): exit=%d%{public}@",
-                    fileURL.lastPathComponent,
-                    "http2-curl",
-                    self.fileSizeBytes(for: fileURL),
-                    process.terminationStatus,
-                    errorText.isEmpty ? "" : " stderr=\(errorText)"
-                )
-                throw TranscriptionError.submissionFailed(
-                    "curl transport failed with exit \(process.terminationStatus): \(errorText)"
-                )
+                guard result.terminationStatus == 0 else {
+                    os_log(
+                        .error,
+                        log: transcriptionLog,
+                        "curl upload failed for %{public}@ (transport=%{public}@, bytes=%{public}lld): exit=%d%{public}@",
+                        fileURL.lastPathComponent,
+                        "http2-curl",
+                        self.fileSizeBytes(for: fileURL),
+                        result.terminationStatus,
+                        errorText.isEmpty ? "" : " stderr=\(errorText)"
+                    )
+                    throw TranscriptionError.submissionFailed(
+                        "curl transport failed with exit \(result.terminationStatus): \(errorText)"
+                    )
+                }
+
+                return try self.parseTranscript(from: outputData)
+            } onCancel: {
+                if process.isRunning {
+                    process.terminate()
+                }
             }
-
-            return try self.parseTranscript(from: outputData)
         }.value
     }
 


### PR DESCRIPTION
## Summary
- Add an optional `curl --http2` transport for API requests used by context collection, post-processing, and transcription flows.
- Thread the existing `forceHTTP2Transcription` setting through `AppState`, `AppContextService`, and `PostProcessingService` so the same toggle governs all API calls.
- Introduce a shared HTTP/2 curl helper that writes request/response bodies through temp files and reports transport or status-code failures.
- Update settings text to reflect that the toggle now affects all API requests, not just transcription uploads.

## Testing
- Not run.
- Verify context generation still succeeds with the default URLSession transport enabled.
- Verify transcription, context inference, and post-processing requests succeed when `Force HTTP/2 for API Requests` is enabled.
- Verify non-200 responses still surface as failures with the returned status code and body text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended HTTP/2 support to context inference and post-processing operations, in addition to transcription uploads.

* **Improvements**
  * Added configurable request timeout (20 seconds) for API calls.
  * Updated settings UI to clarify that "Force HTTP/2 for API Requests" now applies across multiple service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->