### PR TITLE
Set low reasoning for post-processing model

### DIFF
--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -116,6 +116,7 @@ Behavior:
     private let baseURL: String
     private let defaultModel = "openai/gpt-oss-20b"
     private let fallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    private let defaultModelReasoningEffort = "low"
     private let postProcessingMaxCompletionTokens = 4096
     private let postProcessingTimeoutSeconds: TimeInterval = 20
 
@@ -355,6 +356,8 @@ Model: \(model)
         ]
         if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+            payload["reasoning_effort"] = defaultModelReasoningEffort
+            payload["include_reasoning"] = false
         }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
@@ -453,6 +456,8 @@ Model: \(model)
         ]
         if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+            payload["reasoning_effort"] = defaultModelReasoningEffort
+            payload["include_reasoning"] = false
         }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])


### PR DESCRIPTION
## Summary
- Set the default post-processing model to use `reasoning_effort: low`.
- Disable reasoning output for the default model by sending `include_reasoning: false`.
- Apply the new settings in both post-processing request paths that use the default model.

## Testing
- Not run (not requested).
- Reviewed the diff to confirm the new payload fields are only added when `model == defaultModel`.
- Verified the change is limited to [`Sources/PostProcessingService.swift`](/Users/marcbodea/dev/freeflow/Sources/PostProcessingService.swift).

## Evaluation

Testing with the prompt evaluation showed either no change or even a slight improvement in the quality of the output with the lower reasoning effort. This should also reduce processing time, token usage, and rate limit usage.
Results can be found here: https://github.com/marcbodea/freeflow-eval/blob/main/eval/results/gptoss20b-v24-reasoning-low-vs-medium-aggregate-3runs-2026-04-16.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured request processing to use reduced reasoning effort and exclude reasoning data for the default model, while maintaining existing behavior for fallback models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->