### PR TITLE
Trim transcript input before macro matching and post-processing

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -572,21 +572,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let finalTranscript: String
                 let processingStatus: String
                 let postProcessingPrompt: String
-                do {
-                    let postProcessingResult = try await postProcessingService.postProcess(
-                        transcript: rawTranscript,
-                        context: restoredContext,
-                        customVocabulary: capturedCustomVocabulary,
-                        customSystemPrompt: capturedCustomSystemPrompt
-                    )
-                    finalTranscript = postProcessingResult.transcript
+                let result = await self.processTranscript(
+                    rawTranscript,
+                    context: restoredContext,
+                    postProcessingService: postProcessingService,
+                    customVocabulary: capturedCustomVocabulary,
+                    customSystemPrompt: capturedCustomSystemPrompt
+                )
+                finalTranscript = result.finalTranscript
+                if result.status == "Post-processing succeeded" {
                     processingStatus = "Post-processing succeeded (retried)"
-                    postProcessingPrompt = postProcessingResult.prompt
-                } catch {
-                    finalTranscript = rawTranscript
+                } else if result.status == "Post-processing failed, using raw transcript" {
                     processingStatus = "Post-processing failed on retry, using raw transcript"
-                    postProcessingPrompt = ""
+                } else {
+                    processingStatus = result.status
                 }
+                postProcessingPrompt = result.prompt
 
                 await MainActor.run {
                     let updatedItem = PipelineHistoryItem(
@@ -1247,14 +1248,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
         customVocabulary: String,
         customSystemPrompt: String
     ) async -> (finalTranscript: String, status: String, prompt: String) {
-        if let macro = findMatchingMacro(for: rawTranscript) {
+        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedRawTranscript.isEmpty else {
+            return ("", "Skipped macros and post-processing for empty raw transcript", "")
+        }
+
+        if let macro = findMatchingMacro(for: trimmedRawTranscript) {
             os_log(.info, log: recordingLog, "Voice macro triggered: %{public}@", macro.command)
             return (macro.payload, "Voice macro used: \(macro.command)", "")
         }
         
         do {
             let result = try await postProcessingService.postProcess(
-                transcript: rawTranscript,
+                transcript: trimmedRawTranscript,
                 context: context,
                 customVocabulary: customVocabulary,
                 customSystemPrompt: customSystemPrompt
@@ -1262,7 +1269,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return (result.transcript, "Post-processing succeeded", result.prompt)
         } catch {
             os_log(.error, log: recordingLog, "Post-processing failed: %{public}@", error.localizedDescription)
-            return (rawTranscript, "Post-processing failed, using raw transcript", "")
+            return (trimmedRawTranscript, "Post-processing failed, using raw transcript", "")
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -580,13 +580,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     customSystemPrompt: capturedCustomSystemPrompt
                 )
                 finalTranscript = result.finalTranscript
-                if result.status == "Post-processing succeeded" {
-                    processingStatus = "Post-processing succeeded (retried)"
-                } else if result.status == "Post-processing failed, using raw transcript" {
-                    processingStatus = "Post-processing failed on retry, using raw transcript"
-                } else {
-                    processingStatus = result.status
-                }
+                processingStatus = result.outcome.statusMessage(isRetry: true)
                 postProcessingPrompt = result.prompt
 
                 await MainActor.run {
@@ -1241,22 +1235,44 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }?.original
     }
 
+    private enum TranscriptProcessingOutcome {
+        case skippedEmptyRawTranscript
+        case voiceMacro(command: String)
+        case postProcessingSucceeded
+        case postProcessingFailedFallback
+
+        func statusMessage(isRetry: Bool = false) -> String {
+            switch self {
+            case .skippedEmptyRawTranscript:
+                return "Skipped macros and post-processing for empty raw transcript"
+            case .voiceMacro(let command):
+                return "Voice macro used: \(command)"
+            case .postProcessingSucceeded:
+                return isRetry ? "Post-processing succeeded (retried)" : "Post-processing succeeded"
+            case .postProcessingFailedFallback:
+                return isRetry
+                    ? "Post-processing failed on retry, using raw transcript"
+                    : "Post-processing failed, using raw transcript"
+            }
+        }
+    }
+
     private func processTranscript(
         _ rawTranscript: String,
         context: AppContext,
         postProcessingService: PostProcessingService,
         customVocabulary: String,
         customSystemPrompt: String
-    ) async -> (finalTranscript: String, status: String, prompt: String) {
+    ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
         let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmedRawTranscript.isEmpty else {
-            return ("", "Skipped macros and post-processing for empty raw transcript", "")
+            return ("", .skippedEmptyRawTranscript, "")
         }
 
         if let macro = findMatchingMacro(for: trimmedRawTranscript) {
             os_log(.info, log: recordingLog, "Voice macro triggered: %{public}@", macro.command)
-            return (macro.payload, "Voice macro used: \(macro.command)", "")
+            return (macro.payload, .voiceMacro(command: macro.command), "")
         }
         
         do {
@@ -1266,10 +1282,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 customVocabulary: customVocabulary,
                 customSystemPrompt: customSystemPrompt
             )
-            return (result.transcript, "Post-processing succeeded", result.prompt)
+            return (result.transcript, .postProcessingSucceeded, result.prompt)
         } catch {
             os_log(.error, log: recordingLog, "Post-processing failed: %{public}@", error.localizedDescription)
-            return (trimmedRawTranscript, "Post-processing failed, using raw transcript", "")
+            return (trimmedRawTranscript, .postProcessingFailedFallback, "")
         }
     }
 
@@ -1355,7 +1371,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     await MainActor.run { [weak self] in
                         self?.debugStatusMessage = "Running post-processing"
                     }
-                    let (finalTranscript, processingStatus, postProcessingPrompt) = await self.processTranscript(
+                    let result = await self.processTranscript(
                         rawTranscript,
                         context: appContext,
                         postProcessingService: postProcessingService,
@@ -1371,15 +1387,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.lastContextScreenshotStatus = appContext.screenshotError
                             ?? "available (\(appContext.screenshotMimeType ?? "image"))"
                         let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                        let trimmedFinalTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                        self.lastPostProcessingPrompt = postProcessingPrompt
+                        let trimmedFinalTranscript = result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let processingStatus = result.outcome.statusMessage()
+                        self.lastPostProcessingPrompt = result.prompt
                         self.lastRawTranscript = trimmedRawTranscript
                         self.lastPostProcessedTranscript = trimmedFinalTranscript
                         self.lastPostProcessingStatus = processingStatus
                         self.recordPipelineHistoryEntry(
                             rawTranscript: trimmedRawTranscript,
                             postProcessedTranscript: trimmedFinalTranscript,
-                            postProcessingPrompt: postProcessingPrompt,
+                            postProcessingPrompt: result.prompt,
                             context: appContext,
                             processingStatus: processingStatus,
                             audioFileName: savedAudioFile?.fileName


### PR DESCRIPTION
## Summary
- Trim leading and trailing whitespace from transcripts before macro matching and post-processing.
- Skip macro/post-processing work entirely when the trimmed transcript is empty.
- Preserve the trimmed transcript on post-processing failure and keep retry handling consistent with the new result flow.

## Testing
- Not run.
- Reviewed the updated `processTranscript` flow for empty-input handling, macro matching, and retry/error paths.
- Verified the `postProcessingPrompt` and status mapping still align with the returned processing result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty transcripts are now skipped during post-processing.
  * Transcript whitespace and newlines are trimmed before processing for improved quality.

* **Refactor**
  * Post-processing workflow streamlined for consistent behavior between retry and non-retry flows.
  * Post-processing outcomes, status messages, and prompts are now unified and recorded consistently in pipeline history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->