### PR TITLE
Unify LLM API transport and remove HTTP/2 fallback

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -36,6 +36,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     private let maxScreenshotDataURILength = 500_000
     private let screenshotCompressionPrimary = 0.5
     private let screenshotMaxDimension: CGFloat = 1024
+    private let contextRequestTimeoutSeconds: TimeInterval = 20
 
     init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1", customContextPrompt: String = "") {
         self.apiKey = apiKey
@@ -155,6 +156,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         do {
             var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
             request.httpMethod = "POST"
+            request.timeoutInterval = contextRequestTimeoutSeconds
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -205,7 +207,7 @@ Selected text: \(selectedText ?? "None")
             ]
 
             request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await LLMAPITransport.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
                 return nil
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -126,7 +126,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let customContextPromptLastModifiedStorageKey = "custom_context_prompt_last_modified"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
-    private let forceHTTP2TranscriptionStorageKey = "force_http2_transcription"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
     private let voiceMacrosStorageKey = "voice_macros"
@@ -223,12 +222,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    @Published var forceHTTP2Transcription: Bool {
-        didSet {
-            UserDefaults.standard.set(forceHTTP2Transcription, forKey: forceHTTP2TranscriptionStorageKey)
-        }
-    }
-
     @Published var alertSoundsEnabled: Bool {
         didSet {
             UserDefaults.standard.set(alertSoundsEnabled, forKey: alertSoundsEnabledStorageKey)
@@ -303,6 +296,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var isCapturingShortcut = false
 
     init() {
+        UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
         let hasCompletedSetup = UserDefaults.standard.bool(forKey: "hasCompletedSetup")
         let apiKey = Self.loadStoredAPIKey(account: apiKeyStorageKey)
         let apiBaseURL = Self.loadStoredAPIBaseURL(account: "api_base_url")
@@ -323,7 +317,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
-        let forceHTTP2Transcription = UserDefaults.standard.bool(forKey: forceHTTP2TranscriptionStorageKey)
         let soundVolume: Float = UserDefaults.standard.object(forKey: soundVolumeStorageKey) != nil
             ? UserDefaults.standard.float(forKey: soundVolumeStorageKey) : 1.0
         let alertSoundsEnabled = UserDefaults.standard.object(forKey: alertSoundsEnabledStorageKey) != nil
@@ -368,7 +361,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.customContextPromptLastModified = customContextPromptLastModified
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
-        self.forceHTTP2Transcription = forceHTTP2Transcription
         self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
@@ -572,8 +564,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let transcriptionService = TranscriptionService(
             apiKey: apiKey,
-            baseURL: apiBaseURL,
-            forceHTTP2: forceHTTP2Transcription
+            baseURL: apiBaseURL
         )
         let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
         let capturedCustomVocabulary = customVocabulary
@@ -1203,8 +1194,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let transcriptionService = TranscriptionService(
             apiKey: apiKey,
-            baseURL: apiBaseURL,
-            forceHTTP2: forceHTTP2Transcription
+            baseURL: apiBaseURL
         )
         let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
 

--- a/Sources/LLMAPITransport.swift
+++ b/Sources/LLMAPITransport.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum LLMAPITransport {
+    static let defaultMaxAttempts = 2
+
+    private static let transientRetryableErrorCodes: Set<URLError.Code> = [
+        .networkConnectionLost,
+        .timedOut,
+        .cannotConnectToHost,
+        .notConnectedToInternet
+    ]
+
+    private static let requestSession: URLSession = {
+        makeEphemeralSession()
+    }()
+
+    private static func makeEphemeralSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.timeoutIntervalForRequest = 20
+        configuration.timeoutIntervalForResource = 30
+        return URLSession(configuration: configuration)
+    }
+
+    static func data(
+        for request: URLRequest,
+        maxAttempts: Int = defaultMaxAttempts
+    ) async throws -> (Data, URLResponse) {
+        try await perform(maxAttempts: maxAttempts) {
+            try await requestSession.data(for: request)
+        }
+    }
+
+    static func upload(
+        for request: URLRequest,
+        from bodyData: Data,
+        maxAttempts: Int = defaultMaxAttempts
+    ) async throws -> (Data, URLResponse) {
+        try await perform(maxAttempts: maxAttempts) {
+            // Use a fresh session for each upload attempt so a bad reused connection
+            // cannot poison subsequent transcription uploads.
+            let session = makeEphemeralSession()
+            defer { session.finishTasksAndInvalidate() }
+            return try await session.upload(for: request, from: bodyData)
+        }
+    }
+
+    private static func perform<T>(
+        maxAttempts: Int,
+        operation: () async throws -> T
+    ) async throws -> T {
+        precondition(maxAttempts > 0, "maxAttempts must be positive")
+
+        var lastError: Error?
+        for attempt in 1...maxAttempts {
+            do {
+                return try await operation()
+            } catch {
+                lastError = error
+                guard shouldRetry(error: error, attempt: attempt, maxAttempts: maxAttempts) else {
+                    throw error
+                }
+                try await Task.sleep(nanoseconds: retryDelayNanoseconds(forAttempt: attempt))
+            }
+        }
+
+        throw lastError ?? URLError(.unknown)
+    }
+
+    private static func shouldRetry(error: Error, attempt: Int, maxAttempts: Int) -> Bool {
+        guard attempt < maxAttempts else { return false }
+        guard !(error is CancellationError) else { return false }
+        guard let urlError = error as? URLError else { return false }
+        return transientRetryableErrorCodes.contains(urlError.code)
+    }
+
+    private static func retryDelayNanoseconds(forAttempt attempt: Int) -> UInt64 {
+        let delaySeconds = min(pow(2.0, Double(attempt - 1)), 2.0)
+        return UInt64(delaySeconds * 1_000_000_000)
+    }
+}

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -249,7 +249,7 @@ Model: \(model)
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await LLMAPITransport.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PostProcessingError.invalidResponse("No HTTP response")
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -464,24 +464,6 @@ struct GeneralSettingsView: View {
                 }
                 .font(.caption)
             }
-
-            Divider()
-
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Force HTTP/2 for Transcription")
-                        .font(.caption.weight(.semibold))
-                    Text("Uses `curl --http2` for audio transcription uploads. Leave this off unless the default transport is failing.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 0)
-
-                Toggle("", isOn: $appState.forceHTTP2Transcription)
-                    .toggleStyle(.checkbox)
-                    .labelsHidden()
-            }
         }
     }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1005,8 +1005,7 @@ struct SetupView: View {
                     do {
                         let service = TranscriptionService(
                             apiKey: appState.apiKey,
-                            baseURL: appState.apiBaseURL,
-                            forceHTTP2: appState.forceHTTP2Transcription
+                            baseURL: appState.apiBaseURL
                         )
                         let transcript = try await service.transcribe(fileURL: url)
                         await MainActor.run {

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -7,17 +7,15 @@ private let transcriptionLog = OSLog(subsystem: "com.zachlatta.freeflow", catego
 class TranscriptionService {
     private let apiKey: String
     private let baseURL: String
-    private let forceHTTP2: Bool
     private let transcriptionModel = "whisper-large-v3"
     private let transcriptionResponseFormat = "verbose_json"
     private let transcriptionTimeoutSeconds: TimeInterval = 20
     private let uploadSampleRate = 16_000.0
     private let uploadChannelCount: AVAudioChannelCount = 1
 
-    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1", forceHTTP2: Bool = false) {
+    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1") {
         self.apiKey = apiKey
         self.baseURL = baseURL
-        self.forceHTTP2 = forceHTTP2
     }
 
     // Validate API key by hitting a lightweight endpoint
@@ -26,10 +24,11 @@ class TranscriptionService {
         guard !trimmed.isEmpty else { return false }
 
         var request = URLRequest(url: URL(string: "\(baseURL)/models")!)
+        request.timeoutInterval = 10
         request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await LLMAPITransport.data(for: request)
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
             return status == 200
         } catch {
@@ -39,24 +38,14 @@ class TranscriptionService {
 
     // Upload audio file, submit for transcription, poll until done, return text
     func transcribe(fileURL: URL) async throws -> String {
-        return try await withThrowingTaskGroup(of: String.self) { group in
-            group.addTask { [weak self] in
-                guard let self else {
-                    throw TranscriptionError.submissionFailed("Service deallocated")
-                }
-                return try await self.transcribeAudio(fileURL: fileURL)
-            }
+        guard !Task.isCancelled else {
+            throw CancellationError()
+        }
 
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(self.transcriptionTimeoutSeconds * 1_000_000_000))
-                throw TranscriptionError.transcriptionTimedOut(self.transcriptionTimeoutSeconds)
-            }
-
-            guard let result = try await group.next() else {
-                throw TranscriptionError.submissionFailed("No transcription result")
-            }
-            group.cancelAll()
-            return result
+        do {
+            return try await transcribeAudio(fileURL: fileURL)
+        } catch let urlError as URLError where urlError.code == .timedOut {
+            throw TranscriptionError.transcriptionTimedOut(transcriptionTimeoutSeconds)
         }
     }
 
@@ -65,9 +54,6 @@ class TranscriptionService {
         let preparedAudio = try prepareAudioForUpload(from: fileURL)
         defer { preparedAudio.cleanup() }
 
-        if forceHTTP2 {
-            return try await transcribeAudioWithCurl(fileURL: preparedAudio.fileURL)
-        }
         return try await transcribeAudioWithURLSession(fileURL: preparedAudio.fileURL)
     }
 
@@ -75,6 +61,7 @@ class TranscriptionService {
         let url = URL(string: "\(baseURL)/audio/transcriptions")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        request.timeoutInterval = transcriptionTimeoutSeconds
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         let boundary = UUID().uuidString
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
@@ -88,18 +75,17 @@ class TranscriptionService {
             boundary: boundary
         )
 
-        let data: Data
-        let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.upload(for: request, from: body)
+            let (data, response) = try await LLMAPITransport.upload(for: request, from: body)
+            return try validateTranscriptionResponse(data: data, response: response, fileURL: fileURL)
         } catch {
             let nsError = error as NSError
             os_log(
                 .error,
                 log: transcriptionLog,
-                "URLSession upload failed for %{public}@ (transport=%{public}@, bytes=%{public}lld): domain=%{public}@ code=%ld desc=%{public}@",
+                "URLSession upload failed for %{public}@ after %ld attempt(s) (bytes=%{public}lld): domain=%{public}@ code=%ld desc=%{public}@",
                 fileURL.lastPathComponent,
-                "urlsession-default",
+                LLMAPITransport.defaultMaxAttempts,
                 fileSizeBytes(for: fileURL),
                 nsError.domain,
                 nsError.code,
@@ -107,7 +93,9 @@ class TranscriptionService {
             )
             throw error
         }
+    }
 
+    private func validateTranscriptionResponse(data: Data, response: URLResponse, fileURL: URL) throws -> String {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw TranscriptionError.submissionFailed("No response from server")
         }
@@ -117,10 +105,9 @@ class TranscriptionService {
             os_log(
                 .error,
                 log: transcriptionLog,
-                "URLSession upload returned HTTP %ld for %{public}@ (transport=%{public}@, bytes=%{public}lld)",
+                "URLSession upload returned HTTP %ld for %{public}@ (bytes=%{public}lld)",
                 httpResponse.statusCode,
                 fileURL.lastPathComponent,
-                "urlsession-default",
                 fileSizeBytes(for: fileURL)
             )
             throw TranscriptionError.submissionFailed("Status \(httpResponse.statusCode): \(responseBody)")
@@ -128,57 +115,6 @@ class TranscriptionService {
 
         return try parseTranscript(from: data)
     }
-
-    private func transcribeAudioWithCurl(fileURL: URL) async throws -> String {
-        try await Task.detached(priority: .userInitiated) { [apiKey, transcriptionModel, transcriptionResponseFormat] in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
-            process.arguments = [
-                "--silent",
-                "--show-error",
-                "--fail",
-                "--http2",
-                "--max-time", String(Int(self.transcriptionTimeoutSeconds)),
-                "\(self.baseURL)/audio/transcriptions",
-                "-H", "Authorization: Bearer \(apiKey)",
-                "-F", "model=\(transcriptionModel)",
-                "-F", "response_format=\(transcriptionResponseFormat)",
-                "-F", "file=@\(fileURL.path);type=\(self.audioContentType(for: fileURL.lastPathComponent))"
-            ]
-
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
-
-            try process.run()
-            process.waitUntilExit()
-
-            let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
-            let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
-            let errorText = String(data: errorData, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            guard process.terminationStatus == 0 else {
-                os_log(
-                    .error,
-                    log: transcriptionLog,
-                    "curl upload failed for %{public}@ (transport=%{public}@, bytes=%{public}lld): exit=%d%{public}@",
-                    fileURL.lastPathComponent,
-                    "http2-curl",
-                    self.fileSizeBytes(for: fileURL),
-                    process.terminationStatus,
-                    errorText.isEmpty ? "" : " stderr=\(errorText)"
-                )
-                throw TranscriptionError.submissionFailed(
-                    "curl transport failed with exit \(process.terminationStatus): \(errorText)"
-                )
-            }
-
-            return try self.parseTranscript(from: outputData)
-        }.value
-    }
-
     private func audioContentType(for fileName: String) -> String {
         if fileName.lowercased().hasSuffix(".wav") {
             return "audio/wav"


### PR DESCRIPTION
## Summary
- Centralized LLM requests behind a shared `LLMAPITransport` with ephemeral sessions, retry handling, and consistent timeout behavior.
- Removed the transcription-specific `forceHTTP2` setting and the `curl --http2` fallback path.
- Updated transcription, post-processing, and context-generation calls to use the new transport.
- Cleaned up setup and settings UI to remove the deprecated HTTP/2 option.

## Testing
- Not run
- Verified the diff removes all references to `forceHTTP2Transcription` and the HTTP/2 settings toggle.
- Verified transcription and non-transcription LLM requests now route through `LLMAPITransport`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced network reliability with automatic retry logic and exponential backoff for transient network errors.

* **Bug Fixes**
  * Improved timeout handling across API requests and transcription operations.

* **UI Changes**
  * Removed the "Force HTTP/2 for Transcription" setting from Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->