### PR TITLE
Replace AVAudioEngine Recorder With Sample-Buffer Writer

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -987,10 +987,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         statusText = "Starting..."
         hasShownScreenshotPermissionAlert = false
 
-        // Show initializing dots only if engine takes longer than 0.5s to start
+        // Show initializing dots only if engine takes longer than 0.2s to start
         var overlayShown = false
         let initTimer = DispatchSource.makeTimerSource(queue: .main)
-        initTimer.schedule(deadline: .now() + 0.5)
+        initTimer.schedule(deadline: .now() + 0.2)
         initTimer.setEventHandler { [weak self] in
             guard let self, !overlayShown else { return }
             overlayShown = true

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2,7 +2,6 @@ import Foundation
 import Combine
 import AppKit
 import AVFoundation
-import CoreAudio
 import ServiceManagement
 import ApplicationServices
 import ScreenCaptureKit
@@ -286,7 +285,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var contextCaptureTask: Task<AppContext?, Never>?
     private var capturedContext: AppContext?
     private var hasShownScreenshotPermissionAlert = false
-    private var audioDeviceListenerBlock: AudioObjectPropertyListenerBlock?
+    private var audioDeviceObservers: [NSObjectProtocol] = []
+    private var needsMicrophoneRefreshAfterRecording = false
     private let pipelineHistoryStore = PipelineHistoryStore()
     private let shortcutSessionController = DictationShortcutSessionController()
     private var activeRecordingTriggerMode: RecordingTriggerMode?
@@ -372,7 +372,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.precomputeMacros()
 
         refreshAvailableMicrophones()
-        installAudioDeviceListener()
+        installAudioDeviceObservers()
 
         if shortcuts.didMigrateLegacyValue {
             persistShortcut(shortcuts.hold, key: holdShortcutStorageKey)
@@ -389,23 +389,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     deinit {
-        removeAudioDeviceListener()
+        removeAudioDeviceObservers()
     }
 
-    private func removeAudioDeviceListener() {
-        guard let block = audioDeviceListenerBlock else { return }
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        AudioObjectRemovePropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            DispatchQueue.main,
-            block
-        )
-        audioDeviceListenerBlock = nil
+    private func removeAudioDeviceObservers() {
+        let notificationCenter = NotificationCenter.default
+        for observer in audioDeviceObservers {
+            notificationCenter.removeObserver(observer)
+        }
+        audioDeviceObservers.removeAll()
     }
 
     private static func loadStoredAPIKey(account: String) -> String {
@@ -714,26 +706,47 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func refreshAvailableMicrophones() {
+        guard !isRecording, !audioRecorder.isRecording else {
+            needsMicrophoneRefreshAfterRecording = true
+            return
+        }
+
+        needsMicrophoneRefreshAfterRecording = false
         availableMicrophones = AudioDevice.availableInputDevices()
     }
 
-    private func installAudioDeviceListener() {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            DispatchQueue.main.async {
-                self?.refreshAvailableMicrophones()
+    private func refreshAvailableMicrophonesIfNeeded() {
+        guard needsMicrophoneRefreshAfterRecording else { return }
+        refreshAvailableMicrophones()
+    }
+
+    private func installAudioDeviceObservers() {
+        removeAudioDeviceObservers()
+
+        let notificationCenter = NotificationCenter.default
+        let refreshOnAudioDeviceChange: (Notification) -> Void = { [weak self] notification in
+            guard let device = notification.object as? AVCaptureDevice,
+                  device.hasMediaType(.audio) else {
+                return
             }
+            self?.refreshAvailableMicrophones()
         }
-        audioDeviceListenerBlock = block
-        AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            DispatchQueue.main,
-            block
+
+        audioDeviceObservers.append(
+            notificationCenter.addObserver(
+                forName: .AVCaptureDeviceWasConnected,
+                object: nil,
+                queue: .main,
+                using: refreshOnAudioDeviceChange
+            )
+        )
+        audioDeviceObservers.append(
+            notificationCenter.addObserver(
+                forName: .AVCaptureDeviceWasDisconnected,
+                object: nil,
+                queue: .main,
+                using: refreshOnAudioDeviceChange
+            )
         )
     }
 
@@ -1003,6 +1016,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.playAlertSound(named: "Tink")
             }
         }
+        audioRecorder.onRecordingFailure = { [weak self] error in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                initTimer.cancel()
+                self.handleRecordingFailure(error)
+            }
+        }
 
         // Start engine on background thread so UI isn't blocked
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -1022,15 +1042,29 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } catch {
                 DispatchQueue.main.async {
                     initTimer.cancel()
-                    self.isRecording = false
-                    self.activeRecordingTriggerMode = nil
-                    self.shortcutSessionController.reset()
-                    self.errorMessage = self.formattedRecordingStartError(error)
-                    self.statusText = "Error"
-                    self.overlayManager.dismiss()
+                    self.handleRecordingFailure(error)
                 }
             }
         }
+    }
+
+    private func handleRecordingFailure(_ error: Error) {
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
+        audioLevelCancellable?.cancel()
+        audioLevelCancellable = nil
+        contextCaptureTask?.cancel()
+        contextCaptureTask = nil
+        capturedContext = nil
+        audioRecorder.cleanup()
+        isRecording = false
+        isTranscribing = false
+        activeRecordingTriggerMode = nil
+        shortcutSessionController.reset()
+        errorMessage = formattedRecordingStartError(error)
+        statusText = "Error"
+        overlayManager.dismiss()
+        refreshAvailableMicrophonesIfNeeded()
     }
 
     private func formattedRecordingStartError(_ error: Error) -> String {
@@ -1146,6 +1180,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         cancelPendingShortcutStart()
         shortcutSessionController.reset()
         activeRecordingTriggerMode = nil
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
         debugStatusMessage = "Preparing audio"
@@ -1160,37 +1196,41 @@ final class AppState: ObservableObject, @unchecked Sendable {
         lastPostProcessingPrompt = ""
         lastContextScreenshotDataURL = nil
         lastContextScreenshotStatus = "No screenshot"
-
-        guard let fileURL = audioRecorder.stopRecording() else {
-            audioRecorder.cleanup()
-            errorMessage = "No audio recorded"
-            isRecording = false
-            statusText = "Error"
-            overlayManager.dismiss()
-            return
-        }
-        let savedAudioFile = Self.saveAudioFile(from: fileURL)
-        let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
         isRecording = false
         isTranscribing = true
-        statusText = "Transcribing..."
-        debugStatusMessage = "Transcribing audio"
+        statusText = "Preparing audio..."
         errorMessage = nil
         playAlertSound(named: "Pop")
         overlayManager.slideUpToNotch { }
+        audioRecorder.stopRecording { [weak self] fileURL in
+            guard let self else { return }
+            guard let fileURL else {
+                self.isTranscribing = false
+                self.audioRecorder.cleanup()
+                self.errorMessage = "No audio recorded"
+                self.statusText = "Error"
+                self.overlayManager.dismiss()
+                self.refreshAvailableMicrophonesIfNeeded()
+                return
+            }
 
-        transcribingIndicatorTask?.cancel()
-        let indicatorDelay = transcribingIndicatorDelay
-        transcribingIndicatorTask = Task { [weak self] in
-            do {
-                try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
-                let shouldShowTranscribing = self?.isTranscribing ?? false
-                guard shouldShowTranscribing else { return }
-                await MainActor.run { [weak self] in
-                    self?.overlayManager.showTranscribing()
-                }
-            } catch {}
-        }
+            let savedAudioFile = Self.saveAudioFile(from: fileURL)
+            let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
+            self.statusText = "Transcribing..."
+            self.debugStatusMessage = "Transcribing audio"
+
+            self.transcribingIndicatorTask?.cancel()
+            let indicatorDelay = self.transcribingIndicatorDelay
+            self.transcribingIndicatorTask = Task { [weak self] in
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
+                    let shouldShowTranscribing = self?.isTranscribing ?? false
+                    guard shouldShowTranscribing else { return }
+                    await MainActor.run { [weak self] in
+                        self?.overlayManager.showTranscribing()
+                    }
+                } catch {}
+            }
 
         let transcriptionService = TranscriptionService(
             apiKey: apiKey,
@@ -1198,112 +1238,115 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
 
-        Task {
-            do {
-                async let transcript = transcriptionService.transcribe(fileURL: transcriptionFileURL)
-                let rawTranscript = try await transcript
-                let appContext: AppContext
-                if let sessionContext {
-                    appContext = sessionContext
-                } else if let inFlightContext = await inFlightContextTask?.value {
-                    appContext = inFlightContext
-                } else {
-                    appContext = fallbackContextAtStop()
-                }
-                await MainActor.run { [weak self] in
-                    self?.debugStatusMessage = "Running post-processing"
-                }
-                let (finalTranscript, processingStatus, postProcessingPrompt) = await processTranscript(
-                    rawTranscript,
-                    context: appContext,
-                    postProcessingService: postProcessingService,
-                    customVocabulary: customVocabulary,
-                    customSystemPrompt: customSystemPrompt
-                )
-
-                await MainActor.run {
-                    self.lastContextSummary = appContext.contextSummary
-                    self.lastContextScreenshotDataURL = appContext.screenshotDataURL
-                    self.lastContextScreenshotStatus = appContext.screenshotError
-                        ?? "available (\(appContext.screenshotMimeType ?? "image"))"
-                    let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let trimmedFinalTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                    self.lastPostProcessingPrompt = postProcessingPrompt
-                    self.lastRawTranscript = trimmedRawTranscript
-                    self.lastPostProcessedTranscript = trimmedFinalTranscript
-                    self.lastPostProcessingStatus = processingStatus
-                    self.recordPipelineHistoryEntry(
-                        rawTranscript: trimmedRawTranscript,
-                        postProcessedTranscript: trimmedFinalTranscript,
-                        postProcessingPrompt: postProcessingPrompt,
-                        context: appContext,
-                        processingStatus: processingStatus,
-                        audioFileName: savedAudioFile?.fileName
-                    )
-                    self.transcribingIndicatorTask?.cancel()
-                    self.transcribingIndicatorTask = nil
-                    self.lastTranscript = trimmedFinalTranscript
-                    self.isTranscribing = false
-                    self.debugStatusMessage = "Done"
-                    let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
-
-                    if trimmedFinalTranscript.isEmpty {
-                        self.statusText = "Nothing to transcribe"
-                        self.overlayManager.dismiss()
+            Task {
+                do {
+                    async let transcript = transcriptionService.transcribe(fileURL: transcriptionFileURL)
+                    let rawTranscript = try await transcript
+                    let appContext: AppContext
+                    if let sessionContext {
+                        appContext = sessionContext
+                    } else if let inFlightContext = await inFlightContextTask?.value {
+                        appContext = inFlightContext
                     } else {
-                        self.statusText = completionStatusText
-                        self.overlayManager.showDone()
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                            self.overlayManager.dismiss()
-                        }
-
-                        let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
-                        self.pasteAtCursorWhenShortcutReleased {
-                            self.restoreClipboardIfNeeded(pendingClipboardRestore)
-                        }
+                        appContext = self.fallbackContextAtStop()
                     }
-
-                    self.audioRecorder.cleanup()
-
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        if self.statusText == completionStatusText || self.statusText == "Nothing to transcribe" {
-                            self.statusText = "Ready"
-                        }
+                    await MainActor.run { [weak self] in
+                        self?.debugStatusMessage = "Running post-processing"
                     }
-                }
-            } catch {
-                let resolvedContext: AppContext
-                if let sessionContext {
-                    resolvedContext = sessionContext
-                } else if let inFlightContext = await inFlightContextTask?.value {
-                    resolvedContext = inFlightContext
-                } else {
-                    resolvedContext = fallbackContextAtStop()
-                }
-                await MainActor.run {
-                    self.transcribingIndicatorTask?.cancel()
-                    self.transcribingIndicatorTask = nil
-                    self.errorMessage = error.localizedDescription
-                    self.isTranscribing = false
-                    self.statusText = "Error"
-                    self.audioRecorder.cleanup()
-                    self.overlayManager.dismiss()
-                    self.lastPostProcessedTranscript = ""
-                    self.lastRawTranscript = ""
-                    self.lastContextSummary = ""
-                    self.lastPostProcessingStatus = "Error: \(error.localizedDescription)"
-                    self.lastPostProcessingPrompt = ""
-                    self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
-                    self.lastContextScreenshotStatus = resolvedContext.screenshotError
-                        ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
-                    self.recordPipelineHistoryEntry(
-                        rawTranscript: "",
-                        postProcessedTranscript: "",
-                        postProcessingPrompt: "",
-                        context: resolvedContext,
-                        processingStatus: "Error: \(error.localizedDescription)",
-                        audioFileName: savedAudioFile?.fileName
+                    let (finalTranscript, processingStatus, postProcessingPrompt) = await self.processTranscript(
+                        rawTranscript,
+                        context: appContext,
+                        postProcessingService: postProcessingService,
+                        customVocabulary: self.customVocabulary,
+                        customSystemPrompt: self.customSystemPrompt
                     )
+
+                    await MainActor.run {
+                        self.lastContextSummary = appContext.contextSummary
+                        self.lastContextScreenshotDataURL = appContext.screenshotDataURL
+                        self.lastContextScreenshotStatus = appContext.screenshotError
+                            ?? "available (\(appContext.screenshotMimeType ?? "image"))"
+                        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let trimmedFinalTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        self.lastPostProcessingPrompt = postProcessingPrompt
+                        self.lastRawTranscript = trimmedRawTranscript
+                        self.lastPostProcessedTranscript = trimmedFinalTranscript
+                        self.lastPostProcessingStatus = processingStatus
+                        self.recordPipelineHistoryEntry(
+                            rawTranscript: trimmedRawTranscript,
+                            postProcessedTranscript: trimmedFinalTranscript,
+                            postProcessingPrompt: postProcessingPrompt,
+                            context: appContext,
+                            processingStatus: processingStatus,
+                            audioFileName: savedAudioFile?.fileName
+                        )
+                        self.transcribingIndicatorTask?.cancel()
+                        self.transcribingIndicatorTask = nil
+                        self.lastTranscript = trimmedFinalTranscript
+                        self.isTranscribing = false
+                        self.debugStatusMessage = "Done"
+                        let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
+
+                        if trimmedFinalTranscript.isEmpty {
+                            self.statusText = "Nothing to transcribe"
+                            self.overlayManager.dismiss()
+                        } else {
+                            self.statusText = completionStatusText
+                            self.overlayManager.showDone()
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                                self.overlayManager.dismiss()
+                            }
+
+                            let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
+                            self.pasteAtCursorWhenShortcutReleased {
+                                self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                            }
+                        }
+
+                        self.audioRecorder.cleanup()
+                        self.refreshAvailableMicrophonesIfNeeded()
+
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            if self.statusText == completionStatusText || self.statusText == "Nothing to transcribe" {
+                                self.statusText = "Ready"
+                            }
+                        }
+                    }
+                } catch {
+                    let resolvedContext: AppContext
+                    if let sessionContext {
+                        resolvedContext = sessionContext
+                    } else if let inFlightContext = await inFlightContextTask?.value {
+                        resolvedContext = inFlightContext
+                    } else {
+                        resolvedContext = self.fallbackContextAtStop()
+                    }
+                    await MainActor.run {
+                        self.transcribingIndicatorTask?.cancel()
+                        self.transcribingIndicatorTask = nil
+                        self.errorMessage = error.localizedDescription
+                        self.isTranscribing = false
+                        self.statusText = "Error"
+                        self.overlayManager.dismiss()
+                        self.lastPostProcessedTranscript = ""
+                        self.lastRawTranscript = ""
+                        self.lastContextSummary = ""
+                        self.lastPostProcessingStatus = "Error: \(error.localizedDescription)"
+                        self.lastPostProcessingPrompt = ""
+                        self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
+                        self.lastContextScreenshotStatus = resolvedContext.screenshotError
+                            ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
+                        self.recordPipelineHistoryEntry(
+                            rawTranscript: "",
+                            postProcessedTranscript: "",
+                            postProcessingPrompt: "",
+                            context: resolvedContext,
+                            processingStatus: "Error: \(error.localizedDescription)",
+                            audioFileName: savedAudioFile?.fileName
+                        )
+                        self.audioRecorder.cleanup()
+                        self.refreshAvailableMicrophonesIfNeeded()
+                    }
                 }
             }
         }
@@ -1438,8 +1481,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             hasShownScreenshotPermissionAlert = true
 
             // Permission errors are fatal — stop recording
-            _ = audioRecorder.stopRecording()
-            audioRecorder.cleanup()
+            audioRecorder.cancelRecording()
             audioLevelCancellable?.cancel()
             audioLevelCancellable = nil
             contextCaptureTask?.cancel()

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -1,114 +1,54 @@
 import AVFoundation
-import CoreAudio
+import CoreMedia
 import Foundation
 import os.log
 
 private let recordingLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Recording")
 
 struct AudioDevice: Identifiable {
-    let id: AudioDeviceID
+    let id: String
     let uid: String
     let name: String
 
-    static func availableInputDevices() -> [AudioDevice] {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        var dataSize: UInt32 = 0
-        var status = AudioObjectGetPropertyDataSize(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            0, nil,
-            &dataSize
-        )
-        guard status == noErr, dataSize > 0 else { return [] }
-
-        let deviceCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
-        var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
-        status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            0, nil,
-            &dataSize,
-            &deviceIDs
-        )
-        guard status == noErr else { return [] }
-
-        var devices: [AudioDevice] = []
-        for deviceID in deviceIDs {
-            // Check if device has input streams
-            var inputStreamAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioDevicePropertyStreamConfiguration,
-                mScope: kAudioDevicePropertyScopeInput,
-                mElement: kAudioObjectPropertyElementMain
-            )
-            var streamSize: UInt32 = 0
-            guard AudioObjectGetPropertyDataSize(deviceID, &inputStreamAddress, 0, nil, &streamSize) == noErr,
-                  streamSize > 0 else { continue }
-
-            let bufferListRaw = UnsafeMutableRawPointer.allocate(
-                byteCount: Int(streamSize),
-                alignment: MemoryLayout<AudioBufferList>.alignment
-            )
-            defer { bufferListRaw.deallocate() }
-            let bufferListPointer = bufferListRaw.bindMemory(to: AudioBufferList.self, capacity: 1)
-            guard AudioObjectGetPropertyData(deviceID, &inputStreamAddress, 0, nil, &streamSize, bufferListPointer) == noErr else { continue }
-
-            let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPointer)
-            let inputChannels = bufferList.reduce(0) { $0 + Int($1.mNumberChannels) }
-            guard inputChannels > 0 else { continue }
-
-            // Get device UID
-            var uidAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioDevicePropertyDeviceUID,
-                mScope: kAudioObjectPropertyScopeGlobal,
-                mElement: kAudioObjectPropertyElementMain
-            )
-            var uidSize = UInt32(MemoryLayout<CFString?>.size)
-            let uidRaw = UnsafeMutableRawPointer.allocate(
-                byteCount: Int(uidSize),
-                alignment: MemoryLayout<CFString?>.alignment
-            )
-            defer { uidRaw.deallocate() }
-            guard AudioObjectGetPropertyData(deviceID, &uidAddress, 0, nil, &uidSize, uidRaw) == noErr else { continue }
-            guard let uidRef = uidRaw.load(as: CFString?.self) else { continue }
-            let uid = uidRef as String
-            guard !uid.isEmpty else { continue }
-
-            // Get device name
-            var nameAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioObjectPropertyName,
-                mScope: kAudioObjectPropertyScopeGlobal,
-                mElement: kAudioObjectPropertyElementMain
-            )
-            var nameSize = UInt32(MemoryLayout<CFString?>.size)
-            let nameRaw = UnsafeMutableRawPointer.allocate(
-                byteCount: Int(nameSize),
-                alignment: MemoryLayout<CFString?>.alignment
-            )
-            defer { nameRaw.deallocate() }
-            guard AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, nameRaw) == noErr else { continue }
-            guard let nameRef = nameRaw.load(as: CFString?.self) else { continue }
-            let name = nameRef as String
-            guard !name.isEmpty else { continue }
-
-            devices.append(AudioDevice(id: deviceID, uid: uid, name: name))
+    fileprivate static func captureDevices() -> [AVCaptureDevice] {
+        let deviceTypes: [AVCaptureDevice.DeviceType]
+        if #available(macOS 14.0, *) {
+            deviceTypes = [.microphone, .external]
+        } else {
+            deviceTypes = [.builtInMicrophone, .externalUnknown]
         }
-        return devices
+
+        return AVCaptureDevice.DiscoverySession(
+            deviceTypes: deviceTypes,
+            mediaType: .audio,
+            position: .unspecified
+        ).devices
     }
 
-    static func deviceID(forUID uid: String) -> AudioDeviceID? {
-        // Look up through the enumerated devices to avoid CFString pointer issues
-        return availableInputDevices().first(where: { $0.uid == uid })?.id
+    static func availableInputDevices() -> [AudioDevice] {
+        var seenUIDs = Set<String>()
+        return captureDevices()
+            .compactMap { device in
+                let uid = device.uniqueID.trimmingCharacters(in: .whitespacesAndNewlines)
+                let name = device.localizedName.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !uid.isEmpty, !name.isEmpty, seenUIDs.insert(uid).inserted else {
+                    return nil
+                }
+                return AudioDevice(id: uid, uid: uid, name: name)
+            }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
     }
 }
 
 enum AudioRecorderError: LocalizedError {
     case invalidInputFormat(String)
     case missingInputDevice
+    case noAudioBuffersReceived
+    case failedToCreateCaptureInput(String)
+    case failedToStartCaptureSession(String)
+    case failedToBeginFileRecording(String)
 
     var errorDescription: String? {
         switch self {
@@ -116,220 +56,196 @@ enum AudioRecorderError: LocalizedError {
             return "Invalid input format: \(details)"
         case .missingInputDevice:
             return "No audio input device available."
+        case .noAudioBuffersReceived:
+            return "No audio buffers were received from the selected microphone."
+        case .failedToCreateCaptureInput(let details):
+            return "Could not open the selected microphone: \(details)"
+        case .failedToStartCaptureSession(let details):
+            return "Could not start the capture session: \(details)"
+        case .failedToBeginFileRecording(let details):
+            return "Could not begin recording audio: \(details)"
         }
     }
 }
 
-class AudioRecorder: NSObject, ObservableObject {
-    private var audioEngine: AVAudioEngine?
-    private var audioFile: AVAudioFile?
+final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputSampleBufferDelegate {
+    private static let sessionQueueKey = DispatchSpecificKey<UInt8>()
+    private var captureSession: AVCaptureSession?
+    private var currentInput: AVCaptureDeviceInput?
+    private var audioDataOutput: AVCaptureAudioDataOutput?
+    private var sessionObservers: [NSObjectProtocol] = []
     private var tempFileURL: URL?
-    private let audioFileQueue = DispatchQueue(label: "com.zachlatta.freeflow.audiofile")
     private var recordingStartTime: CFAbsoluteTime = 0
-    private var firstBufferLogged = false
     private let _bufferCount = OSAllocatedUnfairLock(initialState: 0)
-    private var currentDeviceUID: String?
-    private var storedInputFormat: AVAudioFormat?
-
-    private var configChangeObserver: NSObjectProtocol?
     private var watchdogTimer: DispatchSourceTimer?
-    private var rebuildAttempt = 0
-    private static let maxRebuildAttempts = 2
-    private static let watchdogTimeout: TimeInterval = 2.0
+    private let sessionQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.session")
+    private let sampleBufferQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.samples")
+    private var activeAudioFile: AVAudioFile?
+    private var activeAudioFormat: AVAudioFormat?
+    private var recordedFrameCount: AVAudioFramePosition = 0
+    private var fileWriteError: Error?
+    private var isSessionInterrupted = false
 
     @Published var isRecording = false
-    /// Thread-safe flag read from the audio tap callback.
     private let _recording = OSAllocatedUnfairLock(initialState: false)
     @Published var audioLevel: Float = 0.0
     private var smoothedLevel: Float = 0.0
 
-    /// Called on the audio thread when the first non-silent buffer arrives.
     var onRecordingReady: (() -> Void)?
+    var onRecordingFailure: ((Error) -> Void)?
     private var readyFired = false
+    private var failureReported = false
+    private static let watchdogTimeout: TimeInterval = 2.0
+    private static let sampleRateLogLimit = 40
 
     override init() {
         super.init()
-        configChangeObserver = NotificationCenter.default.addObserver(
-            forName: .AVAudioEngineConfigurationChange,
-            object: nil,
-            queue: nil
-        ) { [weak self] notification in
-            self?.handleEngineConfigChange(notification)
-        }
+        sessionQueue.setSpecific(key: Self.sessionQueueKey, value: 1)
     }
 
     deinit {
-        if let observer = configChangeObserver {
+        let cleanup = {
+            self.cancelWatchdog()
+            self.teardownSessionLocked()
+        }
+
+        if DispatchQueue.getSpecific(key: Self.sessionQueueKey) != nil {
+            cleanup()
+        } else {
+            sessionQueue.sync(execute: cleanup)
+        }
+    }
+
+    private static func captureDevice(forUID uid: String) -> AVCaptureDevice? {
+        AudioDevice.captureDevices().first(where: { $0.uniqueID == uid })
+    }
+
+    private static func defaultCaptureDevice() -> AVCaptureDevice? {
+        AVCaptureDevice.default(for: .audio) ?? AudioDevice.captureDevices().first
+    }
+
+    private func preferredCaptureDevice(
+        for requestedDeviceUID: String?,
+        reason: String
+    ) -> AVCaptureDevice? {
+        guard let requestedDeviceUID, !requestedDeviceUID.isEmpty, requestedDeviceUID != "default" else {
+            let device = Self.defaultCaptureDevice()
+            if let device {
+                os_log(.info, log: recordingLog, "%{public}@ — using system default device: %{public}@", reason, device.localizedName)
+            }
+            return device
+        }
+
+        if let device = Self.captureDevice(forUID: requestedDeviceUID) {
+            os_log(.info, log: recordingLog, "%{public}@ — keeping selected device: %{public}@ [uid=%{public}@]", reason, device.localizedName, device.uniqueID)
+            return device
+        }
+
+        let fallbackDevice = Self.defaultCaptureDevice()
+        if let fallbackDevice {
+            os_log(.info, log: recordingLog, "%{public}@ — selected device unavailable, falling back to system default: %{public}@ [uid=%{public}@]", reason, fallbackDevice.localizedName, fallbackDevice.uniqueID)
+        }
+        return fallbackDevice
+    }
+
+    private func installSessionObservers(for session: AVCaptureSession) {
+        removeSessionObservers()
+
+        let runtimeObserver = NotificationCenter.default.addObserver(
+            forName: AVCaptureSession.runtimeErrorNotification,
+            object: session,
+            queue: nil
+        ) { [weak self] notification in
+            let error = notification.userInfo?[AVCaptureSessionErrorKey] as? NSError
+            let wrapped = error.map { AudioRecorderError.failedToStartCaptureSession($0.localizedDescription) }
+                ?? AudioRecorderError.failedToStartCaptureSession("Unknown runtime error")
+            self?.reportRecordingFailure(wrapped)
+        }
+        sessionObservers.append(runtimeObserver)
+
+        let interruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVCaptureSession.wasInterruptedNotification,
+            object: session,
+            queue: nil
+        ) { [weak self] notification in
+            self?.handleSessionInterrupted(notification)
+        }
+        sessionObservers.append(interruptionObserver)
+
+        let interruptionEndedObserver = NotificationCenter.default.addObserver(
+            forName: AVCaptureSession.interruptionEndedNotification,
+            object: session,
+            queue: nil
+        ) { [weak self] notification in
+            self?.handleSessionInterruptionEnded(notification)
+        }
+        sessionObservers.append(interruptionEndedObserver)
+    }
+
+    private func removeSessionObservers() {
+        for observer in sessionObservers {
             NotificationCenter.default.removeObserver(observer)
         }
-        cancelWatchdog()
+        sessionObservers.removeAll()
     }
 
-    // MARK: - Engine lifecycle
+    private func teardownSessionLocked() {
+        removeSessionObservers()
+        isSessionInterrupted = false
 
-    private func invalidateEngine() {
-        audioEngine?.inputNode.removeTap(onBus: 0)
-        audioEngine?.stop()
-        audioEngine = nil
-        storedInputFormat = nil
+        audioDataOutput?.setSampleBufferDelegate(nil, queue: nil)
+        if let session = captureSession, session.isRunning {
+            session.stopRunning()
+        }
+
+        captureSession = nil
+        currentInput = nil
+        audioDataOutput = nil
     }
 
-    private func buildAndStartEngine(deviceUID: String?) throws {
-        invalidateEngine()
+    private func reportRecordingFailure(_ error: Error, completion: ((URL?) -> Void)? = nil) {
+        sessionQueue.async {
+            guard !self.failureReported else { return }
+            self.failureReported = true
+            self.cancelWatchdog()
+            self._recording.withLock { $0 = false }
 
-        let t0 = CFAbsoluteTimeGetCurrent()
-        let engine = AVAudioEngine()
-        os_log(.info, log: recordingLog, "AVAudioEngine created: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        // Set specific input device if requested
-        if let uid = deviceUID, !uid.isEmpty, uid != "default",
-           let deviceID = AudioDevice.deviceID(forUID: uid) {
-            os_log(.info, log: recordingLog, "device lookup resolved to %d: %.3fms", deviceID, (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-            let inputUnit = engine.inputNode.audioUnit!
-            var id = deviceID
-            AudioUnitSetProperty(
-                inputUnit,
-                kAudioOutputUnitProperty_CurrentDevice,
-                kAudioUnitScope_Global,
-                0,
-                &id,
-                UInt32(MemoryLayout<AudioDeviceID>.size)
-            )
-        }
-
-        let inputNode = engine.inputNode
-        os_log(.info, log: recordingLog, "inputNode accessed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-        os_log(.info, log: recordingLog, "inputFormat retrieved (rate=%.0f, ch=%d): %.3fms", inputFormat.sampleRate, inputFormat.channelCount, (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        guard inputFormat.sampleRate > 0 else {
-            throw AudioRecorderError.invalidInputFormat("Invalid sample rate: \(inputFormat.sampleRate)")
-        }
-        guard inputFormat.channelCount > 0 else {
-            throw AudioRecorderError.invalidInputFormat("No input channels available")
-        }
-
-        storedInputFormat = inputFormat
-        _bufferCount.withLock { $0 = 0 }
-        readyFired = false
-
-        // Install tap — checks isRecording and audioFile dynamically
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            guard let self, self._recording.withLock({ $0 }) else { return }
-
-            let count = self._bufferCount.withLock { val -> Int in
-                val += 1
-                return val
+            let completion = completion
+            let discardURL = self.finishAudioFileLocked(discard: true)
+            self.teardownSessionLocked()
+            if let discardURL {
+                try? FileManager.default.removeItem(at: discardURL)
             }
 
-            // Check if this buffer has real audio
-            var rms: Float = 0
-            let frames = Int(buffer.frameLength)
-            if frames > 0, let channelData = buffer.floatChannelData {
-                let samples = channelData[0]
-                var sum: Float = 0
-                for i in 0..<frames { sum += samples[i] * samples[i] }
-                rms = sqrtf(sum / Float(frames))
+            DispatchQueue.main.async {
+                self.isRecording = false
+                self.audioLevel = 0.0
+                self.onRecordingFailure?(error)
+                completion?(nil)
             }
-
-            if count <= 40 {
-                let elapsed = (CFAbsoluteTimeGetCurrent() - self.recordingStartTime) * 1000
-                os_log(.info, log: recordingLog, "buffer #%d at %.3fms, frames=%d, rms=%.6f", count, elapsed, buffer.frameLength, rms)
-            }
-
-            // Fire ready callback on first non-silent buffer
-            if !self.readyFired && rms > 0 {
-                self.readyFired = true
-                let elapsed = (CFAbsoluteTimeGetCurrent() - self.recordingStartTime) * 1000
-                os_log(.info, log: recordingLog, "FIRST non-silent buffer at %.3fms — recording ready", elapsed)
-                self.onRecordingReady?()
-            }
-
-            self.audioFileQueue.sync {
-                if let file = self.audioFile {
-                    do {
-                        try file.write(from: buffer)
-                    } catch {
-                        self.audioFile = nil
-                    }
-                }
-            }
-            self.computeAudioLevel(from: buffer)
-        }
-        os_log(.info, log: recordingLog, "tap installed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        engine.prepare()
-        os_log(.info, log: recordingLog, "engine prepared: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        self.audioEngine = engine
-        self.currentDeviceUID = deviceUID
-
-        try engine.start()
-        os_log(.info, log: recordingLog, "engine started: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-    }
-
-    // MARK: - Configuration change handling
-
-    private func handleEngineConfigChange(_ notification: Notification) {
-        guard let engine = notification.object as? AVAudioEngine,
-              engine === self.audioEngine else { return }
-
-        os_log(.info, log: recordingLog, "AVAudioEngineConfigurationChange — invalidating engine")
-        invalidateEngine()
-
-        if _recording.withLock({ $0 }) {
-            os_log(.info, log: recordingLog, "was recording — attempting transparent restart")
-            restartRecording()
         }
     }
-
-    private func restartRecording() {
-        rebuildAttempt += 1
-        if rebuildAttempt > Self.maxRebuildAttempts {
-            os_log(.error, log: recordingLog, "exceeded max rebuild attempts (%d) — giving up", Self.maxRebuildAttempts)
-            _recording.withLock { $0 = false }
-            DispatchQueue.main.async { self.isRecording = false }
-            return
-        }
-
-        // On second attempt, fall back to system default device
-        let deviceToUse: String?
-        if rebuildAttempt >= Self.maxRebuildAttempts {
-            os_log(.info, log: recordingLog, "rebuild attempt %d — falling back to system default device", rebuildAttempt)
-            deviceToUse = nil
-        } else {
-            deviceToUse = currentDeviceUID
-        }
-
-        do {
-            try buildAndStartEngine(deviceUID: deviceToUse)
-            startBufferWatchdog()
-            os_log(.info, log: recordingLog, "transparent restart succeeded (attempt %d)", rebuildAttempt)
-        } catch {
-            os_log(.error, log: recordingLog, "transparent restart failed: %{public}@", error.localizedDescription)
-            _recording.withLock { $0 = false }
-            DispatchQueue.main.async { self.isRecording = false }
-        }
-    }
-
-    // MARK: - Buffer watchdog
 
     private func startBufferWatchdog() {
+        let baselineCount = _bufferCount.withLock { $0 }
         cancelWatchdog()
-        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .userInitiated))
+
+        let timer = DispatchSource.makeTimerSource(queue: sessionQueue)
         timer.schedule(deadline: .now() + Self.watchdogTimeout)
         timer.setEventHandler { [weak self] in
             guard let self else { return }
             guard self._recording.withLock({ $0 }) else { return }
+            guard !self.isSessionInterrupted else {
+                os_log(.info, log: recordingLog, "watchdog suspended while capture session is interrupted")
+                return
+            }
 
             let count = self._bufferCount.withLock { $0 }
-            if count == 0 {
-                os_log(.error, log: recordingLog,
-                       "watchdog: 0 buffers after %.1fs (attempt %d) — rebuilding engine",
-                       Self.watchdogTimeout, self.rebuildAttempt)
-                self.restartRecording()
+            if count == baselineCount {
+                os_log(.error, log: recordingLog, "watchdog: no new buffers after %.1fs — giving up", Self.watchdogTimeout)
+                self.reportRecordingFailure(AudioRecorderError.noAudioBuffersReceived)
             } else {
-                os_log(.info, log: recordingLog, "watchdog: %d buffers after %.1fs — healthy, resetting rebuild counter", count, Self.watchdogTimeout)
-                self.rebuildAttempt = 0
+                os_log(.info, log: recordingLog, "watchdog: %d new buffers after %.1fs — healthy", count - baselineCount, Self.watchdogTimeout)
             }
         }
         timer.resume()
@@ -341,119 +257,275 @@ class AudioRecorder: NSObject, ObservableObject {
         watchdogTimer = nil
     }
 
-    // MARK: - Public API
+    private func finishAudioFileLocked(discard: Bool) -> URL? {
+        var finalizedURL: URL?
+        var shouldKeepFile = false
+
+        // Stop accepting buffers before releasing the writer so we never race the final write.
+        sampleBufferQueue.sync {
+            finalizedURL = self.tempFileURL
+            shouldKeepFile = !discard && self.recordedFrameCount > 0 && self.fileWriteError == nil
+            self.activeAudioFile = nil
+            self.activeAudioFormat = nil
+        }
+
+        defer {
+            self.recordedFrameCount = 0
+            self.fileWriteError = nil
+            if !shouldKeepFile {
+                self.tempFileURL = nil
+            }
+        }
+
+        return shouldKeepFile ? finalizedURL : nil
+    }
+
+    private func handleSessionInterrupted(_ notification: Notification) {
+        _ = notification
+        sessionQueue.async {
+            guard self._recording.withLock({ $0 }) else { return }
+            self.isSessionInterrupted = true
+            self.cancelWatchdog()
+            os_log(.info, log: recordingLog, "capture session interrupted — waiting for recovery")
+        }
+    }
+
+    private func handleSessionInterruptionEnded(_ notification: Notification) {
+        _ = notification
+        sessionQueue.async {
+            guard self._recording.withLock({ $0 }) else { return }
+            self.isSessionInterrupted = false
+            os_log(.info, log: recordingLog, "capture session interruption ended — restarting watchdog")
+            self.startBufferWatchdog()
+        }
+    }
+
+    private func appendSampleBufferToFile(_ sampleBuffer: CMSampleBuffer) throws {
+        if let fileWriteError {
+            throw fileWriteError
+        }
+
+        guard let outputURL = tempFileURL else {
+            throw AudioRecorderError.failedToBeginFileRecording("Missing temporary output URL.")
+        }
+
+        guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else {
+            throw AudioRecorderError.invalidInputFormat("Could not determine audio format from sample buffer.")
+        }
+        let sampleFormat = AVAudioFormat(cmAudioFormatDescription: formatDescription)
+
+        let frameCount = AVAudioFrameCount(CMSampleBufferGetNumSamples(sampleBuffer))
+        guard frameCount > 0 else { return }
+
+        let targetFormat: AVAudioFormat
+        if let activeAudioFormat {
+            targetFormat = activeAudioFormat
+        } else {
+            // Lock the file format to the first buffer we receive and reuse it for the full run.
+            let settings = sampleFormat.settings
+            let audioFile = try AVAudioFile(
+                forWriting: outputURL,
+                settings: settings,
+                commonFormat: sampleFormat.commonFormat,
+                interleaved: sampleFormat.isInterleaved
+            )
+            activeAudioFile = audioFile
+            activeAudioFormat = audioFile.processingFormat
+            targetFormat = audioFile.processingFormat
+            os_log(.info, log: recordingLog, "audio file writer created at %{public}@", outputURL.path)
+        }
+
+        guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCount) else {
+            throw AudioRecorderError.failedToBeginFileRecording("Could not allocate PCM buffer for recording.")
+        }
+        pcmBuffer.frameLength = frameCount
+
+        let status = CMSampleBufferCopyPCMDataIntoAudioBufferList(
+            sampleBuffer,
+            at: 0,
+            frameCount: Int32(frameCount),
+            into: pcmBuffer.mutableAudioBufferList
+        )
+        guard status == noErr else {
+            throw AudioRecorderError.failedToBeginFileRecording("Could not copy sample buffer data (OSStatus \(status)).")
+        }
+
+        guard let activeAudioFile else {
+            throw AudioRecorderError.failedToBeginFileRecording("Audio file writer was not initialized.")
+        }
+
+        try activeAudioFile.write(from: pcmBuffer)
+        recordedFrameCount += AVAudioFramePosition(frameCount)
+    }
+
+    private func makeSession(deviceUID: String?, outputURL: URL) throws {
+        teardownSessionLocked()
+
+        guard let device = preferredCaptureDevice(for: deviceUID, reason: "initial start") else {
+            throw AudioRecorderError.missingInputDevice
+        }
+
+        let session = AVCaptureSession()
+        let dataOutput = AVCaptureAudioDataOutput()
+        dataOutput.audioSettings = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        dataOutput.setSampleBufferDelegate(self, queue: sampleBufferQueue)
+
+        let input: AVCaptureDeviceInput
+        do {
+            input = try AVCaptureDeviceInput(device: device)
+        } catch {
+            throw AudioRecorderError.failedToCreateCaptureInput(error.localizedDescription)
+        }
+
+        session.beginConfiguration()
+        var needsCommitConfiguration = true
+        defer {
+            if needsCommitConfiguration {
+                session.commitConfiguration()
+            }
+        }
+
+        guard session.canAddInput(input) else {
+            throw AudioRecorderError.failedToCreateCaptureInput("Session rejected device input for \(device.localizedName).")
+        }
+        session.addInput(input)
+
+        guard session.canAddOutput(dataOutput) else {
+            throw AudioRecorderError.failedToStartCaptureSession("Session rejected audio data output.")
+        }
+        session.addOutput(dataOutput)
+
+        session.commitConfiguration()
+        needsCommitConfiguration = false
+
+        captureSession = session
+        currentInput = input
+        audioDataOutput = dataOutput
+        isSessionInterrupted = false
+        activeAudioFile = nil
+        activeAudioFormat = nil
+        recordedFrameCount = 0
+        fileWriteError = nil
+        installSessionObservers(for: session)
+
+        os_log(.info, log: recordingLog, "configured capture session with device %{public}@ [uid=%{public}@]", device.localizedName, device.uniqueID)
+
+        session.startRunning()
+        guard session.isRunning else {
+            throw AudioRecorderError.failedToStartCaptureSession("Session failed to enter running state.")
+        }
+
+        os_log(.info, log: recordingLog, "capture session running with device %{public}@ [uid=%{public}@]", device.localizedName, device.uniqueID)
+        tempFileURL = outputURL
+    }
 
     func startRecording(deviceUID: String? = nil) throws {
         let t0 = CFAbsoluteTimeGetCurrent()
         recordingStartTime = t0
-        firstBufferLogged = false
         _bufferCount.withLock { $0 = 0 }
         readyFired = false
-        rebuildAttempt = 0
+        failureReported = false
+        smoothedLevel = 0.0
 
         os_log(.info, log: recordingLog, "startRecording() entered")
 
-        guard AVCaptureDevice.default(for: .audio) != nil else {
-            throw AudioRecorderError.missingInputDevice
-        }
-        os_log(.info, log: recordingLog, "AVCaptureDevice check: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-
-        let engineNeedsRebuild = audioEngine == nil || currentDeviceUID != deviceUID || !(audioEngine?.isRunning ?? false)
-
-        if engineNeedsRebuild {
-            try buildAndStartEngine(deviceUID: deviceUID)
-        } else if let engine = audioEngine, !engine.isRunning {
-            try engine.start()
-            os_log(.info, log: recordingLog, "engine restarted: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        }
-
-        guard let inputFormat = storedInputFormat else {
-            throw AudioRecorderError.invalidInputFormat("No stored input format")
-        }
-
-        // Create a temp file to write audio to
         let tempDir = FileManager.default.temporaryDirectory
-        let fileURL = tempDir.appendingPathComponent(UUID().uuidString + ".wav")
-        self.tempFileURL = fileURL
+        let outputURL = tempDir.appendingPathComponent(UUID().uuidString + ".wav")
 
-        // Try the input format first to avoid conversion issues, then fall back to 16-bit PCM.
-        let newAudioFile: AVAudioFile
         do {
-            newAudioFile = try AVAudioFile(forWriting: fileURL, settings: inputFormat.settings)
+            try sessionQueue.sync {
+                try self.makeSession(deviceUID: deviceUID, outputURL: outputURL)
+                self._recording.withLock { $0 = true }
+                self.startBufferWatchdog()
+            }
         } catch {
-            let fallbackSettings: [String: Any] = [
-                AVFormatIDKey: kAudioFormatLinearPCM,
-                AVSampleRateKey: inputFormat.sampleRate,
-                AVNumberOfChannelsKey: inputFormat.channelCount,
-                AVLinearPCMBitDepthKey: 16,
-                AVLinearPCMIsFloatKey: false,
-                AVLinearPCMIsBigEndianKey: false,
-                AVLinearPCMIsNonInterleaved: inputFormat.isInterleaved ? 0 : 1,
-            ]
-            newAudioFile = try AVAudioFile(
-                forWriting: fileURL,
-                settings: fallbackSettings,
-                commonFormat: .pcmFormatInt16,
-                interleaved: inputFormat.isInterleaved
-            )
+            tempFileURL = nil
+            throw error
         }
-        os_log(.info, log: recordingLog, "audio file created: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
 
-        audioFileQueue.sync { self.audioFile = newAudioFile }
-        _recording.withLock { $0 = true }
-        self.isRecording = true
-
-        startBufferWatchdog()
-
+        DispatchQueue.main.async {
+            self.isRecording = true
+            self.audioLevel = 0.0
+        }
         os_log(.info, log: recordingLog, "startRecording() complete: %.3fms total", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
     }
 
-    func stopRecording() -> URL? {
+    func stopRecording(completion: @escaping (URL?) -> Void) {
         let count = _bufferCount.withLock { $0 }
         let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
         os_log(.info, log: recordingLog, "stopRecording() called: %.3fms after start, %d buffers received", elapsed, count)
 
-        cancelWatchdog()
-        _recording.withLock { $0 = false }
-        audioFileQueue.sync { audioFile = nil }
-        isRecording = false
-        smoothedLevel = 0.0
-        DispatchQueue.main.async { self.audioLevel = 0.0 }
-
-        // Stop engine so mic indicator goes away — keep engine object for fast restart
-        audioEngine?.stop()
-        os_log(.info, log: recordingLog, "engine stopped (mic indicator off)")
-
-        return tempFileURL
+        sessionQueue.async {
+            self.cancelWatchdog()
+            self._recording.withLock { $0 = false }
+            self.teardownSessionLocked()
+            let outputURL = self.finishAudioFileLocked(discard: false)
+            DispatchQueue.main.async {
+                self.isRecording = false
+                self.audioLevel = 0.0
+                completion(outputURL)
+            }
+        }
     }
 
-    private func computeAudioLevel(from buffer: AVAudioPCMBuffer) {
-        let frames = Int(buffer.frameLength)
-        guard frames > 0 else { return }
+    func cancelRecording() {
+        sessionQueue.async {
+            self.cancelWatchdog()
+            self._recording.withLock { $0 = false }
+            self.teardownSessionLocked()
+            let discardURL = self.finishAudioFileLocked(discard: true)
+            if let discardURL {
+                try? FileManager.default.removeItem(at: discardURL)
+            }
+            DispatchQueue.main.async {
+                self.isRecording = false
+                self.audioLevel = 0.0
+            }
+        }
+    }
 
-        var sumOfSquares: Float = 0.0
-        if let channelData = buffer.floatChannelData {
-            let samples = channelData[0]
-            for i in 0..<frames {
-                let sample = samples[i]
-                sumOfSquares += sample * sample
-            }
-        } else if let channelData = buffer.int16ChannelData {
-            let samples = channelData[0]
-            for i in 0..<frames {
-                let sample = Float(samples[i]) / Float(Int16.max)
-                sumOfSquares += sample * sample
-            }
-        } else {
-            return
+    func cleanup() {
+        if let url = tempFileURL {
+            try? FileManager.default.removeItem(at: url)
+            tempFileURL = nil
+        }
+    }
+
+    private func updateAudioLevel(from sampleBuffer: CMSampleBuffer) -> Float {
+        guard let dataBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return 0 }
+
+        var lengthAtOffset = 0
+        var totalLength = 0
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        let status = CMBlockBufferGetDataPointer(
+            dataBuffer,
+            atOffset: 0,
+            lengthAtOffsetOut: &lengthAtOffset,
+            totalLengthOut: &totalLength,
+            dataPointerOut: &dataPointer
+        )
+
+        guard status == kCMBlockBufferNoErr, totalLength > 0, let dataPointer else { return 0 }
+
+        let sampleCount = totalLength / MemoryLayout<Float>.size
+        guard sampleCount > 0 else { return 0 }
+
+        let floatPointer = UnsafeRawPointer(dataPointer).assumingMemoryBound(to: Float.self)
+        var sumOfSquares: Float = 0
+        for index in 0..<sampleCount {
+            let sample = floatPointer[index]
+            sumOfSquares += sample * sample
         }
 
-        let rms = sqrtf(sumOfSquares / Float(frames))
-
-        // Scale RMS (~0.01-0.1 for speech) to 0-1 range
+        let rms = sqrtf(sumOfSquares / Float(sampleCount))
         let scaled = min(rms * 10.0, 1.0)
 
-        // Fast attack, slower release — follows speech dynamics closely
         if scaled > smoothedLevel {
             smoothedLevel = smoothedLevel * 0.3 + scaled * 0.7
         } else {
@@ -463,12 +535,43 @@ class AudioRecorder: NSObject, ObservableObject {
         DispatchQueue.main.async {
             self.audioLevel = self.smoothedLevel
         }
+        return rms
     }
 
-    func cleanup() {
-        if let url = tempFileURL {
-            try? FileManager.default.removeItem(at: url)
-            tempFileURL = nil
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        guard _recording.withLock({ $0 }) else { return }
+
+        do {
+            try appendSampleBufferToFile(sampleBuffer)
+        } catch {
+            fileWriteError = error
+            os_log(.error, log: recordingLog, "audio file write failed: %{public}@", error.localizedDescription)
+            reportRecordingFailure(error)
+            return
+        }
+
+        let count = _bufferCount.withLock { value -> Int in
+            value += 1
+            return value
+        }
+
+        let rms = updateAudioLevel(from: sampleBuffer)
+        if count <= Self.sampleRateLogLimit {
+            let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
+            os_log(.info, log: recordingLog, "buffer #%d at %.3fms, rms=%.6f", count, elapsed, rms)
+        }
+
+        if !readyFired && rms > 0 {
+            readyFired = true
+            let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
+            os_log(.info, log: recordingLog, "FIRST non-silent buffer at %.3fms — recording ready", elapsed)
+            DispatchQueue.main.async {
+                self.onRecordingReady?()
+            }
         }
     }
 }

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -261,7 +261,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         var finalizedURL: URL?
         var shouldKeepFile = false
 
-        // Stop accepting buffers before releasing the writer so we never race the final write.
+        // Drain all queued sample-buffer callbacks before releasing the writer.
         sampleBufferQueue.sync {
             finalizedURL = self.tempFileURL
             shouldKeepFile = !discard && self.recordedFrameCount > 0 && self.fileWriteError == nil
@@ -463,9 +463,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
         sessionQueue.async {
             self.cancelWatchdog()
-            self._recording.withLock { $0 = false }
             self.teardownSessionLocked()
             let outputURL = self.finishAudioFileLocked(discard: false)
+            self._recording.withLock { $0 = false }
             DispatchQueue.main.async {
                 self.isRecording = false
                 self.audioLevel = 0.0
@@ -477,9 +477,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     func cancelRecording() {
         sessionQueue.async {
             self.cancelWatchdog()
-            self._recording.withLock { $0 = false }
             self.teardownSessionLocked()
             let discardURL = self.finishAudioFileLocked(discard: true)
+            self._recording.withLock { $0 = false }
             if let discardURL {
                 try? FileManager.default.removeItem(at: discardURL)
             }

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -77,6 +77,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private var tempFileURL: URL?
     private var recordingStartTime: CFAbsoluteTime = 0
     private let _bufferCount = OSAllocatedUnfairLock(initialState: 0)
+    private let fileWriteErrorLock = OSAllocatedUnfairLock(initialState: ())
     private var watchdogTimer: DispatchSourceTimer?
     private let sessionQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.session")
     private let sampleBufferQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.samples")
@@ -264,14 +265,18 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         // Drain all queued sample-buffer callbacks before releasing the writer.
         sampleBufferQueue.sync {
             finalizedURL = self.tempFileURL
-            shouldKeepFile = !discard && self.recordedFrameCount > 0 && self.fileWriteError == nil
+            shouldKeepFile = !discard && self.recordedFrameCount > 0 && self.fileWriteErrorLock.withLock { _ in
+                self.fileWriteError == nil
+            }
             self.activeAudioFile = nil
             self.activeAudioFormat = nil
         }
 
         defer {
             self.recordedFrameCount = 0
-            self.fileWriteError = nil
+            self.fileWriteErrorLock.withLock { _ in
+                self.fileWriteError = nil
+            }
             if !shouldKeepFile {
                 self.tempFileURL = nil
             }
@@ -301,7 +306,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     }
 
     private func appendSampleBufferToFile(_ sampleBuffer: CMSampleBuffer) throws {
-        if let fileWriteError {
+        if let fileWriteError = fileWriteErrorLock.withLock({ _ in
+            self.fileWriteError
+        }) {
             throw fileWriteError
         }
 
@@ -411,7 +418,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         activeAudioFile = nil
         activeAudioFormat = nil
         recordedFrameCount = 0
-        fileWriteError = nil
+        fileWriteErrorLock.withLock { _ in
+            fileWriteError = nil
+        }
         installSessionObservers(for: session)
 
         os_log(.info, log: recordingLog, "configured capture session with device %{public}@ [uid=%{public}@]", device.localizedName, device.uniqueID)
@@ -445,7 +454,13 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
                 self.startBufferWatchdog()
             }
         } catch {
-            tempFileURL = nil
+            if DispatchQueue.getSpecific(key: Self.sessionQueueKey) != nil {
+                tempFileURL = nil
+            } else {
+                sessionQueue.sync {
+                    tempFileURL = nil
+                }
+            }
             throw error
         }
 
@@ -491,9 +506,17 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     }
 
     func cleanup() {
-        if let url = tempFileURL {
-            try? FileManager.default.removeItem(at: url)
-            tempFileURL = nil
+        let cleanup = {
+            if let url = self.tempFileURL {
+                try? FileManager.default.removeItem(at: url)
+                self.tempFileURL = nil
+            }
+        }
+
+        if DispatchQueue.getSpecific(key: Self.sessionQueueKey) != nil {
+            cleanup()
+        } else {
+            sessionQueue.sync(execute: cleanup)
         }
     }
 
@@ -548,7 +571,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         do {
             try appendSampleBufferToFile(sampleBuffer)
         } catch {
-            fileWriteError = error
+            fileWriteErrorLock.withLock { _ in
+                fileWriteError = error
+            }
             os_log(.error, log: recordingLog, "audio file write failed: %{public}@", error.localizedDescription)
             reportRecordingFailure(error)
             return

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -962,8 +962,24 @@ struct SetupView: View {
                 }
                 do {
                     let recorder = AudioRecorder()
+                    recorder.onRecordingFailure = { [weak recorder] error in
+                        guard let recorder else { return }
+                        Task { @MainActor in
+                            testAudioLevelCancellable?.cancel()
+                            testAudioLevelCancellable = nil
+                            testAudioLevel = 0.0
+                            testHotkeyHarness.isTranscribing = false
+                            testAudioRecorder = nil
+                            testError = error.localizedDescription
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                                testPhase = .done
+                            }
+                            recorder.cleanup()
+                        }
+                    }
                     try recorder.startRecording(deviceUID: appState.selectedMicrophoneID)
                     testAudioRecorder = recorder
+                    testError = nil
                     testAudioLevelCancellable = recorder.$audioLevel
                         .receive(on: DispatchQueue.main)
                         .sink { level in
@@ -982,7 +998,6 @@ struct SetupView: View {
 
             case .stop:
                 guard testPhase == .recording, let recorder = testAudioRecorder else { return }
-                let fileURL = recorder.stopRecording()
                 testAudioLevelCancellable?.cancel()
                 testAudioLevelCancellable = nil
                 testAudioLevel = 0.0
@@ -991,40 +1006,49 @@ struct SetupView: View {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                     testPhase = .transcribing
                 }
-
-                guard let url = fileURL else {
-                    testHotkeyHarness.isTranscribing = false
-                    testError = "No audio file was created."
-                    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                        testPhase = .done
-                    }
-                    return
-                }
-
-                Task {
-                    do {
-                        let service = TranscriptionService(
-                            apiKey: appState.apiKey,
-                            baseURL: appState.apiBaseURL
-                        )
-                        let transcript = try await service.transcribe(fileURL: url)
-                        await MainActor.run {
+                recorder.stopRecording { url in
+                    guard let url else {
+                        Task { @MainActor in
                             testHotkeyHarness.isTranscribing = false
-                            testTranscript = transcript
-                            withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+                            testAudioRecorder = nil
+                            if testError == nil {
+                                testError = "No audio file was created."
+                            }
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                                 testPhase = .done
                             }
+                            recorder.cleanup()
                         }
-                    } catch {
-                        await MainActor.run {
-                            testHotkeyHarness.isTranscribing = false
-                            testError = error.localizedDescription
-                            withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
-                                testPhase = .done
+                        return
+                    }
+
+                    Task {
+                        do {
+                            let service = TranscriptionService(
+                                apiKey: appState.apiKey,
+                                baseURL: appState.apiBaseURL,
+                            )
+                            let transcript = try await service.transcribe(fileURL: url)
+                            await MainActor.run {
+                                testHotkeyHarness.isTranscribing = false
+                                testAudioRecorder = nil
+                                testTranscript = transcript
+                                withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+                                    testPhase = .done
+                                }
+                            }
+                        } catch {
+                            await MainActor.run {
+                                testHotkeyHarness.isTranscribing = false
+                                testAudioRecorder = nil
+                                testError = error.localizedDescription
+                                withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+                                    testPhase = .done
+                                }
                             }
                         }
+                        recorder.cleanup()
                     }
-                    recorder.cleanup()
                 }
 
             case .switchedToToggle:
@@ -1043,8 +1067,7 @@ struct SetupView: View {
         testAudioLevelCancellable?.cancel()
         testAudioLevelCancellable = nil
         if let recorder = testAudioRecorder, recorder.isRecording {
-            _ = recorder.stopRecording()
-            recorder.cleanup()
+            recorder.cancelRecording()
         }
         testAudioRecorder = nil
     }
@@ -1059,9 +1082,8 @@ struct SetupView: View {
         testHotkeyHarness.resetSession()
         if let recorder = testAudioRecorder {
             if recorder.isRecording {
-                _ = recorder.stopRecording()
+                recorder.cancelRecording()
             }
-            recorder.cleanup()
             testAudioRecorder = nil
         }
     }

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1047,7 +1047,9 @@ struct SetupView: View {
                                 }
                             }
                         }
-                        recorder.cleanup()
+                        await MainActor.run {
+                            recorder.cleanup()
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

Replace the current `AVAudioEngine` recording pipeline with a sample-buffer writer built on `AVCaptureAudioDataOutput` + `AVAudioFile`.

This makes microphone selection more reliable and reduces the time to first real audio during dictation.

## What Changed

- Replaced the recorder implementation in `Sources/AudioRecorder.swift`
  - moved from `AVAudioEngine` input taps
  - to `AVCaptureAudioDataOutput` sample buffers written directly into `AVAudioFile`
- Updated `Sources/AppState.swift`
  - adapted recorder start/stop handling to the new finalize path
  - tightened recorder failure handling and cleanup
  - kept microphone refresh behavior aligned with the active recorder
- Updated `Sources/SetupView.swift`
  - aligned the setup test harness with the new recorder stop/failure flow
 - This recorder change also removes our dependence on the previous `AVAudioEngine`-based recording path and the older CoreAudio device-listener approach.
- The new implementation uses `AVCaptureDevice` discovery plus `AVCaptureAudioDataOutput` sample buffers written directly to `AVAudioFile`, so the recorder itself no longer relies on those legacy pieces.


## Why

Microphone selection is a hard requirement for FreeFlow. The previous recording pipeline did not reliably honor the selected microphone and was slower to produce usable audio.

## Benchmark Results

In local benchmark runs, median start-to-first-non-silent-audio improved from `587.57 ms` to `125.67 ms`.

The new recorder also consistently used the selected microphone in those runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of microphone device detection and enumeration.
  * Enhanced error handling and recovery when recording encounters issues.

* **Improvements**
  * Modernized audio capture pipeline for more robust recording performance.
  * Recording process now defers microphone updates when actively recording, improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->