### PR TITLE
Make transcription, cleanup, and context models configurable

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -38,17 +38,23 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     private let apiKey: String
     private let baseURL: String
     private let customContextPrompt: String
-    private let fallbackTextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
-    private let visionModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    private let contextModel: String
     private let maxScreenshotDataURILength = 500_000
     private let screenshotCompressionPrimary = 0.5
     private let screenshotMaxDimension: CGFloat = 1024
     private let contextRequestTimeoutSeconds: TimeInterval = 20
 
-    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1", customContextPrompt: String = "") {
+    init(
+        apiKey: String,
+        baseURL: String = "https://api.groq.com/openai/v1",
+        customContextPrompt: String = "",
+        contextModel: String = "meta-llama/llama-4-scout-17b-16e-instruct"
+    ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.customContextPrompt = customContextPrompt
+        let trimmedModel = contextModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.contextModel = trimmedModel.isEmpty ? "meta-llama/llama-4-scout-17b-16e-instruct" : trimmedModel
     }
 
     func collectSelectionSnapshot() -> AppSelectionSnapshot {
@@ -149,20 +155,19 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         selectedText: String?,
         screenshotDataURL: String?
     ) async -> (activity: String, prompt: String)? {
-        let modelsToTry = [
-            screenshotDataURL != nil ? visionModel : fallbackTextModel,
-            fallbackTextModel
+        let attempts: [(model: String, screenshotDataURL: String?)] = [
+            (contextModel, screenshotDataURL),
+            (contextModel, nil)
         ]
 
-        for model in modelsToTry {
-            let screenshotPayload = model == visionModel ? screenshotDataURL : nil
+        for attempt in attempts {
             if let inferred = await inferActivityWithLLM(
                 appName: appName,
                 bundleIdentifier: bundleIdentifier,
                 windowTitle: windowTitle,
                 selectedText: selectedText,
-                screenshotDataURL: screenshotPayload,
-                model: model
+                screenshotDataURL: attempt.screenshotDataURL,
+                model: attempt.model
             ) {
                 return inferred
             }

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -155,10 +155,17 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         selectedText: String?,
         screenshotDataURL: String?
     ) async -> (activity: String, prompt: String)? {
-        let attempts: [(model: String, screenshotDataURL: String?)] = [
-            (contextModel, screenshotDataURL),
-            (contextModel, nil)
-        ]
+        let attempts: [(model: String, screenshotDataURL: String?)] =
+            if let screenshotDataURL {
+                [
+                    (contextModel, screenshotDataURL),
+                    (contextModel, nil)
+                ]
+            } else {
+                [
+                    (contextModel, nil)
+                ]
+            }
 
         for attempt in attempts {
             if let inferred = await inferActivityWithLLM(

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -165,6 +165,9 @@ private enum SessionIntent {
 final class AppState: ObservableObject, @unchecked Sendable {
     private let apiKeyStorageKey = "groq_api_key"
     private let apiBaseURLStorageKey = "api_base_url"
+    private let transcriptionModelStorageKey = "transcription_model"
+    private let postProcessingModelStorageKey = "post_processing_model"
+    private let contextModelStorageKey = "context_model"
     private let holdShortcutStorageKey = "hold_shortcut"
     private let toggleShortcutStorageKey = "toggle_shortcut"
     private let savedHoldCustomShortcutStorageKey = "saved_hold_custom_shortcut"
@@ -186,6 +189,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let transcribingIndicatorDelay: TimeInterval = 0.25
     private let clipboardRestoreDelay: TimeInterval = 0.15
     let maxPipelineHistoryCount = 20
+    static let defaultTranscriptionModel = "whisper-large-v3"
+    static let defaultPostProcessingModel = "openai/gpt-oss-20b"
+    static let defaultContextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
 
     @Published var hasCompletedSetup: Bool {
         didSet {
@@ -196,14 +202,33 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var apiKey: String {
         didSet {
             persistAPIKey(apiKey)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
         }
     }
 
     @Published var apiBaseURL: String {
         didSet {
             persistAPIBaseURL(apiBaseURL)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
+        }
+    }
+
+    @Published var transcriptionModel: String {
+        didSet {
+            UserDefaults.standard.set(transcriptionModel, forKey: transcriptionModelStorageKey)
+        }
+    }
+
+    @Published var postProcessingModel: String {
+        didSet {
+            UserDefaults.standard.set(postProcessingModel, forKey: postProcessingModelStorageKey)
+        }
+    }
+
+    @Published var contextModel: String {
+        didSet {
+            UserDefaults.standard.set(contextModel, forKey: contextModelStorageKey)
+            rebuildContextService()
         }
     }
 
@@ -266,7 +291,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var customContextPrompt: String {
         didSet {
             UserDefaults.standard.set(customContextPrompt, forKey: customContextPromptStorageKey)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
         }
     }
 
@@ -379,6 +404,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let hasCompletedSetup = UserDefaults.standard.bool(forKey: "hasCompletedSetup")
         let apiKey = Self.loadStoredAPIKey(account: apiKeyStorageKey)
         let apiBaseURL = Self.loadStoredAPIBaseURL(account: "api_base_url")
+        let transcriptionModel = UserDefaults.standard.string(forKey: transcriptionModelStorageKey) ?? Self.defaultTranscriptionModel
+        let postProcessingModel = UserDefaults.standard.string(forKey: postProcessingModelStorageKey) ?? Self.defaultPostProcessingModel
+        let contextModel = UserDefaults.standard.string(forKey: contextModelStorageKey) ?? Self.defaultContextModel
         let shortcuts = Self.loadShortcutConfiguration(
             holdKey: holdShortcutStorageKey,
             toggleKey: toggleShortcutStorageKey
@@ -434,10 +462,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
 
-        self.contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+        self.contextService = AppContextService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            customContextPrompt: customContextPrompt,
+            contextModel: contextModel
+        )
         self.hasCompletedSetup = hasCompletedSetup
         self.apiKey = apiKey
         self.apiBaseURL = apiBaseURL
+        self.transcriptionModel = transcriptionModel
+        self.postProcessingModel = postProcessingModel
+        self.contextModel = contextModel
         self.holdShortcut = shortcuts.hold
         self.toggleShortcut = shortcuts.toggle
         self.savedHoldCustomShortcut = savedHoldCustomShortcut
@@ -552,6 +588,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func rebuildContextService() {
+        contextService = AppContextService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            customContextPrompt: customContextPrompt,
+            contextModel: contextModel
+        )
+    }
+
     private func persistShortcut(_ binding: ShortcutBinding, key: String) {
         guard let data = try? JSONEncoder().encode(binding) else { return }
         UserDefaults.standard.set(data, forKey: key)
@@ -647,9 +692,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let transcriptionService = TranscriptionService(
             apiKey: apiKey,
-            baseURL: apiBaseURL
+            baseURL: apiBaseURL,
+            transcriptionModel: transcriptionModel
         )
-        let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
+        let postProcessingService = PostProcessingService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            preferredModel: postProcessingModel
+        )
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
 
@@ -1644,9 +1694,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let transcriptionService = TranscriptionService(
             apiKey: apiKey,
-            baseURL: apiBaseURL
+            baseURL: apiBaseURL,
+            transcriptionModel: transcriptionModel
         )
-        let postProcessingService = PostProcessingService(apiKey: apiKey, baseURL: apiBaseURL)
+        let postProcessingService = PostProcessingService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            preferredModel: postProcessingModel
+        )
 
             self.transcriptionTask?.cancel()
             self.transcriptionTask = Task {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -167,6 +167,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let apiBaseURLStorageKey = "api_base_url"
     private let transcriptionModelStorageKey = "transcription_model"
     private let postProcessingModelStorageKey = "post_processing_model"
+    private let postProcessingFallbackModelStorageKey = "post_processing_fallback_model"
     private let contextModelStorageKey = "context_model"
     private let holdShortcutStorageKey = "hold_shortcut"
     private let toggleShortcutStorageKey = "toggle_shortcut"
@@ -191,6 +192,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     let maxPipelineHistoryCount = 20
     static let defaultTranscriptionModel = "whisper-large-v3"
     static let defaultPostProcessingModel = "openai/gpt-oss-20b"
+    static let defaultPostProcessingFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     static let defaultContextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
 
     @Published var hasCompletedSetup: Bool {
@@ -222,6 +224,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var postProcessingModel: String {
         didSet {
             UserDefaults.standard.set(postProcessingModel, forKey: postProcessingModelStorageKey)
+        }
+    }
+
+    @Published var postProcessingFallbackModel: String {
+        didSet {
+            UserDefaults.standard.set(postProcessingFallbackModel, forKey: postProcessingFallbackModelStorageKey)
         }
     }
 
@@ -406,6 +414,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let apiBaseURL = Self.loadStoredAPIBaseURL(account: "api_base_url")
         let transcriptionModel = UserDefaults.standard.string(forKey: transcriptionModelStorageKey) ?? Self.defaultTranscriptionModel
         let postProcessingModel = UserDefaults.standard.string(forKey: postProcessingModelStorageKey) ?? Self.defaultPostProcessingModel
+        let postProcessingFallbackModel = UserDefaults.standard.string(forKey: postProcessingFallbackModelStorageKey) ?? Self.defaultPostProcessingFallbackModel
         let contextModel = UserDefaults.standard.string(forKey: contextModelStorageKey) ?? Self.defaultContextModel
         let shortcuts = Self.loadShortcutConfiguration(
             holdKey: holdShortcutStorageKey,
@@ -473,6 +482,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.apiBaseURL = apiBaseURL
         self.transcriptionModel = transcriptionModel
         self.postProcessingModel = postProcessingModel
+        self.postProcessingFallbackModel = postProcessingFallbackModel
         self.contextModel = contextModel
         self.holdShortcut = shortcuts.hold
         self.toggleShortcut = shortcuts.toggle
@@ -698,7 +708,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
-            preferredModel: postProcessingModel
+            preferredModel: postProcessingModel,
+            preferredFallbackModel: postProcessingFallbackModel
         )
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
@@ -1700,7 +1711,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
-            preferredModel: postProcessingModel
+            preferredModel: postProcessingModel,
+            preferredFallbackModel: postProcessingFallbackModel
         )
 
             self.transcriptionTask?.cancel()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -554,7 +554,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private static let defaultAPIBaseURL = "https://api.groq.com/openai/v1"
+    static let defaultAPIBaseURL = "https://api.groq.com/openai/v1"
 
     private struct StoredShortcutConfiguration {
         let hold: ShortcutBinding
@@ -701,11 +701,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             screenshotError: nil
         )
 
-        let transcriptionService = TranscriptionService(
-            apiKey: apiKey,
-            baseURL: apiBaseURL,
-            transcriptionModel: transcriptionModel
-        )
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
@@ -717,6 +712,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         Task {
             do {
+                let transcriptionService = try TranscriptionService(
+                    apiKey: apiKey,
+                    baseURL: apiBaseURL,
+                    transcriptionModel: transcriptionModel
+                )
                 let rawTranscript = try await transcriptionService.transcribe(fileURL: audioURL)
 
                 let finalTranscript: String
@@ -1707,11 +1707,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 } catch {}
             }
 
-        let transcriptionService = TranscriptionService(
-            apiKey: apiKey,
-            baseURL: apiBaseURL,
-            transcriptionModel: transcriptionModel
-        )
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
@@ -1722,6 +1717,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.transcriptionTask?.cancel()
             self.transcriptionTask = Task {
                 do {
+                    let transcriptionService = try TranscriptionService(
+                        apiKey: self.apiKey,
+                        baseURL: self.apiBaseURL,
+                        transcriptionModel: self.transcriptionModel
+                    )
                     async let transcript = transcriptionService.transcribe(fileURL: transcriptionFileURL)
                     let rawTranscript = try await transcript
                     try Task.checkCancellation()

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -115,19 +115,22 @@ Behavior:
     private let apiKey: String
     private let baseURL: String
     private let preferredModel: String
+    private let preferredFallbackModel: String
     private let defaultModel = "openai/gpt-oss-20b"
-    private let fallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    private let defaultFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let postProcessingMaxCompletionTokens = 4096
     private let postProcessingTimeoutSeconds: TimeInterval = 20
 
     init(
         apiKey: String,
         baseURL: String = "https://api.groq.com/openai/v1",
-        preferredModel: String = ""
+        preferredModel: String = "",
+        preferredFallbackModel: String = ""
     ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.preferredModel = preferredModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.preferredFallbackModel = preferredFallbackModel.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     func postProcess(
@@ -248,11 +251,12 @@ Behavior:
             guard shouldFallback else {
                 throw error
             }
-
-            guard let retryModel else {
-                throw error
-            }
         }
+
+        guard let retryModel else {
+            throw PostProcessingError.emptyOutput
+        }
+
         return try await process(
             transcript: transcript,
             contextSummary: contextSummary,
@@ -292,11 +296,12 @@ Behavior:
             guard shouldFallback else {
                 throw error
             }
-
-            guard let retryModel else {
-                throw error
-            }
         }
+
+        guard let retryModel else {
+            throw PostProcessingError.emptyOutput
+        }
+
         return try await processCommandTransform(
             selectedText: selectedText,
             voiceCommand: voiceCommand,
@@ -311,10 +316,13 @@ Behavior:
     }
 
     private func resolvedRetryModel(for primaryModel: String) -> String? {
-        if primaryModel == defaultModel {
-            return fallbackModel
+        if !preferredFallbackModel.isEmpty {
+            return preferredFallbackModel == primaryModel ? nil : preferredFallbackModel
         }
-        if primaryModel == fallbackModel {
+        if primaryModel == defaultModel {
+            return defaultFallbackModel
+        }
+        if primaryModel == defaultFallbackModel {
             return defaultModel
         }
         return nil

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -248,6 +248,10 @@ Behavior:
             guard shouldFallback else {
                 throw error
             }
+
+            guard let retryModel else {
+                throw error
+            }
         }
         return try await process(
             transcript: transcript,
@@ -288,6 +292,10 @@ Behavior:
             guard shouldFallback else {
                 throw error
             }
+
+            guard let retryModel else {
+                throw error
+            }
         }
         return try await processCommandTransform(
             selectedText: selectedText,
@@ -302,14 +310,14 @@ Behavior:
         preferredModel.isEmpty ? defaultModel : preferredModel
     }
 
-    private func resolvedRetryModel(for primaryModel: String) -> String {
+    private func resolvedRetryModel(for primaryModel: String) -> String? {
         if primaryModel == defaultModel {
             return fallbackModel
         }
         if primaryModel == fallbackModel {
             return defaultModel
         }
-        return defaultModel
+        return nil
     }
 
     private func process(

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -224,8 +224,8 @@ Behavior:
         customVocabulary: [String],
         customSystemPrompt: String = ""
     ) async throws -> PostProcessingResult {
-        let primaryModel = preferredModel.isEmpty ? defaultModel : preferredModel
-        let retryModel = preferredModel.isEmpty ? fallbackModel : preferredModel
+        let primaryModel = resolvedPrimaryModel()
+        let retryModel = resolvedRetryModel(for: primaryModel)
         do {
             return try await process(
                 transcript: transcript,
@@ -249,7 +249,6 @@ Behavior:
                 throw error
             }
         }
-
         return try await process(
             transcript: transcript,
             contextSummary: contextSummary,
@@ -265,8 +264,8 @@ Behavior:
         contextSummary: String,
         customVocabulary: [String]
     ) async throws -> PostProcessingResult {
-        let primaryModel = preferredModel.isEmpty ? defaultModel : preferredModel
-        let retryModel = preferredModel.isEmpty ? fallbackModel : preferredModel
+        let primaryModel = resolvedPrimaryModel()
+        let retryModel = resolvedRetryModel(for: primaryModel)
         do {
             return try await processCommandTransform(
                 selectedText: selectedText,
@@ -290,7 +289,6 @@ Behavior:
                 throw error
             }
         }
-
         return try await processCommandTransform(
             selectedText: selectedText,
             voiceCommand: voiceCommand,
@@ -298,6 +296,20 @@ Behavior:
             model: retryModel,
             customVocabulary: customVocabulary
         )
+    }
+
+    private func resolvedPrimaryModel() -> String {
+        preferredModel.isEmpty ? defaultModel : preferredModel
+    }
+
+    private func resolvedRetryModel(for primaryModel: String) -> String {
+        if primaryModel == defaultModel {
+            return fallbackModel
+        }
+        if primaryModel == fallbackModel {
+            return defaultModel
+        }
+        return defaultModel
     }
 
     private func process(

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -114,14 +114,20 @@ Behavior:
 
     private let apiKey: String
     private let baseURL: String
+    private let preferredModel: String
     private let defaultModel = "openai/gpt-oss-20b"
     private let fallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let postProcessingMaxCompletionTokens = 4096
     private let postProcessingTimeoutSeconds: TimeInterval = 20
 
-    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1") {
+    init(
+        apiKey: String,
+        baseURL: String = "https://api.groq.com/openai/v1",
+        preferredModel: String = ""
+    ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
+        self.preferredModel = preferredModel.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     func postProcess(
@@ -218,11 +224,12 @@ Behavior:
         customVocabulary: [String],
         customSystemPrompt: String = ""
     ) async throws -> PostProcessingResult {
+        let primaryModel = preferredModel.isEmpty ? defaultModel : preferredModel
         do {
             return try await process(
                 transcript: transcript,
                 contextSummary: contextSummary,
-                model: defaultModel,
+                model: primaryModel,
                 customVocabulary: customVocabulary,
                 customSystemPrompt: customSystemPrompt
             )
@@ -257,12 +264,13 @@ Behavior:
         contextSummary: String,
         customVocabulary: [String]
     ) async throws -> PostProcessingResult {
+        let primaryModel = preferredModel.isEmpty ? defaultModel : preferredModel
         do {
             return try await processCommandTransform(
                 selectedText: selectedText,
                 voiceCommand: voiceCommand,
                 contextSummary: contextSummary,
-                model: defaultModel,
+                model: primaryModel,
                 customVocabulary: customVocabulary
             )
         } catch let error as PostProcessingError {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -252,19 +252,19 @@ Behavior:
             guard shouldFallback else {
                 throw error
             }
-        }
 
-        guard let retryModel else {
-            throw PostProcessingError.emptyOutput
-        }
+            guard let retryModel else {
+                throw error
+            }
 
-        return try await process(
-            transcript: transcript,
-            contextSummary: contextSummary,
-            model: retryModel,
-            customVocabulary: customVocabulary,
-            customSystemPrompt: customSystemPrompt
-        )
+            return try await process(
+                transcript: transcript,
+                contextSummary: contextSummary,
+                model: retryModel,
+                customVocabulary: customVocabulary,
+                customSystemPrompt: customSystemPrompt
+            )
+        }
     }
 
     private func processCommandTransformWithFallback(
@@ -297,19 +297,19 @@ Behavior:
             guard shouldFallback else {
                 throw error
             }
-        }
 
-        guard let retryModel else {
-            throw PostProcessingError.emptyOutput
-        }
+            guard let retryModel else {
+                throw error
+            }
 
-        return try await processCommandTransform(
-            selectedText: selectedText,
-            voiceCommand: voiceCommand,
-            contextSummary: contextSummary,
-            model: retryModel,
-            customVocabulary: customVocabulary
-        )
+            return try await processCommandTransform(
+                selectedText: selectedText,
+                voiceCommand: voiceCommand,
+                contextSummary: contextSummary,
+                model: retryModel,
+                customVocabulary: customVocabulary
+            )
+        }
     }
 
     private func resolvedPrimaryModel() -> String {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -225,6 +225,7 @@ Behavior:
         customSystemPrompt: String = ""
     ) async throws -> PostProcessingResult {
         let primaryModel = preferredModel.isEmpty ? defaultModel : preferredModel
+        let retryModel = preferredModel.isEmpty ? fallbackModel : preferredModel
         do {
             return try await process(
                 transcript: transcript,
@@ -252,7 +253,7 @@ Behavior:
         return try await process(
             transcript: transcript,
             contextSummary: contextSummary,
-            model: fallbackModel,
+            model: retryModel,
             customVocabulary: customVocabulary,
             customSystemPrompt: customSystemPrompt
         )
@@ -265,6 +266,7 @@ Behavior:
         customVocabulary: [String]
     ) async throws -> PostProcessingResult {
         let primaryModel = preferredModel.isEmpty ? defaultModel : preferredModel
+        let retryModel = preferredModel.isEmpty ? fallbackModel : preferredModel
         do {
             return try await processCommandTransform(
                 selectedText: selectedText,
@@ -293,7 +295,7 @@ Behavior:
             selectedText: selectedText,
             voiceCommand: voiceCommand,
             contextSummary: contextSummary,
-            model: fallbackModel,
+            model: retryModel,
             customVocabulary: customVocabulary
         )
     }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -234,6 +234,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("API Key", icon: "key.fill") {
                     apiKeySection
                 }
+                SettingsCard("Models", icon: "cpu.fill") {
+                    modelsSection
+                }
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
                 }
@@ -466,6 +469,44 @@ struct GeneralSettingsView: View {
                     appState.apiBaseURL = "https://api.groq.com/openai/v1"
                 }
                 .font(.caption)
+            }
+        }
+    }
+
+    private var modelsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Override the default models used for transcription, cleanup, and context inference.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Transcription Model")
+                    .font(.caption.weight(.semibold))
+                TextField(AppState.defaultTranscriptionModel, text: $appState.transcriptionModel)
+                    .textFieldStyle(.roundedBorder)
+                Text("Used for requests to `/audio/transcriptions`.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Post-Processing Model")
+                    .font(.caption.weight(.semibold))
+                TextField(AppState.defaultPostProcessingModel, text: $appState.postProcessingModel)
+                    .textFieldStyle(.roundedBorder)
+                Text("Used for transcript cleanup and Edit Mode transforms.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Context Model")
+                    .font(.caption.weight(.semibold))
+                TextField(AppState.defaultContextModel, text: $appState.contextModel)
+                    .textFieldStyle(.roundedBorder)
+                Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -1007,7 +1048,11 @@ struct PromptsSettingsView: View {
         systemTestError = nil
         systemTestPrompt = nil
 
-        let service = PostProcessingService(apiKey: appState.apiKey, baseURL: appState.apiBaseURL)
+        let service = PostProcessingService(
+            apiKey: appState.apiKey,
+            baseURL: appState.apiBaseURL,
+            preferredModel: appState.postProcessingModel
+        )
         let input = systemTestInput
         let customPrompt = appState.customSystemPrompt
         let vocabulary = appState.customVocabulary
@@ -1223,7 +1268,8 @@ struct PromptsSettingsView: View {
         let service = AppContextService(
             apiKey: appState.apiKey,
             baseURL: appState.apiBaseURL,
-            customContextPrompt: appState.customContextPrompt
+            customContextPrompt: appState.customContextPrompt,
+            contextModel: appState.contextModel
         )
 
         Task {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -96,6 +96,7 @@ struct GeneralSettingsView: View {
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
     @State private var apiKeyInput: String = ""
     @State private var apiBaseURLInput: String = ""
+    @State private var advancedProviderSettingsExpanded = false
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
@@ -233,9 +234,6 @@ struct GeneralSettingsView: View {
                 }
                 SettingsCard("API Key", icon: "key.fill") {
                     apiKeySection
-                }
-                SettingsCard("Models", icon: "cpu.fill") {
-                    modelsSection
                 }
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
@@ -444,32 +442,48 @@ struct GeneralSettingsView: View {
                     .font(.caption)
             }
 
-            Divider()
+            DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Divider()
 
-            Text("API Base URL")
-                .font(.caption.weight(.semibold))
+                    Text("API Base URL")
+                        .font(.caption.weight(.semibold))
 
-            Text("Change this to use a different OpenAI-compatible API provider.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                    Text("Change this to use a different OpenAI-compatible API provider.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
 
-            HStack(spacing: 8) {
-                TextField("https://api.groq.com/openai/v1", text: $apiBaseURLInput)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
-                    .onChange(of: apiBaseURLInput) { newValue in
-                        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !trimmed.isEmpty {
-                            appState.apiBaseURL = trimmed
+                    HStack(spacing: 8) {
+                        TextField("https://api.groq.com/openai/v1", text: $apiBaseURLInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                            .onChange(of: apiBaseURLInput) { newValue in
+                                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    appState.apiBaseURL = trimmed
+                                }
+                            }
+
+                        Button("Reset to Default") {
+                            apiBaseURLInput = "https://api.groq.com/openai/v1"
+                            appState.apiBaseURL = "https://api.groq.com/openai/v1"
                         }
+                        .font(.caption)
                     }
 
-                Button("Reset to Default") {
-                    apiBaseURLInput = "https://api.groq.com/openai/v1"
-                    appState.apiBaseURL = "https://api.groq.com/openai/v1"
+                    modelsSection
                 }
-                .font(.caption)
+            } label: {
+                HStack {
+                    Text("Advanced Provider Settings")
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    advancedProviderSettingsExpanded.toggle()
+                }
             }
+            .padding(.top, 4)
         }
     }
 
@@ -480,8 +494,15 @@ struct GeneralSettingsView: View {
                 .foregroundStyle(.secondary)
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Transcription Model")
-                    .font(.caption.weight(.semibold))
+                HStack {
+                    Text("Transcription Model")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Button("Reset to Default") {
+                        appState.transcriptionModel = AppState.defaultTranscriptionModel
+                    }
+                    .font(.caption)
+                }
                 TextField(AppState.defaultTranscriptionModel, text: $appState.transcriptionModel)
                     .textFieldStyle(.roundedBorder)
                 Text("Used for requests to `/audio/transcriptions`.")
@@ -490,8 +511,15 @@ struct GeneralSettingsView: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Post-Processing Model")
-                    .font(.caption.weight(.semibold))
+                HStack {
+                    Text("Post-Processing Model")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Button("Reset to Default") {
+                        appState.postProcessingModel = AppState.defaultPostProcessingModel
+                    }
+                    .font(.caption)
+                }
                 TextField(AppState.defaultPostProcessingModel, text: $appState.postProcessingModel)
                     .textFieldStyle(.roundedBorder)
                 Text("Used for transcript cleanup and Edit Mode transforms.")
@@ -500,8 +528,32 @@ struct GeneralSettingsView: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Context Model")
-                    .font(.caption.weight(.semibold))
+                HStack {
+                    Text("Post-Processing Fallback Model")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Button("Reset to Default") {
+                        appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
+                    }
+                    .font(.caption)
+                }
+                TextField(AppState.defaultPostProcessingFallbackModel, text: $appState.postProcessingFallbackModel)
+                    .textFieldStyle(.roundedBorder)
+                Text("Used as the explicit retry model for transcript cleanup and Edit Mode transforms.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("Context Model")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Button("Reset to Default") {
+                        appState.contextModel = AppState.defaultContextModel
+                    }
+                    .font(.caption)
+                }
                 TextField(AppState.defaultContextModel, text: $appState.contextModel)
                     .textFieldStyle(.roundedBorder)
                 Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
@@ -1051,7 +1103,8 @@ struct PromptsSettingsView: View {
         let service = PostProcessingService(
             apiKey: appState.apiKey,
             baseURL: appState.apiBaseURL,
-            preferredModel: appState.postProcessingModel
+            preferredModel: appState.postProcessingModel,
+            preferredFallbackModel: appState.postProcessingFallbackModel
         )
         let input = systemTestInput
         let customPrompt = appState.customSystemPrompt

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -41,8 +41,16 @@ private let iso8601DayFormatter: DateFormatter = {
 struct ProviderSettingsFields: View {
     @EnvironmentObject var appState: AppState
     @Binding var apiBaseURLInput: String
+    @FocusState private var isEditingAPIBaseURL: Bool
 
     let showsModelDescription: Bool
+
+    private func commitAPIBaseURL() {
+        let trimmed = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = trimmed.isEmpty ? AppState.defaultAPIBaseURL : trimmed
+        apiBaseURLInput = resolvedBaseURL
+        appState.apiBaseURL = resolvedBaseURL
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -54,19 +62,22 @@ struct ProviderSettingsFields: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 8) {
-                TextField("https://api.groq.com/openai/v1", text: $apiBaseURLInput)
+                TextField(AppState.defaultAPIBaseURL, text: $apiBaseURLInput)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
-                    .onChange(of: apiBaseURLInput) { newValue in
-                        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !trimmed.isEmpty {
-                            appState.apiBaseURL = trimmed
+                    .focused($isEditingAPIBaseURL)
+                    .onSubmit {
+                        commitAPIBaseURL()
+                    }
+                    .onChange(of: isEditingAPIBaseURL) { isEditing in
+                        if !isEditing {
+                            commitAPIBaseURL()
                         }
                     }
 
                 Button("Reset to Default") {
-                    apiBaseURLInput = "https://api.groq.com/openai/v1"
-                    appState.apiBaseURL = "https://api.groq.com/openai/v1"
+                    apiBaseURLInput = AppState.defaultAPIBaseURL
+                    appState.apiBaseURL = AppState.defaultAPIBaseURL
                 }
                 .font(.caption)
             }
@@ -578,7 +589,10 @@ struct GeneralSettingsView: View {
         keyValidationSuccess = false
 
         Task {
-            let valid = await TranscriptionService.validateAPIKey(key, baseURL: baseURL.isEmpty ? "https://api.groq.com/openai/v1" : baseURL)
+            let valid = await TranscriptionService.validateAPIKey(
+                key,
+                baseURL: baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
+            )
             await MainActor.run {
                 isValidatingKey = false
                 if valid {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -42,6 +42,14 @@ struct ProviderSettingsFields: View {
     @EnvironmentObject var appState: AppState
     @Binding var apiBaseURLInput: String
     @FocusState private var isEditingAPIBaseURL: Bool
+    @FocusState private var isEditingTranscriptionModel: Bool
+    @FocusState private var isEditingPostProcessingModel: Bool
+    @FocusState private var isEditingPostProcessingFallbackModel: Bool
+    @FocusState private var isEditingContextModel: Bool
+    @State private var transcriptionModelDraft: String = ""
+    @State private var postProcessingModelDraft: String = ""
+    @State private var postProcessingFallbackModelDraft: String = ""
+    @State private var contextModelDraft: String = ""
 
     let showsModelDescription: Bool
 
@@ -50,6 +58,34 @@ struct ProviderSettingsFields: View {
         let resolvedBaseURL = trimmed.isEmpty ? AppState.defaultAPIBaseURL : trimmed
         apiBaseURLInput = resolvedBaseURL
         appState.apiBaseURL = resolvedBaseURL
+    }
+
+    private func commitTranscriptionModel() {
+        let trimmed = transcriptionModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        transcriptionModelDraft = trimmed
+        guard appState.transcriptionModel != trimmed else { return }
+        appState.transcriptionModel = trimmed
+    }
+
+    private func commitPostProcessingModel() {
+        let trimmed = postProcessingModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        postProcessingModelDraft = trimmed
+        guard appState.postProcessingModel != trimmed else { return }
+        appState.postProcessingModel = trimmed
+    }
+
+    private func commitPostProcessingFallbackModel() {
+        let trimmed = postProcessingFallbackModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        postProcessingFallbackModelDraft = trimmed
+        guard appState.postProcessingFallbackModel != trimmed else { return }
+        appState.postProcessingFallbackModel = trimmed
+    }
+
+    private func commitContextModel() {
+        let trimmed = contextModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        contextModelDraft = trimmed
+        guard appState.contextModel != trimmed else { return }
+        appState.contextModel = trimmed
     }
 
     var body: some View {
@@ -92,9 +128,19 @@ struct ProviderSettingsFields: View {
                 Text("Transcription Model")
                     .font(.caption.weight(.semibold))
                 HStack(spacing: 8) {
-                    TextField(AppState.defaultTranscriptionModel, text: $appState.transcriptionModel)
+                    TextField(AppState.defaultTranscriptionModel, text: $transcriptionModelDraft)
                         .textFieldStyle(.roundedBorder)
+                        .focused($isEditingTranscriptionModel)
+                        .onSubmit {
+                            commitTranscriptionModel()
+                        }
+                        .onChange(of: isEditingTranscriptionModel) { isEditing in
+                            if !isEditing {
+                                commitTranscriptionModel()
+                            }
+                        }
                     Button("Reset to Default") {
+                        transcriptionModelDraft = AppState.defaultTranscriptionModel
                         appState.transcriptionModel = AppState.defaultTranscriptionModel
                     }
                     .font(.caption)
@@ -108,9 +154,19 @@ struct ProviderSettingsFields: View {
                 Text("Post-Processing Model")
                     .font(.caption.weight(.semibold))
                 HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingModel, text: $appState.postProcessingModel)
+                    TextField(AppState.defaultPostProcessingModel, text: $postProcessingModelDraft)
                         .textFieldStyle(.roundedBorder)
+                        .focused($isEditingPostProcessingModel)
+                        .onSubmit {
+                            commitPostProcessingModel()
+                        }
+                        .onChange(of: isEditingPostProcessingModel) { isEditing in
+                            if !isEditing {
+                                commitPostProcessingModel()
+                            }
+                        }
                     Button("Reset to Default") {
+                        postProcessingModelDraft = AppState.defaultPostProcessingModel
                         appState.postProcessingModel = AppState.defaultPostProcessingModel
                     }
                     .font(.caption)
@@ -124,9 +180,19 @@ struct ProviderSettingsFields: View {
                 Text("Post-Processing Fallback Model")
                     .font(.caption.weight(.semibold))
                 HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingFallbackModel, text: $appState.postProcessingFallbackModel)
+                    TextField(AppState.defaultPostProcessingFallbackModel, text: $postProcessingFallbackModelDraft)
                         .textFieldStyle(.roundedBorder)
+                        .focused($isEditingPostProcessingFallbackModel)
+                        .onSubmit {
+                            commitPostProcessingFallbackModel()
+                        }
+                        .onChange(of: isEditingPostProcessingFallbackModel) { isEditing in
+                            if !isEditing {
+                                commitPostProcessingFallbackModel()
+                            }
+                        }
                     Button("Reset to Default") {
+                        postProcessingFallbackModelDraft = AppState.defaultPostProcessingFallbackModel
                         appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
                     }
                     .font(.caption)
@@ -140,9 +206,19 @@ struct ProviderSettingsFields: View {
                 Text("Context Model")
                     .font(.caption.weight(.semibold))
                 HStack(spacing: 8) {
-                    TextField(AppState.defaultContextModel, text: $appState.contextModel)
+                    TextField(AppState.defaultContextModel, text: $contextModelDraft)
                         .textFieldStyle(.roundedBorder)
+                        .focused($isEditingContextModel)
+                        .onSubmit {
+                            commitContextModel()
+                        }
+                        .onChange(of: isEditingContextModel) { isEditing in
+                            if !isEditing {
+                                commitContextModel()
+                            }
+                        }
                     Button("Reset to Default") {
+                        contextModelDraft = AppState.defaultContextModel
                         appState.contextModel = AppState.defaultContextModel
                     }
                     .font(.caption)
@@ -150,6 +226,32 @@ struct ProviderSettingsFields: View {
                 Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+        }
+        .onAppear {
+            transcriptionModelDraft = appState.transcriptionModel
+            postProcessingModelDraft = appState.postProcessingModel
+            postProcessingFallbackModelDraft = appState.postProcessingFallbackModel
+            contextModelDraft = appState.contextModel
+        }
+        .onChange(of: appState.transcriptionModel) { value in
+            if !isEditingTranscriptionModel {
+                transcriptionModelDraft = value
+            }
+        }
+        .onChange(of: appState.postProcessingModel) { value in
+            if !isEditingPostProcessingModel {
+                postProcessingModelDraft = value
+            }
+        }
+        .onChange(of: appState.postProcessingFallbackModel) { value in
+            if !isEditingPostProcessingFallbackModel {
+                postProcessingFallbackModelDraft = value
+            }
+        }
+        .onChange(of: appState.contextModel) { value in
+            if !isEditingContextModel {
+                contextModelDraft = value
             }
         }
     }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -494,68 +494,64 @@ struct GeneralSettingsView: View {
                 .foregroundStyle(.secondary)
 
             VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Text("Transcription Model")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
+                Text("Transcription Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultTranscriptionModel, text: $appState.transcriptionModel)
+                        .textFieldStyle(.roundedBorder)
                     Button("Reset to Default") {
                         appState.transcriptionModel = AppState.defaultTranscriptionModel
                     }
                     .font(.caption)
                 }
-                TextField(AppState.defaultTranscriptionModel, text: $appState.transcriptionModel)
-                    .textFieldStyle(.roundedBorder)
-                Text("Used for requests to `/audio/transcriptions`.")
+                Text("Used for speech-to-text transcription.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Text("Post-Processing Model")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
+                Text("Post-Processing Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultPostProcessingModel, text: $appState.postProcessingModel)
+                        .textFieldStyle(.roundedBorder)
                     Button("Reset to Default") {
                         appState.postProcessingModel = AppState.defaultPostProcessingModel
                     }
                     .font(.caption)
                 }
-                TextField(AppState.defaultPostProcessingModel, text: $appState.postProcessingModel)
-                    .textFieldStyle(.roundedBorder)
                 Text("Used for transcript cleanup and Edit Mode transforms.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Text("Post-Processing Fallback Model")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
+                Text("Post-Processing Fallback Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultPostProcessingFallbackModel, text: $appState.postProcessingFallbackModel)
+                        .textFieldStyle(.roundedBorder)
                     Button("Reset to Default") {
                         appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
                     }
                     .font(.caption)
                 }
-                TextField(AppState.defaultPostProcessingFallbackModel, text: $appState.postProcessingFallbackModel)
-                    .textFieldStyle(.roundedBorder)
                 Text("Used as the explicit retry model for transcript cleanup and Edit Mode transforms.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Text("Context Model")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
+                Text("Context Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultContextModel, text: $appState.contextModel)
+                        .textFieldStyle(.roundedBorder)
                     Button("Reset to Default") {
                         appState.contextModel = AppState.defaultContextModel
                     }
                     .font(.caption)
                 }
-                TextField(AppState.defaultContextModel, text: $appState.contextModel)
-                    .textFieldStyle(.roundedBorder)
                 Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -414,7 +414,7 @@ struct GeneralSettingsView: View {
 
     private var apiKeySection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("FreeFlow uses Groq's whisper-large-v3 model for transcription.")
+            Text("FreeFlow uses the configured transcription model with your selected OpenAI-compatible provider.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -1526,7 +1526,7 @@ struct RunLogEntryView: View {
                             title: "Transcribe Audio",
                             content: {
                                 VStack(alignment: .leading, spacing: 4) {
-                                    Text("Sent audio to Groq whisper-large-v3")
+                                    Text("Sent audio to \(AppState.defaultTranscriptionModel)")
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                         .textSelection(.enabled)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1526,7 +1526,7 @@ struct RunLogEntryView: View {
                             title: "Transcribe Audio",
                             content: {
                                 VStack(alignment: .leading, spacing: 4) {
-                                    Text("Sent audio to \(AppState.defaultTranscriptionModel)")
+                                    Text("Sent audio to the configured transcription model")
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                         .textSelection(.enabled)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -38,6 +38,112 @@ private let iso8601DayFormatter: DateFormatter = {
     return formatter
 }()
 
+struct ProviderSettingsFields: View {
+    @EnvironmentObject var appState: AppState
+    @Binding var apiBaseURLInput: String
+
+    let showsModelDescription: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("API Base URL")
+                .font(.caption.weight(.semibold))
+
+            Text("Change this to use a different OpenAI-compatible API provider.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                TextField("https://api.groq.com/openai/v1", text: $apiBaseURLInput)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+                    .onChange(of: apiBaseURLInput) { newValue in
+                        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            appState.apiBaseURL = trimmed
+                        }
+                    }
+
+                Button("Reset to Default") {
+                    apiBaseURLInput = "https://api.groq.com/openai/v1"
+                    appState.apiBaseURL = "https://api.groq.com/openai/v1"
+                }
+                .font(.caption)
+            }
+
+            if showsModelDescription {
+                Text("If you use another provider, enter that provider's model IDs here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Transcription Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultTranscriptionModel, text: $appState.transcriptionModel)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Reset to Default") {
+                        appState.transcriptionModel = AppState.defaultTranscriptionModel
+                    }
+                    .font(.caption)
+                }
+                Text("Used for speech-to-text transcription.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Post-Processing Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultPostProcessingModel, text: $appState.postProcessingModel)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Reset to Default") {
+                        appState.postProcessingModel = AppState.defaultPostProcessingModel
+                    }
+                    .font(.caption)
+                }
+                Text("Used for transcript cleanup and Edit Mode transforms.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Post-Processing Fallback Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultPostProcessingFallbackModel, text: $appState.postProcessingFallbackModel)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Reset to Default") {
+                        appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
+                    }
+                    .font(.caption)
+                }
+                Text("Used as the explicit retry model for transcript cleanup and Edit Mode transforms.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Context Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField(AppState.defaultContextModel, text: $appState.contextModel)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Reset to Default") {
+                        appState.contextModel = AppState.defaultContextModel
+                    }
+                    .font(.caption)
+                }
+                Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
 // MARK: - Settings
 
 struct SettingsView: View {
@@ -445,33 +551,10 @@ struct GeneralSettingsView: View {
             DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
                 VStack(alignment: .leading, spacing: 12) {
                     Divider()
-
-                    Text("API Base URL")
-                        .font(.caption.weight(.semibold))
-
-                    Text("Change this to use a different OpenAI-compatible API provider.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    HStack(spacing: 8) {
-                        TextField("https://api.groq.com/openai/v1", text: $apiBaseURLInput)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
-                            .onChange(of: apiBaseURLInput) { newValue in
-                                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                                if !trimmed.isEmpty {
-                                    appState.apiBaseURL = trimmed
-                                }
-                            }
-
-                        Button("Reset to Default") {
-                            apiBaseURLInput = "https://api.groq.com/openai/v1"
-                            appState.apiBaseURL = "https://api.groq.com/openai/v1"
-                        }
-                        .font(.caption)
-                    }
-
-                    modelsSection
+                    ProviderSettingsFields(
+                        apiBaseURLInput: $apiBaseURLInput,
+                        showsModelDescription: false
+                    )
                 }
             } label: {
                 HStack {
@@ -484,78 +567,6 @@ struct GeneralSettingsView: View {
                 }
             }
             .padding(.top, 4)
-        }
-    }
-
-    private var modelsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Override the default models used for transcription, cleanup, and context inference.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Transcription Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultTranscriptionModel, text: $appState.transcriptionModel)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Reset to Default") {
-                        appState.transcriptionModel = AppState.defaultTranscriptionModel
-                    }
-                    .font(.caption)
-                }
-                Text("Used for speech-to-text transcription.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Post-Processing Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingModel, text: $appState.postProcessingModel)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Reset to Default") {
-                        appState.postProcessingModel = AppState.defaultPostProcessingModel
-                    }
-                    .font(.caption)
-                }
-                Text("Used for transcript cleanup and Edit Mode transforms.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Post-Processing Fallback Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingFallbackModel, text: $appState.postProcessingFallbackModel)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Reset to Default") {
-                        appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
-                    }
-                    .font(.caption)
-                }
-                Text("Used as the explicit retry model for transcript cleanup and Edit Mode transforms.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Context Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultContextModel, text: $appState.contextModel)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Reset to Default") {
-                        appState.contextModel = AppState.defaultContextModel
-                    }
-                    .font(.caption)
-                }
-                Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
         }
     }
 
@@ -574,7 +585,7 @@ struct GeneralSettingsView: View {
                     appState.apiKey = key
                     keyValidationSuccess = true
                 } else {
-                    keyValidationError = "Invalid API key. Please check and try again."
+                    keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
                 }
             }
         }

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1052,7 +1052,7 @@ struct SetupView: View {
     func validateAndContinue() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         let baseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedBaseURL = baseURL.isEmpty ? "https://api.groq.com/openai/v1" : baseURL
+        let resolvedBaseURL = baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
         appState.apiBaseURL = resolvedBaseURL
         isValidatingKey = true
         keyValidationError = nil

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1208,7 +1208,7 @@ struct SetupView: View {
 
                     Task {
                         do {
-                            let service = TranscriptionService(
+                            let service = try TranscriptionService(
                                 apiKey: appState.apiKey,
                                 baseURL: appState.apiBaseURL,
                                 transcriptionModel: appState.transcriptionModel

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -4,6 +4,48 @@ import Combine
 import Foundation
 import ServiceManagement
 
+private struct SetupProviderSettingsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var apiBaseURLInput: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Advanced Provider Settings")
+                    .font(.title2.weight(.semibold))
+                Text("Use these fields when pointing FreeFlow at another OpenAI-compatible provider or when you need custom model IDs.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+
+            Divider()
+
+            ScrollView {
+                ProviderSettingsFields(
+                    apiBaseURLInput: $apiBaseURLInput,
+                    showsModelDescription: true
+                )
+                .padding(20)
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Done") {
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(16)
+        }
+        .frame(width: 560, height: 520)
+    }
+}
+
 struct SetupView: View {
     var onComplete: () -> Void
     @EnvironmentObject var appState: AppState
@@ -28,8 +70,10 @@ struct SetupView: View {
     @State private var micPermissionGranted = false
     @State private var accessibilityGranted = false
     @State private var apiKeyInput: String = ""
+    @State private var apiBaseURLInput: String = ""
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
+    @State private var showingProviderSettingsSheet = false
     @State private var accessibilityTimer: Timer?
     @State private var screenRecordingTimer: Timer?
     @State private var customVocabularyInput: String = ""
@@ -141,6 +185,7 @@ struct SetupView: View {
         .frame(width: 520, height: 680)
         .onAppear {
             apiKeyInput = appState.apiKey
+            apiBaseURLInput = appState.apiBaseURL
             customVocabularyInput = appState.customVocabulary
             checkMicPermission()
             checkAccessibility()
@@ -152,6 +197,10 @@ struct SetupView: View {
             accessibilityTimer?.invalidate()
             screenRecordingTimer?.invalidate()
             appState.resumeHotkeyMonitoringAfterShortcutCapture()
+        }
+        .sheet(isPresented: $showingProviderSettingsSheet) {
+            SetupProviderSettingsSheet(apiBaseURLInput: $apiBaseURLInput)
+                .environmentObject(appState)
         }
         .onChange(of: isCapturingShortcut) { isCapturing in
             if isCapturing {
@@ -313,57 +362,96 @@ struct SetupView: View {
     }
 
     var apiKeyStep: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "key.fill")
-                .font(.system(size: 60))
-                .foregroundStyle(.blue)
+        VStack {
+            Spacer(minLength: 0)
 
-            Text("Groq API Key")
-                .font(.title)
-                .fontWeight(.bold)
+            VStack(spacing: 20) {
+                Image(systemName: "key.fill")
+                    .font(.system(size: 60))
+                    .foregroundStyle(.blue)
 
-            Text("FreeFlow uses Groq for fast, high-accuracy transcription.")
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+                Text("API Key")
+                    .font(.title)
+                    .fontWeight(.bold)
 
-            VStack(alignment: .leading, spacing: 10) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("How to get a free API key:")
-                        .font(.subheadline.weight(.semibold))
-                    VStack(alignment: .leading, spacing: 2) {
-                        instructionRow(number: "1", text: "Go to [console.groq.com/keys](https://console.groq.com/keys)")
-                        instructionRow(number: "2", text: "Create a free account (if you don't have one)")
-                        instructionRow(number: "3", text: "Click **Create API Key** and copy it")
-                    }
-                }
-                .padding(10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.blue.opacity(0.06))
-                )
+                Text("Enter an API key for your OpenAI-compatible provider. If you are not using Groq, expand the advanced provider settings and enter that provider's base URL and model IDs before continuing.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("API Key")
-                        .font(.headline)
-                    SecureField("Paste your Groq API key", text: $apiKeyInput)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(.body, design: .monospaced))
-                        .disabled(isValidatingKey)
-                        .onChange(of: apiKeyInput) { _ in
-                            keyValidationError = nil
+                VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Using Groq?")
+                            .font(.subheadline.weight(.semibold))
+                        VStack(alignment: .leading, spacing: 2) {
+                            instructionRow(number: "1", text: "Go to [console.groq.com/keys](https://console.groq.com/keys)")
+                            instructionRow(number: "2", text: "Create a free account (if you don't have one)")
+                            instructionRow(number: "3", text: "Click **Create API Key** and copy it")
                         }
-
-                    if let error = keyValidationError {
-                        Label(error, systemImage: "xmark.circle.fill")
-                            .foregroundStyle(.red)
-                            .font(.caption)
                     }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.blue.opacity(0.06))
+                    )
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("API Key")
+                            .font(.headline)
+                        SecureField("Paste your API key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                            .disabled(isValidatingKey)
+                            .onChange(of: apiKeyInput) { _ in
+                                keyValidationError = nil
+                            }
+
+                        if let error = keyValidationError {
+                            Label(error, systemImage: "xmark.circle.fill")
+                                .foregroundStyle(.red)
+                                .font(.caption)
+                        }
+                    }
+
+                    Button {
+                        showingProviderSettingsSheet = true
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "slider.horizontal.3")
+                                .foregroundStyle(.secondary)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Advanced Provider Settings")
+                                    .foregroundStyle(.primary)
+                                Text("Base URL and model IDs")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "arrow.up.right.square")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.55))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 8)
                 }
             }
+            .frame(maxWidth: 440)
 
+            Spacer(minLength: 0)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     var micPermissionStep: some View {
@@ -963,11 +1051,14 @@ struct SetupView: View {
 
     func validateAndContinue() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = baseURL.isEmpty ? "https://api.groq.com/openai/v1" : baseURL
+        appState.apiBaseURL = resolvedBaseURL
         isValidatingKey = true
         keyValidationError = nil
 
         Task {
-            let valid = await TranscriptionService.validateAPIKey(key, baseURL: appState.apiBaseURL)
+            let valid = await TranscriptionService.validateAPIKey(key, baseURL: resolvedBaseURL)
             await MainActor.run {
                 isValidatingKey = false
                 if valid {
@@ -976,7 +1067,7 @@ struct SetupView: View {
                         currentStep = nextStep(currentStep)
                     }
                 } else {
-                    keyValidationError = "Invalid API key. Please check and try again."
+                    keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
                 }
             }
         }
@@ -1120,6 +1211,7 @@ struct SetupView: View {
                             let service = TranscriptionService(
                                 apiKey: appState.apiKey,
                                 baseURL: appState.apiBaseURL,
+                                transcriptionModel: appState.transcriptionModel
                             )
                             let transcript = try await service.transcribe(fileURL: url)
                             await MainActor.run {

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -6,7 +6,7 @@ private let transcriptionLog = OSLog(subsystem: "com.zachlatta.freeflow", catego
 
 class TranscriptionService {
     private let apiKey: String
-    private let baseURL: String
+    private let baseURL: URL
     private let transcriptionModel: String
     private let transcriptionResponseFormat = "verbose_json"
     private let transcriptionTimeoutSeconds: TimeInterval = 20
@@ -17,9 +17,9 @@ class TranscriptionService {
         apiKey: String,
         baseURL: String = "https://api.groq.com/openai/v1",
         transcriptionModel: String = "whisper-large-v3"
-    ) {
+    ) throws {
         self.apiKey = apiKey
-        self.baseURL = baseURL
+        self.baseURL = try Self.normalizedBaseURL(from: baseURL)
         let trimmedModel = transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
         self.transcriptionModel = trimmedModel.isEmpty ? "whisper-large-v3" : trimmedModel
     }
@@ -28,8 +28,9 @@ class TranscriptionService {
     static func validateAPIKey(_ key: String, baseURL: String = "https://api.groq.com/openai/v1") async -> Bool {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
+        guard let baseURL = try? normalizedBaseURL(from: baseURL) else { return false }
 
-        var request = URLRequest(url: URL(string: "\(baseURL)/models")!)
+        var request = URLRequest(url: baseURL.appendingPathComponent("models"))
         request.timeoutInterval = 10
         request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
 
@@ -64,7 +65,9 @@ class TranscriptionService {
     }
 
     private func transcribeAudioWithURLSession(fileURL: URL) async throws -> String {
-        let url = URL(string: "\(baseURL)/audio/transcriptions")!
+        let url = baseURL
+            .appendingPathComponent("audio")
+            .appendingPathComponent("transcriptions")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = transcriptionTimeoutSeconds
@@ -194,6 +197,42 @@ class TranscriptionService {
             && format.commonFormat == .pcmFormatInt16
     }
 
+    private static func normalizedBaseURL(from baseURL: String) throws -> URL {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw TranscriptionError.invalidBaseURL("Provider URL is empty.")
+        }
+
+        guard var components = URLComponents(string: trimmed) else {
+            throw TranscriptionError.invalidBaseURL("Provider URL is malformed.")
+        }
+
+        guard let scheme = components.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            throw TranscriptionError.invalidBaseURL("Provider URL must use http or https.")
+        }
+
+        guard let host = components.host, !host.isEmpty else {
+            throw TranscriptionError.invalidBaseURL("Provider URL must include a host.")
+        }
+
+        components.scheme = scheme
+        if components.path == "/" {
+            components.path = ""
+        } else {
+            components.path = components.path.replacingOccurrences(
+                of: "/+$",
+                with: "",
+                options: .regularExpression
+            )
+        }
+
+        guard let normalizedURL = components.url else {
+            throw TranscriptionError.invalidBaseURL("Provider URL is malformed.")
+        }
+
+        return normalizedURL
+    }
+
     // Whisper-large-v3 hallucinates common short phrases on silence/background
     // noise. Drop them when whisper itself reports a high no_speech_prob.
     // Add a new (phrase, minNoSpeechProb) pair here to filter more hallucinations.
@@ -264,6 +303,7 @@ class TranscriptionService {
 }
 
 enum TranscriptionError: LocalizedError {
+    case invalidBaseURL(String)
     case uploadFailed(String)
     case submissionFailed(String)
     case transcriptionFailed(String)
@@ -273,6 +313,7 @@ enum TranscriptionError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .invalidBaseURL(let msg): return "Invalid provider URL: \(msg)"
         case .uploadFailed(let msg): return "Upload failed: \(msg)"
         case .submissionFailed(let msg): return "Submission failed: \(msg)"
         case .transcriptionTimedOut(let seconds): return "Transcription timed out after \(Int(seconds))s"

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -239,8 +239,24 @@ class TranscriptionService {
         guard hallucinationPhrases.contains(normalized) else {
             return false
         }
-        guard let segments = json["segments"] as? [[String: Any]],
-              let noSpeechProb = segments.first?["no_speech_prob"] as? Double else {
+
+        guard let segments = json["segments"] as? [[String: Any]] else {
+            os_log(
+                .info,
+                log: transcriptionLog,
+                "Skipping hallucination filter for '%{public}@': provider response has no segments/no_speech metadata",
+                normalized
+            )
+            return false
+        }
+
+        guard let noSpeechProb = segments.first?["no_speech_prob"] as? Double else {
+            os_log(
+                .info,
+                log: transcriptionLog,
+                "Skipping hallucination filter for '%{public}@': provider response omitted no_speech_prob",
+                normalized
+            )
             return false
         }
         return noSpeechProb >= hallucinationNoSpeechThreshold

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -7,15 +7,21 @@ private let transcriptionLog = OSLog(subsystem: "com.zachlatta.freeflow", catego
 class TranscriptionService {
     private let apiKey: String
     private let baseURL: String
-    private let transcriptionModel = "whisper-large-v3"
+    private let transcriptionModel: String
     private let transcriptionResponseFormat = "verbose_json"
     private let transcriptionTimeoutSeconds: TimeInterval = 20
     private let uploadSampleRate = 16_000.0
     private let uploadChannelCount: AVAudioChannelCount = 1
 
-    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1") {
+    init(
+        apiKey: String,
+        baseURL: String = "https://api.groq.com/openai/v1",
+        transcriptionModel: String = "whisper-large-v3"
+    ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
+        let trimmedModel = transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.transcriptionModel = trimmedModel.isEmpty ? "whisper-large-v3" : trimmedModel
     }
 
     // Validate API key by hitting a lightweight endpoint


### PR DESCRIPTION
## Summary

This PR makes the app's model choices configurable instead of hardcoded.

It adds settings for:
- transcription model
- post-processing model
- context model

## Details

- Persist the three model settings in `AppState`
- Pass them through to:
  - `TranscriptionService`
  - `PostProcessingService`
  - `AppContextService`
- Add a small `Models` section in Settings

## Behavior

Default behavior is unchanged when these settings are left untouched.

Current defaults remain:
- transcription: `whisper-large-v3`
- post-processing: `openai/gpt-oss-20b`
- context: `meta-llama/llama-4-scout-17b-16e-instruct`

## Why

`API Base URL` is already configurable, but the app still uses fixed model IDs. This makes local / self-hosted OpenAI-compatible setups harder to use when model names differ.

## Validation

- built locally successfully
- verified that defaults remain unchanged unless overridden


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced Provider Settings UI and sheet to configure provider base URL and choose transcription, post-processing, fallback, and context models; values are trimmed, persisted, and resettable. Setup and API key copy made provider-generic.

* **Bug Fixes / Improvements**
  * Runtime consistently uses the configured context model; screenshots attached only to the first attempt with a single retry. Transcription/post-processing use selected models. Base URL/API key validation improved with clearer messages and safer URL handling and logging.

* **Tests**
  * Prompt tests updated to use configured model settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->