### PR TITLE
Swap transcript sanitizers in post-processing flow

### DIFF
--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -380,7 +380,7 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
+        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
         guard !sanitizedTranscript.isEmpty else {
             throw PostProcessingError.emptyOutput
         }
@@ -480,7 +480,7 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
+        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
         guard !sanitizedTranscript.isEmpty else {
             throw PostProcessingError.emptyOutput
         }

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -380,11 +380,11 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
-        guard !sanitizedTranscript.isEmpty else {
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PostProcessingError.emptyOutput
         }
 
+        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
         return PostProcessingResult(
             transcript: sanitizedTranscript,
             prompt: promptForDisplay
@@ -480,11 +480,11 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
-        guard !sanitizedTranscript.isEmpty else {
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PostProcessingError.emptyOutput
         }
 
+        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
         return PostProcessingResult(
             transcript: sanitizedTranscript,
             prompt: promptForDisplay


### PR DESCRIPTION
## Summary
- Swapped the sanitization functions used by the post-processing and command-mode transcript paths.
- This restores each path to using its intended sanitizer before empty-output validation.
- The change is limited to `Sources/PostProcessingService.swift`.

## Testing
- Not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post-response sanitization so each processing path now uses the correct cleanup and empty-output checks.
  * Ensures consistent trimming, quote handling, and empty-result normalization across modes to prevent spurious empty or quoted transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->