### PR TITLE
Improve recording overlay feedback states

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -371,6 +371,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingManualCommandInvocation = false
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
+    private var pendingOverlayDismissToken: UUID?
     private var shouldMonitorHotkeys = false
     private var isCapturingShortcut = false
 
@@ -1248,6 +1249,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
         guard !isRecording && !isTranscribing else { return }
+        clearPendingOverlayDismissToken()
         let scheduledSelectionSnapshot = pendingSelectionSnapshot
         let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
@@ -1330,6 +1332,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let self, !overlayShown else { return }
             overlayShown = true
             os_log(.info, log: recordingLog, "engine slow — showing initializing overlay")
+            self.clearPendingOverlayDismissToken()
             self.overlayManager.showInitializing(
                 mode: self.activeRecordingTriggerMode ?? triggerMode,
                 isCommandMode: self.currentSessionIntent.isCommandMode
@@ -1345,6 +1348,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.cancelRecordingInitializationTimer()
                 os_log(.info, log: recordingLog, "first real audio — transitioning to waveform")
                 self.statusText = "Recording..."
+                self.clearPendingOverlayDismissToken()
                 if overlayShown {
                     self.overlayManager.transitionToRecording(
                         mode: self.activeRecordingTriggerMode ?? triggerMode,
@@ -1717,15 +1721,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
                         if trimmedFinalTranscript.isEmpty {
                             self.statusText = "Nothing to transcribe"
+                            self.clearPendingOverlayDismissToken()
                             self.overlayManager.dismiss()
                         } else {
                             self.statusText = completionStatusText
                             if shouldPersistRawDictationFallback {
-                                self.overlayManager.showFailureIndicator()
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                                    self.overlayManager.dismiss()
-                                }
+                                self.scheduleOverlayDismissAfterFailureIndicator(after: 2.5)
                             } else {
+                                self.clearPendingOverlayDismissToken()
                                 self.overlayManager.dismiss()
                             }
 
@@ -1978,6 +1981,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func startDebugOverlay() {
         isDebugOverlayActive = true
+        clearPendingOverlayDismissToken()
         overlayManager.showRecording()
 
         // Simulate audio levels with a timer
@@ -1997,7 +2001,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
         debugOverlayTimer?.invalidate()
         debugOverlayTimer = nil
         isDebugOverlayActive = false
+        clearPendingOverlayDismissToken()
         overlayManager.dismiss()
+    }
+
+    private func clearPendingOverlayDismissToken() {
+        pendingOverlayDismissToken = nil
+    }
+
+    private func scheduleOverlayDismissAfterFailureIndicator(after delay: TimeInterval) {
+        let dismissToken = UUID()
+        pendingOverlayDismissToken = dismissToken
+        overlayManager.showFailureIndicator()
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
+            self.pendingOverlayDismissToken = nil
+            self.overlayManager.dismiss()
+        }
     }
 
     func toggleDebugPanel() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1707,13 +1707,25 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.debugStatusMessage = "Done"
                         let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
 
+                        let shouldPersistRawDictationFallback: Bool
+                        switch result.outcome {
+                        case .postProcessingFailedFallback:
+                            shouldPersistRawDictationFallback = !trimmedFinalTranscript.isEmpty
+                        default:
+                            shouldPersistRawDictationFallback = false
+                        }
+
                         if trimmedFinalTranscript.isEmpty {
                             self.statusText = "Nothing to transcribe"
                             self.overlayManager.dismiss()
                         } else {
                             self.statusText = completionStatusText
-                            self.overlayManager.showDone()
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                            if shouldPersistRawDictationFallback {
+                                self.overlayManager.showFallbackMessage("Used raw dictation")
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+                                    self.overlayManager.dismiss()
+                                }
+                            } else {
                                 self.overlayManager.dismiss()
                             }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1721,7 +1721,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         } else {
                             self.statusText = completionStatusText
                             if shouldPersistRawDictationFallback {
-                                self.overlayManager.showFallbackMessage("Used raw dictation")
+                                self.overlayManager.showFailureIndicator()
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
                                     self.overlayManager.dismiss()
                                 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1249,7 +1249,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
         guard !isRecording && !isTranscribing else { return }
-        clearPendingOverlayDismissToken()
         let scheduledSelectionSnapshot = pendingSelectionSnapshot
         let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
@@ -1316,6 +1315,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func beginRecording(triggerMode: RecordingTriggerMode) {
         os_log(.info, log: recordingLog, "beginRecording() entered")
+        clearPendingOverlayDismissToken()
         errorMessage = nil
 
         isRecording = true

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -9,13 +9,14 @@ final class RecordingOverlayState: ObservableObject {
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
     @Published var isCommandMode = false
     @Published var showsTranscribingSpinner = false
+    @Published var feedbackMessage: String?
 }
 
 enum OverlayPhase {
     case initializing
     case recording
     case transcribing
-    case done
+    case feedback
 }
 
 // MARK: - Panel Helpers
@@ -92,6 +93,7 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .initializing
             self.overlayState.showsTranscribingSpinner = false
+            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: false)
         }
@@ -104,6 +106,7 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
+            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: true)
         }
@@ -116,6 +119,7 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
+            self.overlayState.feedbackMessage = nil
             self.updateOverlayLayout(animated: true)
         }
     }
@@ -145,9 +149,9 @@ final class RecordingOverlayManager {
         }
     }
 
-    func showDone() {
+    func showFallbackMessage(_ message: String) {
         DispatchQueue.main.async {
-            self.showDonePanel()
+            self.showFeedbackPanel(message: message)
         }
     }
 
@@ -202,6 +206,7 @@ final class RecordingOverlayManager {
         lockedOverlayWidth = overlayWindow?.frame.width ?? overlayWidth
         overlayState.phase = .transcribing
         overlayState.showsTranscribingSpinner = showsTranscribingSpinner
+        overlayState.feedbackMessage = nil
         showOverlayPanel(animatedResize: true)
     }
 
@@ -244,8 +249,15 @@ final class RecordingOverlayManager {
     }
 
     private var overlayWidth: CGFloat {
-        if let lockedOverlayWidth, (overlayState.phase == .transcribing || overlayState.phase == .done) {
+        if let lockedOverlayWidth, overlayState.phase == .transcribing {
             return lockedOverlayWidth
+        }
+
+        if overlayState.phase == .feedback {
+            let approximateTextWidth = CGFloat((overlayState.feedbackMessage?.count ?? 0) * 7)
+            let feedbackWidth = max(168, min(260, 48 + approximateTextWidth))
+            guard screenHasNotch else { return feedbackWidth }
+            return max(notchWidth, feedbackWidth)
         }
 
         let commandModeWidth: CGFloat = 180
@@ -265,22 +277,18 @@ final class RecordingOverlayManager {
         return max(notchWidth, baseWidth)
     }
 
-    private func showDonePanel() {
-        overlayState.phase = .done
-
-        guard let panel = overlayWindow else { return }
-        panel.contentView = makeOverlayContent(frame: panel.frame)
-
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.2
-            panel.animator().alphaValue = 0
-        }
+    private func showFeedbackPanel(message: String) {
+        lockedOverlayWidth = nil
+        overlayState.phase = .feedback
+        overlayState.feedbackMessage = message
+        showOverlayPanel(animatedResize: true)
     }
 
     private func dismissAll() {
         lockedOverlayWidth = nil
         overlayState.isCommandMode = false
         overlayState.showsTranscribingSpinner = false
+        overlayState.feedbackMessage = nil
         if let panel = overlayWindow {
             panel.orderOut(nil)
             overlayWindow = nil
@@ -344,6 +352,33 @@ struct WaveformView: View {
     }
 }
 
+struct ProcessingWaveformView: View {
+    private static let barCount = 9
+    private static let multipliers: [CGFloat] = [0.42, 0.58, 0.76, 0.9, 1.0, 0.9, 0.76, 0.58, 0.42]
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
+            let time = context.date.timeIntervalSinceReferenceDate
+
+            HStack(spacing: 2.5) {
+                ForEach(0..<Self.barCount, id: \.self) { index in
+                    let wave = 0.5 + 0.5 * sin((time * 5.6) - Double(index) * 0.5)
+                    let shimmer = 0.5 + 0.5 * sin((time * 2.8) + Double(index) * 0.75)
+                    let amplitude = min(
+                        0.16 + CGFloat(wave) * Self.multipliers[index] * 0.52 + CGFloat(shimmer) * 0.08,
+                        1.0
+                    )
+
+                    WaveformBar(amplitude: amplitude)
+                        .opacity(0.45 + CGFloat(wave) * 0.5)
+                }
+            }
+            .frame(height: 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
 struct InitializingDotsView: View {
     @State private var activeDot = 0
     @State private var timer: Timer?
@@ -393,14 +428,14 @@ struct RecordingOverlayView: View {
                 if state.phase == .initializing {
                     InitializingDotsView()
                         .transition(.opacity)
-                } else if state.phase == .done {
-                    DoneView()
+                } else if state.phase == .feedback, let feedbackMessage = state.feedbackMessage {
+                    FeedbackMessageView(message: feedbackMessage)
                         .transition(.opacity.combined(with: .scale(scale: 0.96)))
                 } else if showsLiveRecordingContent {
                     WaveformView(audioLevel: state.audioLevel)
                         .transition(.opacity)
                 } else {
-                    TranscribingSpinnerView()
+                    ProcessingWaveformView()
                         .transition(.opacity.combined(with: .scale(scale: 0.96)))
                 }
             }
@@ -443,15 +478,6 @@ struct RecordingOverlayView: View {
 
 // MARK: - Transcribing Indicator
 
-struct DoneView: View {
-    var body: some View {
-        Image(systemName: "checkmark")
-            .font(.system(size: 12, weight: .bold))
-            .foregroundStyle(.white)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
 struct CommandModeIndicator: View {
     var body: some View {
         Image(systemName: "pencil")
@@ -461,24 +487,19 @@ struct CommandModeIndicator: View {
     }
 }
 
-struct TranscribingSpinnerView: View {
-    @State private var isAnimating = false
+struct FeedbackMessageView: View {
+    let message: String
 
     var body: some View {
-        Circle()
-            .trim(from: 0.14, to: 0.82)
-            .stroke(
-                Color.white,
-                style: StrokeStyle(lineWidth: 2.2, lineCap: .round)
-            )
-            .frame(width: 14, height: 14)
-            .rotationEffect(.degrees(isAnimating ? 360 : 0))
-            .animation(
-                .linear(duration: 0.75).repeatForever(autoreverses: false),
-                value: isAnimating
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onAppear { isAnimating = true }
-            .onDisappear { isAnimating = false }
+        HStack(spacing: 8) {
+            WaveformView(audioLevel: 0.42)
+                .frame(width: 26)
+
+            Text(message)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(.white.opacity(0.92))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -9,7 +9,6 @@ final class RecordingOverlayState: ObservableObject {
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
     @Published var isCommandMode = false
     @Published var showsTranscribingSpinner = false
-    @Published var feedbackMessage: String?
 }
 
 enum OverlayPhase {
@@ -93,7 +92,6 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .initializing
             self.overlayState.showsTranscribingSpinner = false
-            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: false)
         }
@@ -106,7 +104,6 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
-            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: true)
         }
@@ -119,7 +116,6 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
-            self.overlayState.feedbackMessage = nil
             self.updateOverlayLayout(animated: true)
         }
     }
@@ -149,9 +145,9 @@ final class RecordingOverlayManager {
         }
     }
 
-    func showFallbackMessage(_ message: String) {
+    func showFailureIndicator() {
         DispatchQueue.main.async {
-            self.showFeedbackPanel(message: message)
+            self.showFeedbackPanel()
         }
     }
 
@@ -206,7 +202,6 @@ final class RecordingOverlayManager {
         lockedOverlayWidth = overlayWindow?.frame.width ?? overlayWidth
         overlayState.phase = .transcribing
         overlayState.showsTranscribingSpinner = showsTranscribingSpinner
-        overlayState.feedbackMessage = nil
         showOverlayPanel(animatedResize: true)
     }
 
@@ -254,8 +249,7 @@ final class RecordingOverlayManager {
         }
 
         if overlayState.phase == .feedback {
-            let approximateTextWidth = CGFloat((overlayState.feedbackMessage?.count ?? 0) * 7)
-            let feedbackWidth = max(168, min(260, 48 + approximateTextWidth))
+            let feedbackWidth: CGFloat = 92
             guard screenHasNotch else { return feedbackWidth }
             return max(notchWidth, feedbackWidth)
         }
@@ -277,10 +271,9 @@ final class RecordingOverlayManager {
         return max(notchWidth, baseWidth)
     }
 
-    private func showFeedbackPanel(message: String) {
+    private func showFeedbackPanel() {
         lockedOverlayWidth = nil
         overlayState.phase = .feedback
-        overlayState.feedbackMessage = message
         showOverlayPanel(animatedResize: true)
     }
 
@@ -288,7 +281,6 @@ final class RecordingOverlayManager {
         lockedOverlayWidth = nil
         overlayState.isCommandMode = false
         overlayState.showsTranscribingSpinner = false
-        overlayState.feedbackMessage = nil
         if let panel = overlayWindow {
             panel.orderOut(nil)
             overlayWindow = nil
@@ -423,49 +415,52 @@ struct RecordingOverlayView: View {
     }
 
     var body: some View {
-        ZStack {
-            Group {
-                if state.phase == .initializing {
-                    InitializingDotsView()
-                        .transition(.opacity)
-                } else if state.phase == .feedback, let feedbackMessage = state.feedbackMessage {
-                    FeedbackMessageView(message: feedbackMessage)
-                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                } else if showsLiveRecordingContent {
-                    WaveformView(audioLevel: state.audioLevel)
-                        .transition(.opacity)
-                } else {
-                    ProcessingWaveformView()
-                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                }
-            }
-
-            HStack {
-                Group {
-                    if state.isCommandMode {
-                        CommandModeIndicator()
-                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                    }
-                }
-                .frame(width: leadingAccessoryWidth, alignment: .center)
-                .frame(maxHeight: .infinity, alignment: .center)
-
-                Spacer(minLength: 0)
-
-                Group {
-                    if showsStopButton {
-                        Button(action: onStopButtonPressed) {
-                            Image(systemName: "stop.fill")
-                                .font(.system(size: 9, weight: .bold))
-                            .foregroundStyle(.white)
-                            .frame(width: 20, height: 20)
-                            .background(Circle().fill(Color.red.opacity(0.92)))
+        Group {
+            if state.phase == .feedback {
+                FailureIndicatorView()
+            } else {
+                ZStack {
+                    Group {
+                        if state.phase == .initializing {
+                            InitializingDotsView()
+                                .transition(.opacity)
+                        } else if showsLiveRecordingContent {
+                            WaveformView(audioLevel: state.audioLevel)
+                                .transition(.opacity)
+                        } else {
+                            ProcessingWaveformView()
+                                .transition(.opacity.combined(with: .scale(scale: 0.96)))
                         }
-                        .buttonStyle(.plain)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                    }
+
+                    HStack {
+                        Group {
+                            if state.isCommandMode {
+                                CommandModeIndicator()
+                                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                            }
+                        }
+                        .frame(width: leadingAccessoryWidth, alignment: .center)
+                        .frame(maxHeight: .infinity, alignment: .center)
+
+                        Spacer(minLength: 0)
+
+                        Group {
+                            if showsStopButton {
+                                Button(action: onStopButtonPressed) {
+                                    Image(systemName: "stop.fill")
+                                        .font(.system(size: 9, weight: .bold))
+                                        .foregroundStyle(.white)
+                                        .frame(width: 20, height: 20)
+                                        .background(Circle().fill(Color.red.opacity(0.92)))
+                                }
+                                .buttonStyle(.plain)
+                                .transition(.move(edge: .trailing).combined(with: .opacity))
+                            }
+                        }
+                        .frame(width: trailingAccessoryWidth, alignment: .trailing)
                     }
                 }
-                .frame(width: trailingAccessoryWidth, alignment: .trailing)
             }
         }
         .padding(.horizontal, 12)
@@ -487,19 +482,13 @@ struct CommandModeIndicator: View {
     }
 }
 
-struct FeedbackMessageView: View {
-    let message: String
-
+struct FailureIndicatorView: View {
     var body: some View {
-        HStack(spacing: 8) {
-            WaveformView(audioLevel: 0.42)
-                .frame(width: 26)
-
-            Text(message)
-                .font(.system(size: 11.5, weight: .medium))
-                .foregroundStyle(.white.opacity(0.92))
-                .lineLimit(1)
-        }
+        Image(systemName: "xmark")
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(width: 20, height: 20)
+            .background(Circle().fill(Color.red.opacity(0.92)))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }


### PR DESCRIPTION
## Summary
- Replace the old done checkmark with a red failure indicator for raw dictation fallback cases.
- Add a dedicated feedback overlay phase with adjusted sizing and presentation behavior.
- Update the recording overlay UI to show a processing waveform while transcribing and simplify state handling.
- Keep fallback text visible briefly before dismissing the overlay when post-processing fails but raw dictation is preserved.

## Testing
- Not run
- Verified the changed overlay flows in code paths for normal completion, empty transcript, and post-processing fallback handling.
- Checked that the overlay phase transitions and width logic match the new feedback state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaces the previous "done" visual with a failure/feedback indicator and a new animated processing waveform for non-live audio.
* **Bug Fixes**
  * Improves overlay dismissal and timing so completion overlays and failure/fallback indicators display and hide reliably based on transcription outcomes, avoiding stale dismissals and ensuring immediate or scheduled dismissal as appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->