### PR TITLE
Smooth recording waveform and transcribing overlay

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -128,7 +128,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
     private let voiceMacrosStorageKey = "voice_macros"
-    private let transcribingIndicatorDelay: TimeInterval = 1.0
+    private let transcribingIndicatorDelay: TimeInterval = 0.25
     private let clipboardRestoreDelay: TimeInterval = 0.15
     let maxPipelineHistoryCount = 20
 
@@ -1315,7 +1315,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         statusText = "Preparing audio..."
         errorMessage = nil
         playAlertSound(named: "Pop")
-        overlayManager.slideUpToNotch { }
+        overlayManager.prepareForTranscribing()
         audioRecorder.stopRecording { [weak self] fileURL in
             guard let self else { return }
             guard let fileURL else {

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -90,7 +90,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     @Published var isRecording = false
     private let _recording = OSAllocatedUnfairLock(initialState: false)
     @Published var audioLevel: Float = 0.0
-    private var liveLevelNormalizer = LiveAudioLevelNormalizer()
+    private let liveLevelNormalizerLock = OSAllocatedUnfairLock(initialState: LiveAudioLevelNormalizer())
 
     var onRecordingReady: (() -> Void)?
     var onRecordingFailure: ((Error) -> Void)?
@@ -214,7 +214,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             let completion = completion
             let discardURL = self.finishAudioFileLocked(discard: true)
             self.teardownSessionLocked()
-            self.liveLevelNormalizer.reset()
+            self.liveLevelNormalizerLock.withLock { $0.reset() }
             if let discardURL {
                 try? FileManager.default.removeItem(at: discardURL)
             }
@@ -441,7 +441,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         _bufferCount.withLock { $0 = 0 }
         readyFired = false
         failureReported = false
-        liveLevelNormalizer.reset()
+        liveLevelNormalizerLock.withLock { $0.reset() }
 
         os_log(.info, log: recordingLog, "startRecording() entered")
 
@@ -482,7 +482,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             self.teardownSessionLocked()
             let outputURL = self.finishAudioFileLocked(discard: false)
             self._recording.withLock { $0 = false }
-            self.liveLevelNormalizer.reset()
+            self.liveLevelNormalizerLock.withLock { $0.reset() }
             DispatchQueue.main.async {
                 self.isRecording = false
                 self.audioLevel = 0.0
@@ -497,7 +497,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             self.teardownSessionLocked()
             let discardURL = self.finishAudioFileLocked(discard: true)
             self._recording.withLock { $0 = false }
-            self.liveLevelNormalizer.reset()
+            self.liveLevelNormalizerLock.withLock { $0.reset() }
             if let discardURL {
                 try? FileManager.default.removeItem(at: discardURL)
             }
@@ -550,7 +550,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         }
 
         let rms = sqrtf(sumOfSquares / Float(sampleCount))
-        let normalizedDisplayLevel = liveLevelNormalizer.normalizedLevel(forRMS: rms)
+        let normalizedDisplayLevel = liveLevelNormalizerLock.withLock {
+            $0.normalizedLevel(forRMS: rms)
+        }
 
         DispatchQueue.main.async {
             self.audioLevel = normalizedDisplayLevel

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -90,7 +90,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     @Published var isRecording = false
     private let _recording = OSAllocatedUnfairLock(initialState: false)
     @Published var audioLevel: Float = 0.0
-    private var smoothedLevel: Float = 0.0
+    private var liveLevelNormalizer = LiveAudioLevelNormalizer()
 
     var onRecordingReady: (() -> Void)?
     var onRecordingFailure: ((Error) -> Void)?
@@ -214,6 +214,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             let completion = completion
             let discardURL = self.finishAudioFileLocked(discard: true)
             self.teardownSessionLocked()
+            self.liveLevelNormalizer.reset()
             if let discardURL {
                 try? FileManager.default.removeItem(at: discardURL)
             }
@@ -440,7 +441,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         _bufferCount.withLock { $0 = 0 }
         readyFired = false
         failureReported = false
-        smoothedLevel = 0.0
+        liveLevelNormalizer.reset()
 
         os_log(.info, log: recordingLog, "startRecording() entered")
 
@@ -481,6 +482,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             self.teardownSessionLocked()
             let outputURL = self.finishAudioFileLocked(discard: false)
             self._recording.withLock { $0 = false }
+            self.liveLevelNormalizer.reset()
             DispatchQueue.main.async {
                 self.isRecording = false
                 self.audioLevel = 0.0
@@ -495,6 +497,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             self.teardownSessionLocked()
             let discardURL = self.finishAudioFileLocked(discard: true)
             self._recording.withLock { $0 = false }
+            self.liveLevelNormalizer.reset()
             if let discardURL {
                 try? FileManager.default.removeItem(at: discardURL)
             }
@@ -547,16 +550,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         }
 
         let rms = sqrtf(sumOfSquares / Float(sampleCount))
-        let scaled = min(rms * 10.0, 1.0)
-
-        if scaled > smoothedLevel {
-            smoothedLevel = smoothedLevel * 0.3 + scaled * 0.7
-        } else {
-            smoothedLevel = smoothedLevel * 0.6 + scaled * 0.4
-        }
+        let normalizedDisplayLevel = liveLevelNormalizer.normalizedLevel(forRMS: rms)
 
         DispatchQueue.main.async {
-            self.audioLevel = self.smoothedLevel
+            self.audioLevel = normalizedDisplayLevel
         }
         return rms
     }

--- a/Sources/LiveAudioLevelNormalizer.swift
+++ b/Sources/LiveAudioLevelNormalizer.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+struct LiveAudioLevelNormalizer {
+    private static let minimumRMS: Float = 0.00001
+    private static let minSpanDB: Float = 18
+    private static let peakHeadroomDB: Float = 8
+    private static let speechGateMarginDB: Float = 3
+    private static let minimumVisibleActiveLevel: Float = 0.12
+    private static let noiseGateNormalizedThreshold: Float = 0.06
+    private static let floorRiseWindowDB: Float = 4
+    private static let floorFallBlend: Float = 0.12
+    private static let floorRiseBlend: Float = 0.02
+    private static let peakAttackBlend: Float = 0.55
+    private static let peakReleaseBlend: Float = 0.04
+    private static let displayAttackBlend: Float = 0.45
+    private static let displayReleaseBlend: Float = 0.12
+
+    private var noiseFloorDB: Float = -55
+    private var peakCeilingDB: Float = -37
+    private var displayLevel: Float = 0
+
+    mutating func reset() {
+        noiseFloorDB = -55
+        peakCeilingDB = -37
+        displayLevel = 0
+    }
+
+    mutating func normalizedLevel(forRMS rms: Float) -> Float {
+        let levelDB = 20 * log10f(max(rms, Self.minimumRMS))
+
+        updateNoiseFloor(with: levelDB)
+        updatePeakCeiling(with: levelDB)
+
+        let displayCeilingDB = peakCeilingDB + Self.peakHeadroomDB
+        let dynamicSpan = max(displayCeilingDB - noiseFloorDB, Self.minSpanDB + Self.peakHeadroomDB)
+        var normalized = clamp((levelDB - noiseFloorDB) / dynamicSpan)
+        let isActiveSpeech = levelDB >= noiseFloorDB + Self.speechGateMarginDB
+
+        if normalized < Self.noiseGateNormalizedThreshold && levelDB <= noiseFloorDB + Self.speechGateMarginDB {
+            normalized = 0
+        } else if isActiveSpeech {
+            normalized = max(normalized, Self.minimumVisibleActiveLevel)
+        }
+
+        let blend = normalized > displayLevel ? Self.displayAttackBlend : Self.displayReleaseBlend
+        displayLevel = mix(displayLevel, normalized, blend)
+        return displayLevel
+    }
+
+    private mutating func updateNoiseFloor(with levelDB: Float) {
+        let ceilingLimitedLevel = min(levelDB, peakCeilingDB - Self.minSpanDB)
+
+        if ceilingLimitedLevel <= noiseFloorDB {
+            noiseFloorDB = mix(noiseFloorDB, ceilingLimitedLevel, Self.floorFallBlend)
+        } else if ceilingLimitedLevel <= noiseFloorDB + Self.floorRiseWindowDB {
+            noiseFloorDB = mix(noiseFloorDB, ceilingLimitedLevel, Self.floorRiseBlend)
+        }
+    }
+
+    private mutating func updatePeakCeiling(with levelDB: Float) {
+        let minimumCeiling = noiseFloorDB + Self.minSpanDB
+
+        if levelDB >= peakCeilingDB {
+            peakCeilingDB = mix(peakCeilingDB, levelDB, Self.peakAttackBlend)
+        } else {
+            peakCeilingDB = mix(peakCeilingDB, max(levelDB, minimumCeiling), Self.peakReleaseBlend)
+        }
+
+        peakCeilingDB = max(peakCeilingDB, minimumCeiling)
+    }
+
+    private func mix(_ current: Float, _ target: Float, _ blend: Float) -> Float {
+        current + (target - current) * blend
+    }
+
+    private func clamp(_ value: Float) -> Float {
+        min(max(value, 0), 1)
+    }
+}

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -358,13 +358,24 @@ struct RecordingOverlayView: View {
     @ObservedObject var state: RecordingOverlayState
     let onStopButtonPressed: () -> Void
 
+    private var showsLiveRecordingContent: Bool {
+        state.phase == .recording || !state.showsTranscribingSpinner
+    }
+
+    private var showsStopButton: Bool {
+        showsLiveRecordingContent && state.recordingTriggerMode == .toggle
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             Group {
                 if state.phase == .initializing {
                     InitializingDotsView()
                         .transition(.opacity)
-                } else if state.phase == .recording || !state.showsTranscribingSpinner {
+                } else if state.phase == .done {
+                    DoneView()
+                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                } else if showsLiveRecordingContent {
                     WaveformView(audioLevel: state.audioLevel)
                         .transition(.opacity)
                 } else {
@@ -373,7 +384,7 @@ struct RecordingOverlayView: View {
                 }
             }
 
-            if state.phase == .recording && state.recordingTriggerMode == .toggle {
+            if showsStopButton {
                 Button(action: onStopButtonPressed) {
                     HStack(spacing: 5) {
                         Image(systemName: "stop.fill")
@@ -398,6 +409,15 @@ struct RecordingOverlayView: View {
 }
 
 // MARK: - Transcribing Indicator
+
+struct DoneView: View {
+    var body: some View {
+        Image(systemName: "checkmark")
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
 
 struct TranscribingSpinnerView: View {
     @State private var isAnimating = false

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -359,7 +359,7 @@ struct RecordingOverlayView: View {
     let onStopButtonPressed: () -> Void
 
     private var showsLiveRecordingContent: Bool {
-        state.phase == .recording || !state.showsTranscribingSpinner
+        state.phase == .recording || (state.phase == .transcribing && !state.showsTranscribingSpinner)
     }
 
     private var showsStopButton: Bool {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -131,19 +131,13 @@ final class RecordingOverlayManager {
 
     func prepareForTranscribing() {
         DispatchQueue.main.async {
-            self.lockedOverlayWidth = self.overlayWindow?.frame.width ?? self.overlayWidth
-            self.overlayState.phase = .transcribing
-            self.overlayState.showsTranscribingSpinner = false
-            self.showOverlayPanel(animatedResize: true)
+            self.setTranscribingPhase(showsTranscribingSpinner: false)
         }
     }
 
     func showTranscribing() {
         DispatchQueue.main.async {
-            self.lockedOverlayWidth = self.overlayWindow?.frame.width ?? self.overlayWidth
-            self.overlayState.phase = .transcribing
-            self.overlayState.showsTranscribingSpinner = true
-            self.showOverlayPanel(animatedResize: true)
+            self.setTranscribingPhase(showsTranscribingSpinner: true)
         }
     }
 
@@ -198,6 +192,13 @@ final class RecordingOverlayManager {
         panel.ignoresMouseEvents = !overlayAcceptsMouseEvents
         panel.contentView = makeOverlayContent(frame: frame)
         resize(panel: panel, to: frame, animated: animated)
+    }
+
+    private func setTranscribingPhase(showsTranscribingSpinner: Bool) {
+        lockedOverlayWidth = overlayWindow?.frame.width ?? overlayWidth
+        overlayState.phase = .transcribing
+        overlayState.showsTranscribingSpinner = showsTranscribingSpinner
+        showOverlayPanel(animatedResize: true)
     }
 
     private func makeOverlayContent(frame: NSRect) -> NSView {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -7,6 +7,7 @@ final class RecordingOverlayState: ObservableObject {
     @Published var phase: OverlayPhase = .recording
     @Published var audioLevel: Float = 0.0
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
+    @Published var showsTranscribingSpinner = false
 }
 
 enum OverlayPhase {
@@ -57,8 +58,8 @@ private func makeNotchContent<V: View>(
 
 final class RecordingOverlayManager {
     private var overlayWindow: NSPanel?
-    private var transcribingPanel: NSPanel?
     private let overlayState = RecordingOverlayState()
+    private var lockedOverlayWidth: CGFloat?
 
     var onStopButtonPressed: (() -> Void)?
 
@@ -85,8 +86,10 @@ final class RecordingOverlayManager {
 
     func showInitializing(mode: RecordingTriggerMode = .hold) {
         DispatchQueue.main.async {
+            self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
             self.overlayState.phase = .initializing
+            self.overlayState.showsTranscribingSpinner = false
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: false)
         }
@@ -94,8 +97,10 @@ final class RecordingOverlayManager {
 
     func showRecording(mode: RecordingTriggerMode = .hold) {
         DispatchQueue.main.async {
+            self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
             self.overlayState.phase = .recording
+            self.overlayState.showsTranscribingSpinner = false
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: true)
         }
@@ -103,8 +108,10 @@ final class RecordingOverlayManager {
 
     func transitionToRecording(mode: RecordingTriggerMode = .hold) {
         DispatchQueue.main.async {
+            self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
             self.overlayState.phase = .recording
+            self.overlayState.showsTranscribingSpinner = false
             self.updateOverlayLayout(animated: true)
         }
     }
@@ -122,15 +129,21 @@ final class RecordingOverlayManager {
         }
     }
 
-    func showTranscribing() {
+    func prepareForTranscribing() {
         DispatchQueue.main.async {
-            self.showTranscribingPanel()
+            self.lockedOverlayWidth = self.overlayWindow?.frame.width ?? self.overlayWidth
+            self.overlayState.phase = .transcribing
+            self.overlayState.showsTranscribingSpinner = false
+            self.showOverlayPanel(animatedResize: true)
         }
     }
 
-    func slideUpToNotch(completion: @escaping () -> Void) {
+    func showTranscribing() {
         DispatchQueue.main.async {
-            self.slideOverlayUp(completion: completion)
+            self.lockedOverlayWidth = self.overlayWindow?.frame.width ?? self.overlayWidth
+            self.overlayState.phase = .transcribing
+            self.overlayState.showsTranscribingSpinner = true
+            self.showOverlayPanel(animatedResize: true)
         }
     }
 
@@ -226,96 +239,33 @@ final class RecordingOverlayManager {
     }
 
     private var overlayWidth: CGFloat {
+        if let lockedOverlayWidth, (overlayState.phase == .transcribing || overlayState.phase == .done) {
+            return lockedOverlayWidth
+        }
+
         let baseWidth: CGFloat = overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle ? 150 : 92
         guard screenHasNotch else { return baseWidth }
         return max(notchWidth, baseWidth)
     }
 
-    private func slideOverlayUp(completion: @escaping () -> Void) {
-        guard let panel = overlayWindow, let screen = NSScreen.main else {
-            completion()
-            return
-        }
-
-        let hiddenY = screen.frame.maxY
-        let frame = panel.frame
-
-        NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.09
-            context.timingFunction = CAMediaTimingFunction(controlPoints: 0.4, 0.0, 1.0, 1.0)
-            panel.animator().setFrame(
-                NSRect(x: frame.origin.x, y: hiddenY, width: frame.width, height: frame.height),
-                display: true
-            )
-        }, completionHandler: {
-            panel.orderOut(nil)
-            self.overlayWindow = nil
-            completion()
-        })
-    }
-
-    private func showTranscribingPanel() {
-        overlayState.phase = .transcribing
-
-        if let panel = overlayWindow {
-            panel.orderOut(nil)
-            overlayWindow = nil
-        }
-
-        if transcribingPanel != nil { return }
-
-        let overlap = screenHasNotch ? notchOverlap : 0
-        let panelWidth: CGFloat = 44
-        let panelHeight: CGFloat = 22 + overlap
-
-        let panel = makeOverlayPanel(width: panelWidth, height: panelHeight)
-        panel.hasShadow = false
-        panel.contentView = makeNotchContent(
-            width: panelWidth,
-            height: panelHeight,
-            cornerRadius: screenHasNotch ? 14 : 11,
-            rootView: TranscribingIndicatorView().padding(.top, overlap)
-        )
-
-        if let screen = NSScreen.main {
-            let x = screen.frame.midX - panelWidth / 2
-            let y = screen.frame.maxY - panelHeight
-            panel.setFrame(NSRect(x: x, y: y, width: panelWidth, height: panelHeight), display: true)
-        }
-
-        panel.alphaValue = 0
-        panel.orderFrontRegardless()
-
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.25
-            panel.animator().alphaValue = 1
-        }
-
-        transcribingPanel = panel
-    }
-
     private func showDonePanel() {
         overlayState.phase = .done
 
-        if let panel = transcribingPanel {
-            NSAnimationContext.runAnimationGroup({ context in
-                context.duration = 0.2
-                panel.animator().alphaValue = 0
-            }, completionHandler: {
-                panel.orderOut(nil)
-                self.transcribingPanel = nil
-            })
+        guard let panel = overlayWindow else { return }
+        panel.contentView = makeOverlayContent(frame: panel.frame)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            panel.animator().alphaValue = 0
         }
     }
 
     private func dismissAll() {
+        lockedOverlayWidth = nil
+        overlayState.showsTranscribingSpinner = false
         if let panel = overlayWindow {
             panel.orderOut(nil)
             overlayWindow = nil
-        }
-        if let panel = transcribingPanel {
-            panel.orderOut(nil)
-            transcribingPanel = nil
         }
     }
 }
@@ -340,13 +290,18 @@ struct WaveformView: View {
 
     private static let barCount = 9
     private static let multipliers: [CGFloat] = [0.35, 0.55, 0.75, 0.9, 1.0, 0.9, 0.75, 0.55, 0.35]
+    private static let centerIndex = CGFloat((barCount - 1) / 2)
 
     var body: some View {
         HStack(spacing: 2.5) {
             ForEach(0..<Self.barCount, id: \.self) { index in
                 WaveformBar(amplitude: barAmplitude(for: index))
                     .animation(
-                        .interpolatingSpring(stiffness: 600, damping: 28),
+                        .spring(
+                            response: barResponse(for: index),
+                            dampingFraction: 0.88
+                        )
+                        .delay(barDelay(for: index)),
                         value: audioLevel
                     )
             }
@@ -357,6 +312,17 @@ struct WaveformView: View {
     private func barAmplitude(for index: Int) -> CGFloat {
         let level = CGFloat(audioLevel)
         return min(level * Self.multipliers[index], 1.0)
+    }
+
+    private func barResponse(for index: Int) -> Double {
+        let distance = abs(CGFloat(index) - Self.centerIndex)
+        let normalizedDistance = distance / Self.centerIndex
+        return 0.18 + Double(normalizedDistance) * 0.06
+    }
+
+    private func barDelay(for index: Int) -> Double {
+        let distance = abs(CGFloat(index) - Self.centerIndex)
+        return Double(distance) * 0.01
     }
 }
 
@@ -398,9 +364,12 @@ struct RecordingOverlayView: View {
                 if state.phase == .initializing {
                     InitializingDotsView()
                         .transition(.opacity)
-                } else {
+                } else if state.phase == .recording || !state.showsTranscribingSpinner {
                     WaveformView(audioLevel: state.audioLevel)
                         .transition(.opacity)
+                } else {
+                    TranscribingSpinnerView()
+                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
                 }
             }
 
@@ -430,35 +399,24 @@ struct RecordingOverlayView: View {
 
 // MARK: - Transcribing Indicator
 
-struct TranscribingIndicatorView: View {
-    @State private var animatingDot = 0
-    @State private var dotAnimationTimer: Timer?
+struct TranscribingSpinnerView: View {
+    @State private var isAnimating = false
 
     var body: some View {
-        HStack(spacing: 4) {
-            ForEach(0..<3, id: \.self) { index in
-                Circle()
-                    .fill(.white.opacity(animatingDot == index ? 0.9 : 0.25))
-                    .frame(width: 4.5, height: 4.5)
-                    .animation(.easeInOut(duration: 0.4), value: animatingDot)
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { startDotAnimation() }
-        .onDisappear { stopDotAnimation() }
-    }
-
-    private func startDotAnimation() {
-        dotAnimationTimer?.invalidate()
-        dotAnimationTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
-            DispatchQueue.main.async {
-                animatingDot = (animatingDot + 1) % 3
-            }
-        }
-    }
-
-    private func stopDotAnimation() {
-        dotAnimationTimer?.invalidate()
-        dotAnimationTimer = nil
+        Circle()
+            .trim(from: 0.14, to: 0.82)
+            .stroke(
+                Color.white,
+                style: StrokeStyle(lineWidth: 2.2, lineCap: .round)
+            )
+            .frame(width: 14, height: 14)
+            .rotationEffect(.degrees(isAnimating ? 360 : 0))
+            .animation(
+                .linear(duration: 0.75).repeatForever(autoreverses: false),
+                value: isAnimating
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onAppear { isAnimating = true }
+            .onDisappear { isAnimating = false }
     }
 }


### PR DESCRIPTION
## Summary
- Replace the fixed recording level smoothing with a dynamic live audio level normalizer so the waveform responds more naturally across quiet and loud input.
- Make the transcribing transition use the existing overlay window, locking width during the phase change instead of swapping panels.
- Simplify the transcribing indicator into a compact spinner and tighten the delay before the transcribing state appears.
- Adjust waveform animation so the bars move with a softer, more layered spring effect.

## Testing
- Not run
- Visually checked the overlay transition flow in code for recording, transcribing, and done states.
- Verified the audio level reset paths are called when recording starts and stops so the normalizer does not carry state between sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcribing indicator now appears faster (0.25s) with smoother transition into transcribing.
  * More accurate, dynamically normalized audio level meter for clearer, stable visual feedback.
  * Added a rotating transcribing spinner and a dedicated "Done" checkmark.
  * Per-bar waveform animations for richer, more responsive visuals.

* **Bug Fixes / UX**
  * Unified overlay sizing, improved visibility rules, and smoother transitions between recording → transcribing → done.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->