### PR TITLE
Refactor shortcut handling and fix stuck-key instability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 .DS_Store
 *.swp
 .env
+.build

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ space := $(empty) $(empty)
 APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
 APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
 
-SOURCES = $(wildcard Sources/*.swift)
+SOURCES = $(shell find Sources -name '*.swift' -type f | sort)
 RESOURCES = $(CONTENTS)/Resources
 ARCH ?= $(shell uname -m)
 ICON_SOURCE = Resources/AppIcon-Source.png

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ space := $(empty) $(empty)
 APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
 APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
 
-SOURCES = $(shell find Sources -name '*.swift' -type f | sort)
+SOURCES = $(shell find Sources -name '*.swift' -type f | LC_ALL=C sort)
 RESOURCES = $(CONTENTS)/Resources
 ARCH ?= $(shell uname -m)
 ICON_SOURCE = Resources/AppIcon-Source.png

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -103,6 +103,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+
     func showSetupWindow() {
         NSApp.setActivationPolicy(.regular)
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1369,6 +1369,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let scheduledSelectionSnapshot = pendingSelectionSnapshot
         let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
+        guard prepareRecordingStart(
+            triggerMode: triggerMode,
+            selectionSnapshot: scheduledSelectionSnapshot,
+            manualCommandRequested: scheduledSelectionSnapshot == nil
+                ? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
+                : scheduledManualCommandInvocation,
+            startedAt: t0
+        ) else { return }
+        guard ensureMicrophoneAccess() else { return }
+        os_log(.info, log: recordingLog, "mic access check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+        beginRecording(triggerMode: triggerMode)
+        os_log(.info, log: recordingLog, "startRecording() finished: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+    }
+
+    private func prepareRecordingStart(
+        triggerMode: RecordingTriggerMode,
+        selectionSnapshot: AppSelectionSnapshot? = nil,
+        manualCommandRequested: Bool? = nil,
+        startedAt: CFAbsoluteTime? = nil
+    ) -> Bool {
         activeRecordingTriggerMode = triggerMode
         guard hasAccessibility else {
             errorMessage = "Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility."
@@ -1377,32 +1397,33 @@ final class AppState: ObservableObject, @unchecked Sendable {
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
             showAccessibilityAlert()
-            return
+            return false
         }
-        os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        let selectionSnapshot = scheduledSelectionSnapshot ?? contextService.collectSelectionSnapshot()
-        let manualCommandRequested = scheduledSelectionSnapshot == nil
-            ? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
-            : scheduledManualCommandInvocation
+        if let startedAt {
+            os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+        }
+
+        let selectionSnapshot = selectionSnapshot ?? contextService.collectSelectionSnapshot()
+        let manualCommandRequested = manualCommandRequested
+            ?? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
         guard let resolvedIntent = resolveSessionIntent(
             triggerMode: triggerMode,
             selectionSnapshot: selectionSnapshot,
             manualCommandRequested: manualCommandRequested
-        ) else { return }
+        ) else { return false }
 
         if resolvedIntent.isCommandMode {
-            guard ensureScreenCaptureAccess() else { return }
-            os_log(.info, log: recordingLog, "screen capture check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+            guard ensureScreenCaptureAccess() else { return false }
+            if let startedAt {
+                os_log(.info, log: recordingLog, "screen capture check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+            }
         } else {
             hasScreenRecordingPermission = hasScreenCapturePermission()
         }
 
         currentSessionIntent = resolvedIntent
         overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
-        guard ensureMicrophoneAccess() else { return }
-        os_log(.info, log: recordingLog, "mic access check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        beginRecording(triggerMode: triggerMode)
-        os_log(.info, log: recordingLog, "startRecording() finished: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+        return true
     }
 
     private func ensureScreenCaptureAccess() -> Bool {
@@ -1446,8 +1467,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     if granted {
                         strongSelf.errorMessage = nil
                         if triggerMode == .toggle {
+                            guard strongSelf.prepareRecordingStart(triggerMode: .toggle) else { return }
                             strongSelf.shortcutSessionController.beginManual(mode: .toggle)
-                            strongSelf.activeRecordingTriggerMode = .toggle
                             strongSelf.beginRecording(triggerMode: .toggle)
                         } else {
                             strongSelf.currentSessionIntent = .dictation

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -424,12 +424,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             holdKey: holdShortcutStorageKey,
             toggleKey: toggleShortcutStorageKey
         )
-        let storedSavedHoldCustomShortcut = Self.loadShortcut(forKey: savedHoldCustomShortcutStorageKey)
-        let storedSavedToggleCustomShortcut = Self.loadShortcut(forKey: savedToggleCustomShortcutStorageKey)
-        let savedHoldCustomShortcut = storedSavedHoldCustomShortcut?.binding
-            ?? (shortcuts.hold.isCustom ? shortcuts.hold : nil)
-        let savedToggleCustomShortcut = storedSavedToggleCustomShortcut?.binding
-            ?? (shortcuts.toggle.isCustom ? shortcuts.toggle : nil)
+        let savedHoldCustomShortcut = Self.loadSavedCustomShortcut(
+            forKey: savedHoldCustomShortcutStorageKey,
+            fallback: shortcuts.hold.isCustom ? shortcuts.hold : nil
+        )
+        let savedToggleCustomShortcut = Self.loadSavedCustomShortcut(
+            forKey: savedToggleCustomShortcutStorageKey,
+            fallback: shortcuts.toggle.isCustom ? shortcuts.toggle : nil
+        )
         let customVocabulary = UserDefaults.standard.string(forKey: customVocabularyStorageKey) ?? ""
         let customSystemPrompt = UserDefaults.standard.string(forKey: customSystemPromptStorageKey) ?? ""
         let customContextPrompt = UserDefaults.standard.string(forKey: customContextPromptStorageKey) ?? ""
@@ -492,8 +494,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.contextModel = contextModel
         self.holdShortcut = shortcuts.hold
         self.toggleShortcut = shortcuts.toggle
-        self.savedHoldCustomShortcut = savedHoldCustomShortcut
-        self.savedToggleCustomShortcut = savedToggleCustomShortcut
+        self.savedHoldCustomShortcut = savedHoldCustomShortcut.binding
+        self.savedToggleCustomShortcut = savedToggleCustomShortcut.binding
         self.isCommandModeEnabled = isCommandModeEnabled
         self.commandModeStyle = commandModeStyle
         self.commandModeManualModifier = commandModeManualModifier
@@ -517,12 +519,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         refreshAvailableMicrophones()
         installAudioDeviceObservers()
 
-        if shortcuts.didUpdateStoredValues {
+        if shortcuts.didUpdateHoldStoredValue {
             persistShortcut(shortcuts.hold, key: holdShortcutStorageKey)
+        }
+        if shortcuts.didUpdateToggleStoredValue {
             persistShortcut(shortcuts.toggle, key: toggleShortcutStorageKey)
         }
-        persistOptionalShortcut(savedHoldCustomShortcut, key: savedHoldCustomShortcutStorageKey)
-        persistOptionalShortcut(savedToggleCustomShortcut, key: savedToggleCustomShortcutStorageKey)
+        if savedHoldCustomShortcut.didUpdateStoredValue {
+            persistOptionalShortcut(savedHoldCustomShortcut.binding, key: savedHoldCustomShortcutStorageKey)
+        }
+        if savedToggleCustomShortcut.didUpdateStoredValue {
+            persistOptionalShortcut(savedToggleCustomShortcut.binding, key: savedToggleCustomShortcutStorageKey)
+        }
 
         overlayManager.onStopButtonPressed = { [weak self] in
             DispatchQueue.main.async {
@@ -564,7 +572,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private struct StoredShortcutConfiguration {
         let hold: ShortcutBinding
         let toggle: ShortcutBinding
-        let didUpdateStoredValues: Bool
+        let didUpdateHoldStoredValue: Bool
+        let didUpdateToggleStoredValue: Bool
+    }
+
+    private struct StoredOptionalShortcut {
+        let binding: ShortcutBinding?
+        let didUpdateStoredValue: Bool
+    }
+
+    private struct StoredShortcutLoadResult {
+        let binding: ShortcutBinding?
+        let hadStoredValue: Bool
+        let didNormalize: Bool
     }
 
     private static func loadStoredAPIBaseURL(account: String) -> String {
@@ -575,32 +595,49 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private static func loadShortcutConfiguration(holdKey: String, toggleKey: String) -> StoredShortcutConfiguration {
-        if let holdResult = loadShortcut(forKey: holdKey),
-           let toggleResult = loadShortcut(forKey: toggleKey) {
-            return StoredShortcutConfiguration(
-                hold: holdResult.binding,
-                toggle: toggleResult.binding,
-                didUpdateStoredValues: holdResult.didNormalize || toggleResult.didNormalize
-            )
-        }
-
         let legacyPreset = ShortcutPreset(
             rawValue: UserDefaults.standard.string(forKey: "hotkey_option") ?? ShortcutPreset.fnKey.rawValue
         ) ?? .fnKey
         let hold = legacyPreset.binding
         let toggle = hold.withAddedModifiers(.command)
-        return StoredShortcutConfiguration(hold: hold, toggle: toggle, didUpdateStoredValues: true)
+        let storedHold = loadShortcut(forKey: holdKey)
+        let storedToggle = loadShortcut(forKey: toggleKey)
+        return StoredShortcutConfiguration(
+            hold: storedHold.binding ?? hold,
+            toggle: storedToggle.binding ?? toggle,
+            didUpdateHoldStoredValue: storedHold.binding == nil || storedHold.didNormalize,
+            didUpdateToggleStoredValue: storedToggle.binding == nil || storedToggle.didNormalize
+        )
     }
 
-    private static func loadShortcut(forKey key: String) -> (binding: ShortcutBinding, didNormalize: Bool)? {
+    private static func loadShortcut(forKey key: String) -> StoredShortcutLoadResult {
         guard let data = UserDefaults.standard.data(forKey: key) else {
-            return nil
+            return StoredShortcutLoadResult(binding: nil, hadStoredValue: false, didNormalize: false)
         }
         guard let decoded = try? JSONDecoder().decode(ShortcutBinding.self, from: data) else {
-            return nil
+            return StoredShortcutLoadResult(binding: nil, hadStoredValue: true, didNormalize: false)
         }
         let normalized = decoded.normalizedForStorageMigration()
-        return (binding: normalized, didNormalize: normalized != decoded)
+        return StoredShortcutLoadResult(
+            binding: normalized,
+            hadStoredValue: true,
+            didNormalize: normalized != decoded
+        )
+    }
+
+    private static func loadSavedCustomShortcut(
+        forKey key: String,
+        fallback: ShortcutBinding?
+    ) -> StoredOptionalShortcut {
+        let stored = loadShortcut(forKey: key)
+        if let binding = stored.binding {
+            return StoredOptionalShortcut(binding: binding, didUpdateStoredValue: stored.didNormalize)
+        }
+
+        return StoredOptionalShortcut(
+            binding: fallback,
+            didUpdateStoredValue: stored.hadStoredValue || fallback != nil
+        )
     }
 
     private func persistAPIBaseURL(_ value: String) {
@@ -840,7 +877,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized:
             refreshAvailableMicrophones()
-            completion(true)
+            DispatchQueue.main.async {
+                completion(true)
+            }
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
                 DispatchQueue.main.async {
@@ -852,10 +891,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         case .denied, .restricted:
             openMicrophoneSettings()
-            completion(false)
+            DispatchQueue.main.async {
+                completion(false)
+            }
         @unknown default:
             openMicrophoneSettings()
-            completion(false)
+            DispatchQueue.main.async {
+                completion(false)
+            }
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -421,9 +421,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             holdKey: holdShortcutStorageKey,
             toggleKey: toggleShortcutStorageKey
         )
-        let savedHoldCustomShortcut = Self.loadShortcut(forKey: savedHoldCustomShortcutStorageKey)
+        let storedSavedHoldCustomShortcut = Self.loadShortcut(forKey: savedHoldCustomShortcutStorageKey)
+        let storedSavedToggleCustomShortcut = Self.loadShortcut(forKey: savedToggleCustomShortcutStorageKey)
+        let savedHoldCustomShortcut = storedSavedHoldCustomShortcut?.binding
             ?? (shortcuts.hold.isCustom ? shortcuts.hold : nil)
-        let savedToggleCustomShortcut = Self.loadShortcut(forKey: savedToggleCustomShortcutStorageKey)
+        let savedToggleCustomShortcut = storedSavedToggleCustomShortcut?.binding
             ?? (shortcuts.toggle.isCustom ? shortcuts.toggle : nil)
         let customVocabulary = UserDefaults.standard.string(forKey: customVocabularyStorageKey) ?? ""
         let customSystemPrompt = UserDefaults.standard.string(forKey: customSystemPromptStorageKey) ?? ""
@@ -512,7 +514,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         refreshAvailableMicrophones()
         installAudioDeviceObservers()
 
-        if shortcuts.didMigrateLegacyValue {
+        if shortcuts.didUpdateStoredValues {
             persistShortcut(shortcuts.hold, key: holdShortcutStorageKey)
             persistShortcut(shortcuts.toggle, key: toggleShortcutStorageKey)
         }
@@ -559,7 +561,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private struct StoredShortcutConfiguration {
         let hold: ShortcutBinding
         let toggle: ShortcutBinding
-        let didMigrateLegacyValue: Bool
+        let didUpdateStoredValues: Bool
     }
 
     private static func loadStoredAPIBaseURL(account: String) -> String {
@@ -570,9 +572,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private static func loadShortcutConfiguration(holdKey: String, toggleKey: String) -> StoredShortcutConfiguration {
-        if let hold = loadShortcut(forKey: holdKey),
-           let toggle = loadShortcut(forKey: toggleKey) {
-            return StoredShortcutConfiguration(hold: hold, toggle: toggle, didMigrateLegacyValue: false)
+        if let holdResult = loadShortcut(forKey: holdKey),
+           let toggleResult = loadShortcut(forKey: toggleKey) {
+            return StoredShortcutConfiguration(
+                hold: holdResult.binding,
+                toggle: toggleResult.binding,
+                didUpdateStoredValues: holdResult.didNormalize || toggleResult.didNormalize
+            )
         }
 
         let legacyPreset = ShortcutPreset(
@@ -580,14 +586,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         ) ?? .fnKey
         let hold = legacyPreset.binding
         let toggle = hold.withAddedModifiers(.command)
-        return StoredShortcutConfiguration(hold: hold, toggle: toggle, didMigrateLegacyValue: true)
+        return StoredShortcutConfiguration(hold: hold, toggle: toggle, didUpdateStoredValues: true)
     }
 
-    private static func loadShortcut(forKey key: String) -> ShortcutBinding? {
+    private static func loadShortcut(forKey key: String) -> (binding: ShortcutBinding, didNormalize: Bool)? {
         guard let data = UserDefaults.standard.data(forKey: key) else {
             return nil
         }
-        return try? JSONDecoder().decode(ShortcutBinding.self, from: data)
+        guard let decoded = try? JSONDecoder().decode(ShortcutBinding.self, from: data) else {
+            return nil
+        }
+        let normalized = decoded.normalizedForStorageMigration()
+        return (binding: normalized, didNormalize: normalized != decoded)
     }
 
     private func persistAPIBaseURL(_ value: String) {
@@ -609,7 +619,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func persistShortcut(_ binding: ShortcutBinding, key: String) {
-        guard let data = try? JSONEncoder().encode(binding) else { return }
+        let normalizedBinding = binding.normalizedForStorageMigration()
+        guard let data = try? JSONEncoder().encode(normalizedBinding) else { return }
         UserDefaults.standard.set(data, forKey: key)
     }
 
@@ -982,6 +993,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @discardableResult
     func setShortcut(_ binding: ShortcutBinding, for role: ShortcutRole) -> String? {
+        let binding = binding.normalizedForStorageMigration()
         let nextHoldShortcut = role == .hold ? binding : holdShortcut
         let nextToggleShortcut = role == .toggle ? binding : toggleShortcut
         let otherBinding = role == .hold ? toggleShortcut : holdShortcut

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -839,6 +839,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func requestMicrophoneAccess(completion: @escaping (Bool) -> Void) {
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized:
+            refreshAvailableMicrophones()
             completion(true)
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -829,6 +829,35 @@ final class AppState: ObservableObject, @unchecked Sendable {
         AXIsProcessTrustedWithOptions(options)
     }
 
+    func openMicrophoneSettings() {
+        let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+        if let url = settingsURL {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    func requestMicrophoneAccess(completion: @escaping (Bool) -> Void) {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            completion(true)
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        self?.refreshAvailableMicrophones()
+                    }
+                    completion(granted)
+                }
+            }
+        case .denied, .restricted:
+            openMicrophoneSettings()
+            completion(false)
+        @unknown default:
+            openMicrophoneSettings()
+            completion(false)
+        }
+    }
+
     func hasScreenCapturePermission() -> Bool {
         CGPreflightScreenCaptureAccess()
     }
@@ -1007,8 +1036,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if binding.isDisabled && otherBinding.isDisabled {
             return "At least one shortcut must remain enabled."
         }
-        guard !binding.overlaps(with: otherBinding) else {
-            return "Hold and tap shortcuts must not overlap."
+        guard !binding.conflicts(with: otherBinding) else {
+            return "Hold and tap shortcuts must be distinct."
         }
         if isCommandModeEnabled,
            commandModeStyle == .manual,
@@ -1053,13 +1082,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         let derivedHold = holdBinding.withAddedModifiers(manualModifier)
-        if !holdBinding.isDisabled && derivedHold.overlaps(with: toggleBinding) {
-            return "That modifier would make the command hold shortcut overlap an existing dictation shortcut."
+        if !holdBinding.isDisabled && derivedHold.conflicts(with: toggleBinding) {
+            return "That modifier would make the command hold shortcut conflict with an existing dictation shortcut."
         }
 
         let derivedToggle = toggleBinding.withAddedModifiers(manualModifier)
-        if !toggleBinding.isDisabled && derivedToggle.overlaps(with: holdBinding) {
-            return "That modifier would make the command tap shortcut overlap an existing dictation shortcut."
+        if !toggleBinding.isDisabled && derivedToggle.conflicts(with: holdBinding) {
+            return "That modifier would make the command tap shortcut conflict with an existing dictation shortcut."
         }
 
         return nil
@@ -1606,10 +1635,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
-            if let url = settingsURL {
-                NSWorkspace.shared.open(url)
-            }
+            openMicrophoneSettings()
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1005,8 +1005,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if binding.isDisabled && otherBinding.isDisabled {
             return "At least one shortcut must remain enabled."
         }
-        guard binding != otherBinding else {
-            return "Hold and tap shortcuts must be different."
+        guard !binding.overlaps(with: otherBinding) else {
+            return "Hold and tap shortcuts must not overlap."
         }
         if isCommandModeEnabled,
            commandModeStyle == .manual,
@@ -1051,12 +1051,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         let derivedHold = holdBinding.withAddedModifiers(manualModifier)
-        if !holdBinding.isDisabled && derivedHold == toggleBinding {
+        if !holdBinding.isDisabled && derivedHold.overlaps(with: toggleBinding) {
             return "That modifier would make the command hold shortcut overlap an existing dictation shortcut."
         }
 
         let derivedToggle = toggleBinding.withAddedModifiers(manualModifier)
-        if !toggleBinding.isDisabled && derivedToggle == holdBinding {
+        if !toggleBinding.isDisabled && derivedToggle.overlaps(with: holdBinding) {
             return "That modifier would make the command tap shortcut overlap an existing dictation shortcut."
         }
 
@@ -1348,8 +1348,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
         os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        guard ensureScreenCaptureAccess() else { return }
-        os_log(.info, log: recordingLog, "screen capture check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
         let selectionSnapshot = scheduledSelectionSnapshot ?? contextService.collectSelectionSnapshot()
         let manualCommandRequested = scheduledSelectionSnapshot == nil
             ? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
@@ -1359,6 +1357,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             selectionSnapshot: selectionSnapshot,
             manualCommandRequested: manualCommandRequested
         ) else { return }
+
+        if resolvedIntent.isCommandMode {
+            guard ensureScreenCaptureAccess() else { return }
+            os_log(.info, log: recordingLog, "screen capture check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+        } else {
+            hasScreenRecordingPermission = hasScreenCapturePermission()
+        }
+
         currentSessionIntent = resolvedIntent
         overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
         guard ensureMicrophoneAccess() else { return }
@@ -2032,6 +2038,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         if isScreenCapturePermissionError(message) && !hasShownScreenshotPermissionAlert {
             hasScreenRecordingPermission = false
+            guard currentSessionIntent.isCommandMode else { return }
             errorMessage = message
             hasShownScreenshotPermissionAlert = true
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -269,18 +269,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var isCommandModeEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isCommandModeEnabled, forKey: commandModeEnabledStorageKey)
+            restartHotkeyMonitoring()
         }
     }
 
     @Published var commandModeStyle: CommandModeStyle {
         didSet {
             UserDefaults.standard.set(commandModeStyle.rawValue, forKey: commandModeStyleStorageKey)
+            restartHotkeyMonitoring()
         }
     }
 
     @Published private(set) var commandModeManualModifier: CommandModeManualModifier {
         didSet {
             UserDefaults.standard.set(commandModeManualModifier.rawValue, forKey: commandModeManualModifierStorageKey)
+            restartHotkeyMonitoring()
         }
     }
 
@@ -1125,16 +1128,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return "That modifier is already part of the tap shortcut."
         }
 
-        let derivedHold = holdBinding.withAddedModifiers(manualModifier)
-        if !holdBinding.isDisabled && derivedHold.conflicts(with: toggleBinding) {
-            return "That modifier would make the command hold shortcut conflict with an existing dictation shortcut."
-        }
-
-        let derivedToggle = toggleBinding.withAddedModifiers(manualModifier)
-        if !toggleBinding.isDisabled && derivedToggle.conflicts(with: holdBinding) {
-            return "That modifier would make the command tap shortcut conflict with an existing dictation shortcut."
-        }
-
         return nil
     }
 
@@ -1169,6 +1162,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         restartHotkeyMonitoring()
     }
 
+    private var activeShortcutConfiguration: ShortcutConfiguration {
+        let permittedAdditionalExactMatchModifiers: ShortcutModifiers
+        if isCommandModeEnabled, commandModeStyle == .manual {
+            permittedAdditionalExactMatchModifiers = commandModeManualModifier.shortcutModifier
+        } else {
+            permittedAdditionalExactMatchModifiers = []
+        }
+
+        return ShortcutConfiguration(
+            hold: holdShortcut,
+            toggle: toggleShortcut,
+            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+        )
+    }
+
     private func restartHotkeyMonitoring() {
         guard shouldMonitorHotkeys, !isCapturingShortcut, !isAwaitingMicrophonePermission else {
             hotkeyManager.stop()
@@ -1176,7 +1184,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         do {
-            try hotkeyManager.start(configuration: ShortcutConfiguration(hold: holdShortcut, toggle: toggleShortcut))
+            try hotkeyManager.start(configuration: activeShortcutConfiguration)
             hotkeyMonitoringErrorMessage = nil
         } catch {
             hotkeyMonitoringErrorMessage = error.localizedDescription

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1406,34 +1406,34 @@ final class AppState: ObservableObject, @unchecked Sendable {
             prepareForMicrophonePermissionPrompt(triggerMode: triggerMode)
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
                 DispatchQueue.main.async {
-                    guard let self else { return }
-                    let pendingTriggerMode = self.pendingMicrophonePermissionTriggerMode
-                    self.pendingMicrophonePermissionTriggerMode = nil
-                    self.isAwaitingMicrophonePermission = false
-                    self.restartHotkeyMonitoring()
+                    guard let strongSelf = self else { return }
+                    let pendingTriggerMode = strongSelf.pendingMicrophonePermissionTriggerMode
+                    strongSelf.pendingMicrophonePermissionTriggerMode = nil
+                    strongSelf.isAwaitingMicrophonePermission = false
+                    strongSelf.restartHotkeyMonitoring()
 
                     guard let triggerMode = pendingTriggerMode else { return }
                     if granted {
-                        self.errorMessage = nil
+                        strongSelf.errorMessage = nil
                         if triggerMode == .toggle {
-                            self.shortcutSessionController.beginManual(mode: .toggle)
-                            self.activeRecordingTriggerMode = .toggle
-                            self.beginRecording(triggerMode: .toggle)
+                            strongSelf.shortcutSessionController.beginManual(mode: .toggle)
+                            strongSelf.activeRecordingTriggerMode = .toggle
+                            strongSelf.beginRecording(triggerMode: .toggle)
                         } else {
-                            self.currentSessionIntent = .dictation
-                            self.statusText = "Microphone access granted. Press and hold again to record."
-                            self.scheduleReadyStatusReset(
+                            strongSelf.currentSessionIntent = .dictation
+                            strongSelf.statusText = "Microphone access granted. Press and hold again to record."
+                            strongSelf.scheduleReadyStatusReset(
                                 after: 2,
                                 matching: ["Microphone access granted. Press and hold again to record."]
                             )
                         }
                     } else {
-                        self.errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
-                        self.statusText = "No Microphone"
-                        self.activeRecordingTriggerMode = nil
-                        self.currentSessionIntent = .dictation
-                        self.shortcutSessionController.reset()
-                        self.showMicrophonePermissionAlert()
+                        strongSelf.errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
+                        strongSelf.statusText = "No Microphone"
+                        strongSelf.activeRecordingTriggerMode = nil
+                        strongSelf.currentSessionIntent = .dictation
+                        strongSelf.shortcutSessionController.reset()
+                        strongSelf.showMicrophonePermissionAlert()
                     }
                 }
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -408,6 +408,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingOverlayDismissToken: UUID?
     private var shouldMonitorHotkeys = false
     private var isCapturingShortcut = false
+    private var isAwaitingMicrophonePermission = false
+    private var pendingMicrophonePermissionTriggerMode: RecordingTriggerMode?
 
     init() {
         UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
@@ -1095,7 +1097,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func restartHotkeyMonitoring() {
-        guard shouldMonitorHotkeys, !isCapturingShortcut else {
+        guard shouldMonitorHotkeys, !isCapturingShortcut, !isAwaitingMicrophonePermission else {
             hotkeyManager.stop()
             return
         }
@@ -1397,18 +1399,41 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case .authorized:
             return true
         case .notDetermined:
+            guard let triggerMode = activeRecordingTriggerMode else {
+                return false
+            }
+
+            prepareForMicrophonePermissionPrompt(triggerMode: triggerMode)
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
                 DispatchQueue.main.async {
+                    guard let self else { return }
+                    let pendingTriggerMode = self.pendingMicrophonePermissionTriggerMode
+                    self.pendingMicrophonePermissionTriggerMode = nil
+                    self.isAwaitingMicrophonePermission = false
+                    self.restartHotkeyMonitoring()
+
+                    guard let triggerMode = pendingTriggerMode else { return }
                     if granted {
-                        guard let self, let triggerMode = self.activeRecordingTriggerMode else { return }
-                        self.beginRecording(triggerMode: triggerMode)
+                        self.errorMessage = nil
+                        if triggerMode == .toggle {
+                            self.shortcutSessionController.beginManual(mode: .toggle)
+                            self.activeRecordingTriggerMode = .toggle
+                            self.beginRecording(triggerMode: .toggle)
+                        } else {
+                            self.currentSessionIntent = .dictation
+                            self.statusText = "Microphone access granted. Press and hold again to record."
+                            self.scheduleReadyStatusReset(
+                                after: 2,
+                                matching: ["Microphone access granted. Press and hold again to record."]
+                            )
+                        }
                     } else {
-                        self?.errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
-                        self?.statusText = "No Microphone"
-                        self?.activeRecordingTriggerMode = nil
-                        self?.currentSessionIntent = .dictation
-                        self?.shortcutSessionController.reset()
-                        self?.showMicrophonePermissionAlert()
+                        self.errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
+                        self.statusText = "No Microphone"
+                        self.activeRecordingTriggerMode = nil
+                        self.currentSessionIntent = .dictation
+                        self.shortcutSessionController.reset()
+                        self.showMicrophonePermissionAlert()
                     }
                 }
             }
@@ -1422,6 +1447,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
             showMicrophonePermissionAlert()
             return false
         }
+    }
+
+    private func prepareForMicrophonePermissionPrompt(triggerMode: RecordingTriggerMode) {
+        isAwaitingMicrophonePermission = true
+        pendingMicrophonePermissionTriggerMode = triggerMode
+        hotkeyManager.stop()
+        shortcutSessionController.reset()
+        activeRecordingTriggerMode = nil
+        cancelRecordingInitializationTimer()
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
+        audioLevelCancellable?.cancel()
+        audioLevelCancellable = nil
+        overlayManager.dismiss()
     }
 
     private func beginRecording(triggerMode: RecordingTriggerMode) {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -357,6 +357,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var errorMessage: String?
     @Published var statusText: String = "Ready"
     @Published var hasAccessibility = false
+    @Published var hotkeyMonitoringErrorMessage: String?
     @Published var isDebugOverlayActive = false
     @Published var selectedSettingsTab: SettingsTab? = .general
     @Published var pipelineHistory: [PipelineHistoryItem] = []
@@ -931,6 +932,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     var shortcutStatusText: String {
+        if hotkeyMonitoringErrorMessage != nil {
+            return "Global shortcuts unavailable"
+        }
+
         switch (hasEnabledHoldShortcut, hasEnabledToggleShortcut) {
         case (true, true):
             return "Hold \(holdShortcut.displayName) or tap \(toggleShortcut.displayName) to dictate"
@@ -1073,6 +1078,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     func stopHotkeyMonitoring() {
         shouldMonitorHotkeys = false
+        hotkeyMonitoringErrorMessage = nil
         hotkeyManager.onShortcutEvent = nil
         hotkeyManager.onEscapeKeyPressed = nil
         hotkeyManager.stop()
@@ -1094,7 +1100,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
 
-        hotkeyManager.start(configuration: ShortcutConfiguration(hold: holdShortcut, toggle: toggleShortcut))
+        do {
+            try hotkeyManager.start(configuration: ShortcutConfiguration(hold: holdShortcut, toggle: toggleShortcut))
+            hotkeyMonitoringErrorMessage = nil
+        } catch {
+            hotkeyMonitoringErrorMessage = error.localizedDescription
+            os_log(.error, log: recordingLog, "Hotkey monitoring failed to start: %{public}@", error.localizedDescription)
+        }
     }
 
     private func handleShortcutEvent(_ event: ShortcutEvent) {
@@ -1336,6 +1348,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
         os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+        guard ensureScreenCaptureAccess() else { return }
+        os_log(.info, log: recordingLog, "screen capture check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
         let selectionSnapshot = scheduledSelectionSnapshot ?? contextService.collectSelectionSnapshot()
         let manualCommandRequested = scheduledSelectionSnapshot == nil
             ? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
@@ -1351,6 +1365,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
         os_log(.info, log: recordingLog, "mic access check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
         beginRecording(triggerMode: triggerMode)
         os_log(.info, log: recordingLog, "startRecording() finished: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+    }
+
+    private func ensureScreenCaptureAccess() -> Bool {
+        let granted = hasScreenCapturePermission()
+        hasScreenRecordingPermission = granted
+        guard granted else {
+            let message = "Screen recording permission not granted. Enable in System Settings > Privacy & Security > Screen Recording."
+            errorMessage = message
+            statusText = "Screenshot Required"
+            activeRecordingTriggerMode = nil
+            currentSessionIntent = .dictation
+            shortcutSessionController.reset()
+            playAlertSound(named: "Basso")
+            showScreenshotPermissionAlert(message: message)
+            return false
+        }
+
+        return true
     }
 
     private func ensureMicrophoneAccess() -> Bool {
@@ -1999,6 +2031,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         os_log(.error, "Screenshot capture issue: %{public}@", message)
 
         if isScreenCapturePermissionError(message) && !hasShownScreenshotPermissionAlert {
+            hasScreenRecordingPermission = false
+            errorMessage = message
             hasShownScreenshotPermissionAlert = true
 
             // Permission errors are fatal — stop recording

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -1,0 +1,134 @@
+import Cocoa
+
+final class GlobalShortcutBackend {
+    private var eventTap: CFMachPort?
+    private var eventTapRunLoopSource: CFRunLoopSource?
+    private var pressedModifierKeyCodes: Set<UInt16> = []
+
+    var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
+    var onEscapeKeyPressed: (() -> Bool)?
+
+    func start() {
+        stop()
+        installEventTap()
+    }
+
+    func stop() {
+        if let source = eventTapRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        eventTapRunLoopSource = nil
+        if let tap = eventTap {
+            CFMachPortInvalidate(tap)
+        }
+        eventTap = nil
+        pressedModifierKeyCodes.removeAll()
+    }
+
+    deinit {
+        stop()
+    }
+
+    private func installEventTap() {
+        let eventMask = [
+            CGEventType.flagsChanged,
+            CGEventType.keyDown,
+            CGEventType.keyUp
+        ].reduce(CGEventMask(0)) { partialResult, eventType in
+            partialResult | (CGEventMask(1) << eventType.rawValue)
+        }
+
+        let callback: CGEventTapCallBack = { _, type, event, userInfo in
+            guard let userInfo else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let backend = Unmanaged<GlobalShortcutBackend>.fromOpaque(userInfo).takeUnretainedValue()
+            return backend.handleEventTap(type: type, event: event)
+        }
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: callback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            return
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        eventTap = tap
+        eventTapRunLoopSource = source
+    }
+
+    private func handleEventTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        switch type {
+        case .tapDisabledByTimeout, .tapDisabledByUserInput:
+            pressedModifierKeyCodes.removeAll()
+            _ = onInputEvent?(.backendReset)
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+
+        case .flagsChanged, .keyDown, .keyUp:
+            guard let nsEvent = NSEvent(cgEvent: event) else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let shouldConsume: Bool
+            switch type {
+            case .flagsChanged:
+                shouldConsume = handleFlagsChanged(nsEvent)
+            case .keyDown:
+                shouldConsume = handleKeyDown(nsEvent)
+            case .keyUp:
+                shouldConsume = handleKeyUp(nsEvent)
+            default:
+                shouldConsume = false
+            }
+
+            return shouldConsume ? nil : Unmanaged.passUnretained(event)
+
+        default:
+            return Unmanaged.passUnretained(event)
+        }
+    }
+
+    private func handleFlagsChanged(_ event: NSEvent) -> Bool {
+        guard ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else {
+            return false
+        }
+
+        let isDown: Bool
+        if pressedModifierKeyCodes.contains(event.keyCode) {
+            pressedModifierKeyCodes.remove(event.keyCode)
+            isDown = false
+        } else {
+            pressedModifierKeyCodes.insert(event.keyCode)
+            isDown = true
+        }
+
+        return onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown)) == .consume
+    }
+
+    private func handleKeyDown(_ event: NSEvent) -> Bool {
+        if event.keyCode == 53 {
+            guard !event.isARepeat else { return false }
+            return onEscapeKeyPressed?() ?? false
+        }
+
+        guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
+        return onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat)) == .consume
+    }
+
+    private func handleKeyUp(_ event: NSEvent) -> Bool {
+        guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
+        return onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: false, isRepeat: false)) == .consume
+    }
+}

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -20,7 +20,6 @@ enum GlobalShortcutBackendError: LocalizedError {
 final class GlobalShortcutBackend {
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
-    private var pressedModifierKeyCodes: Set<UInt16> = []
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
     var onEscapeKeyPressed: (() -> Bool)?
@@ -31,15 +30,8 @@ final class GlobalShortcutBackend {
     }
 
     func stop() {
-        if let source = eventTapRunLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-        }
-        eventTapRunLoopSource = nil
-        if let tap = eventTap {
-            CFMachPortInvalidate(tap)
-        }
-        eventTap = nil
-        pressedModifierKeyCodes.removeAll()
+        tearDownEventTap()
+        notifyBackendReset()
     }
 
     deinit {
@@ -89,11 +81,25 @@ final class GlobalShortcutBackend {
         eventTapRunLoopSource = source
     }
 
+    private func tearDownEventTap() {
+        if let source = eventTapRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        eventTapRunLoopSource = nil
+        if let tap = eventTap {
+            CFMachPortInvalidate(tap)
+        }
+        eventTap = nil
+    }
+
+    private func notifyBackendReset() {
+        _ = onInputEvent?(.backendReset)
+    }
+
     private func handleEventTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
-            pressedModifierKeyCodes.removeAll()
-            _ = onInputEvent?(.backendReset)
+            notifyBackendReset()
             if let tap = eventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)
             }
@@ -127,12 +133,6 @@ final class GlobalShortcutBackend {
         guard ShortcutBinding.modifierKeyCodes.contains(event.keyCode),
               let isDown = ModifierKeyEventState.isKeyDown(for: event) else {
             return false
-        }
-
-        if isDown {
-            pressedModifierKeyCodes.insert(event.keyCode)
-        } else {
-            pressedModifierKeyCodes.remove(event.keyCode)
         }
 
         return onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown)) == .consume

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -5,11 +5,14 @@ private let shortcutLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "
 
 enum GlobalShortcutBackendError: LocalizedError {
     case eventTapUnavailable
+    case eventTapRunLoopSourceUnavailable
 
     var errorDescription: String? {
         switch self {
         case .eventTapUnavailable:
             return "Global shortcut monitoring could not start. FreeFlow requires keyboard monitoring permission for global shortcuts."
+        case .eventTapRunLoopSourceUnavailable:
+            return "Global shortcut monitoring could not start because the event tap run loop source could not be created."
         }
     }
 }
@@ -73,7 +76,12 @@ final class GlobalShortcutBackend {
             throw GlobalShortcutBackendError.eventTapUnavailable
         }
 
-        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            CFMachPortInvalidate(tap)
+            os_log(.error, log: shortcutLog, "Failed to create run loop source for global shortcut event tap")
+            throw GlobalShortcutBackendError.eventTapRunLoopSourceUnavailable
+        }
+
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
 

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -1,4 +1,18 @@
 import Cocoa
+import os.log
+
+private let shortcutLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Shortcuts")
+
+enum GlobalShortcutBackendError: LocalizedError {
+    case eventTapUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .eventTapUnavailable:
+            return "Global shortcut monitoring could not start. FreeFlow requires keyboard monitoring permission for global shortcuts."
+        }
+    }
+}
 
 final class GlobalShortcutBackend {
     private var eventTap: CFMachPort?
@@ -8,9 +22,9 @@ final class GlobalShortcutBackend {
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
     var onEscapeKeyPressed: (() -> Bool)?
 
-    func start() {
+    func start() throws {
         stop()
-        installEventTap()
+        try installEventTap()
     }
 
     func stop() {
@@ -29,7 +43,7 @@ final class GlobalShortcutBackend {
         stop()
     }
 
-    private func installEventTap() {
+    private func installEventTap() throws {
         let eventMask = [
             CGEventType.flagsChanged,
             CGEventType.keyDown,
@@ -55,7 +69,8 @@ final class GlobalShortcutBackend {
             callback: callback,
             userInfo: Unmanaged.passUnretained(self).toOpaque()
         ) else {
-            return
+            os_log(.error, log: shortcutLog, "Failed to install global shortcut event tap")
+            throw GlobalShortcutBackendError.eventTapUnavailable
         }
 
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
@@ -101,17 +116,15 @@ final class GlobalShortcutBackend {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) -> Bool {
-        guard ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else {
+        guard ShortcutBinding.modifierKeyCodes.contains(event.keyCode),
+              let isDown = ModifierKeyEventState.isKeyDown(for: event) else {
             return false
         }
 
-        let isDown: Bool
-        if pressedModifierKeyCodes.contains(event.keyCode) {
-            pressedModifierKeyCodes.remove(event.keyCode)
-            isDown = false
-        } else {
+        if isDown {
             pressedModifierKeyCodes.insert(event.keyCode)
-            isDown = true
+        } else {
+            pressedModifierKeyCodes.remove(event.keyCode)
         }
 
         return onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown)) == .consume

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -145,11 +145,23 @@ final class GlobalShortcutBackend {
         }
 
         guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
-        return onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat)) == .consume
+        let snapshotDecision = onInputEvent?(
+            .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(for: event))
+        ) ?? .passthrough
+        let keyDecision = onInputEvent?(
+            .keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat)
+        ) ?? .passthrough
+        return snapshotDecision == .consume || keyDecision == .consume
     }
 
     private func handleKeyUp(_ event: NSEvent) -> Bool {
         guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
-        return onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: false, isRepeat: false)) == .consume
+        let snapshotDecision = onInputEvent?(
+            .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(for: event))
+        ) ?? .passthrough
+        let keyDecision = onInputEvent?(
+            .keyChanged(keyCode: event.keyCode, isDown: false, isRepeat: false)
+        ) ?? .passthrough
+        return snapshotDecision == .consume || keyDecision == .consume
     }
 }

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -1,376 +1,57 @@
 import Cocoa
 
 final class HotkeyManager {
-    private var localFlagsMonitor: Any?
-    private var localKeyDownMonitor: Any?
-    private var localKeyUpMonitor: Any?
-    private var eventTap: CFMachPort?
-    private var eventTapRunLoopSource: CFRunLoopSource?
-
+    private let backend = GlobalShortcutBackend()
     private var configuration = ShortcutConfiguration(
         hold: .defaultHold,
         toggle: .defaultToggle
     )
-    private var pressedKeyCodes: Set<UInt16> = []
-    private var pressedModifierKeyCodes: Set<UInt16> = []
-    private var holdIsActive = false
-    private var toggleIsActive = false
+    private var inputState = ShortcutInputState()
 
     var onShortcutEvent: ((ShortcutEvent) -> Void)?
     var onEscapeKeyPressed: (() -> Bool)?
 
     var currentPressedModifiers: ShortcutModifiers {
-        currentModifiers
+        inputState.currentModifiers
+    }
+
+    var hasPressedShortcutInputs: Bool {
+        inputState.hasPressedShortcutInputs(configuration: configuration)
     }
 
     func start(configuration: ShortcutConfiguration) {
         stop()
         self.configuration = configuration
-        installMonitors()
+        backend.onInputEvent = { [weak self] event in
+            self?.handleInputEvent(event) ?? .passthrough
+        }
+        backend.onEscapeKeyPressed = { [weak self] in
+            self?.onEscapeKeyPressed?() ?? false
+        }
+        backend.start()
     }
 
     func stop() {
-        if let monitor = localFlagsMonitor { NSEvent.removeMonitor(monitor) }
-        if let monitor = localKeyDownMonitor { NSEvent.removeMonitor(monitor) }
-        if let monitor = localKeyUpMonitor { NSEvent.removeMonitor(monitor) }
-        localFlagsMonitor = nil
-        localKeyDownMonitor = nil
-        localKeyUpMonitor = nil
-        if let source = eventTapRunLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-        }
-        eventTapRunLoopSource = nil
-        if let tap = eventTap {
-            CFMachPortInvalidate(tap)
-        }
-        eventTap = nil
-        pressedKeyCodes.removeAll()
-        pressedModifierKeyCodes.removeAll()
-        holdIsActive = false
-        toggleIsActive = false
+        backend.stop()
+        backend.onInputEvent = nil
+        backend.onEscapeKeyPressed = nil
+        inputState = ShortcutInputState()
     }
 
     deinit {
         stop()
     }
 
-    private func installMonitors() {
-        installEventTap()
-
-        // Fall back to local monitors if the event tap cannot be installed.
-        guard eventTap == nil else { return }
-
-        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-            let shouldConsume = self?.handleFlagsChanged(event) ?? false
-            return shouldConsume ? nil : event
-        }
-        localKeyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            let shouldConsume = self?.handleKeyDown(event) ?? false
-            return shouldConsume ? nil : event
-        }
-        localKeyUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyUp) { [weak self] event in
-            let shouldConsume = self?.handleKeyUp(event) ?? false
-            return shouldConsume ? nil : event
-        }
-    }
-
-    var hasPressedShortcutInputs: Bool {
-        pressedKeyCodes.contains(where: shortcutReferencesKeyCode)
-            || pressedModifierKeyCodes.contains(where: shortcutReferencesModifierKeyCode)
-    }
-
-    private func installEventTap() {
-        let eventMask = [
-            CGEventType.flagsChanged,
-            CGEventType.keyDown,
-            CGEventType.keyUp
-        ].reduce(CGEventMask(0)) { partialResult, eventType in
-            partialResult | (CGEventMask(1) << eventType.rawValue)
-        }
-
-        let callback: CGEventTapCallBack = { _, type, event, userInfo in
-            guard let userInfo else {
-                return Unmanaged.passUnretained(event)
-            }
-
-            let manager = Unmanaged<HotkeyManager>.fromOpaque(userInfo).takeUnretainedValue()
-            return manager.handleEventTap(type: type, event: event)
-        }
-
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: eventMask,
-            callback: callback,
-            userInfo: Unmanaged.passUnretained(self).toOpaque()
-        ) else {
-            return
-        }
-
-        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
-
-        eventTap = tap
-        eventTapRunLoopSource = source
-    }
-
-    private func handleEventTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        switch type {
-        case .tapDisabledByTimeout, .tapDisabledByUserInput:
-            if let tap = eventTap {
-                CGEvent.tapEnable(tap: tap, enable: true)
-            }
-            return Unmanaged.passUnretained(event)
-        case .flagsChanged, .keyDown, .keyUp:
-            guard let nsEvent = NSEvent(cgEvent: event) else {
-                return Unmanaged.passUnretained(event)
-            }
-
-            let shouldConsume: Bool
-            switch type {
-            case .flagsChanged:
-                shouldConsume = handleFlagsChanged(nsEvent)
-            case .keyDown:
-                shouldConsume = handleKeyDown(nsEvent)
-            case .keyUp:
-                shouldConsume = handleKeyUp(nsEvent)
-            default:
-                shouldConsume = false
-            }
-
-            return shouldConsume ? nil : Unmanaged.passUnretained(event)
-        default:
-            return Unmanaged.passUnretained(event)
-        }
-    }
-
-    private func handleFlagsChanged(_ event: NSEvent) -> Bool {
-        let shouldConsumeBefore = shouldConsumeModifierEvent(
-            for: event.keyCode,
-            pressedKeys: pressedKeyCodes,
-            pressedModifiers: pressedModifierKeyCodes
+    private func handleInputEvent(_ event: ShortcutInputEvent) -> ShortcutConsumeDecision {
+        let result = ShortcutMatcher.reduce(
+            state: inputState,
+            event: event,
+            configuration: configuration
         )
-
-        if ShortcutBinding.modifierKeyCodes.contains(event.keyCode) {
-            var updatedModifierKeyCodes = pressedModifierKeyCodes
-            if updatedModifierKeyCodes.contains(event.keyCode) {
-                updatedModifierKeyCodes.remove(event.keyCode)
-            } else {
-                updatedModifierKeyCodes.insert(event.keyCode)
-            }
-            pressedModifierKeyCodes = updatedModifierKeyCodes
-        }
-
-        let shouldConsumeAfter = shouldConsumeModifierEvent(
-            for: event.keyCode,
-            pressedKeys: pressedKeyCodes,
-            pressedModifiers: pressedModifierKeyCodes
-        )
-        evaluateActiveBindings()
-        return shouldConsumeBefore || shouldConsumeAfter
-    }
-
-    private func handleKeyDown(_ event: NSEvent) -> Bool {
-        if event.keyCode == 53 {
-            guard !event.isARepeat else { return false }
-            return onEscapeKeyPressed?() ?? false
-        }
-
-        guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
-
-        let shouldConsumeBefore = shouldConsumeKeyEvent(
-            for: event.keyCode,
-            pressedKeys: pressedKeyCodes,
-            pressedModifiers: pressedModifierKeyCodes
-        )
-        guard !event.isARepeat else { return shouldConsumeBefore }
-
-        var updatedKeyCodes = pressedKeyCodes
-        updatedKeyCodes.insert(event.keyCode)
-        pressedKeyCodes = updatedKeyCodes
-
-        let shouldConsumeAfter = shouldConsumeKeyEvent(
-            for: event.keyCode,
-            pressedKeys: pressedKeyCodes,
-            pressedModifiers: pressedModifierKeyCodes
-        )
-        evaluateActiveBindings()
-        return shouldConsumeBefore || shouldConsumeAfter
-    }
-
-    private func handleKeyUp(_ event: NSEvent) -> Bool {
-        guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
-
-        let shouldConsumeBefore = shouldConsumeKeyEvent(
-            for: event.keyCode,
-            pressedKeys: pressedKeyCodes,
-            pressedModifiers: pressedModifierKeyCodes
-        )
-
-        var updatedKeyCodes = pressedKeyCodes
-        updatedKeyCodes.remove(event.keyCode)
-        pressedKeyCodes = updatedKeyCodes
-
-        let shouldConsumeAfter = shouldConsumeKeyEvent(
-            for: event.keyCode,
-            pressedKeys: pressedKeyCodes,
-            pressedModifiers: pressedModifierKeyCodes
-        )
-        evaluateActiveBindings()
-        return shouldConsumeBefore || shouldConsumeAfter
-    }
-
-    private func evaluateActiveBindings() {
-        let previousHold = holdIsActive
-        let previousToggle = toggleIsActive
-
-        holdIsActive = bindingIsActive(configuration.hold)
-        toggleIsActive = bindingIsActive(configuration.toggle)
-
-        emitChanges(
-            previousHold: previousHold,
-            previousToggle: previousToggle,
-            currentHold: holdIsActive,
-            currentToggle: toggleIsActive
-        )
-    }
-
-    private func emitChanges(
-        previousHold: Bool,
-        previousToggle: Bool,
-        currentHold: Bool,
-        currentToggle: Bool
-    ) {
-        var activations: [(ShortcutEvent, Int)] = []
-        var deactivations: [(ShortcutEvent, Int)] = []
-
-        if !previousHold && currentHold {
-            activations.append((.holdActivated, configuration.hold.specificityScore))
-        }
-        if !previousToggle && currentToggle {
-            activations.append((.toggleActivated, configuration.toggle.specificityScore))
-        }
-        if previousHold && !currentHold {
-            deactivations.append((.holdDeactivated, configuration.hold.specificityScore))
-        }
-        if previousToggle && !currentToggle {
-            deactivations.append((.toggleDeactivated, configuration.toggle.specificityScore))
-        }
-
-        for (event, _) in activations.sorted(by: { $0.1 > $1.1 }) {
+        inputState = result.state
+        for event in result.emittedEvents {
             onShortcutEvent?(event)
         }
-        for (event, _) in deactivations.sorted(by: { $0.1 < $1.1 }) {
-            onShortcutEvent?(event)
-        }
-    }
-
-    private func bindingIsActive(_ binding: ShortcutBinding) -> Bool {
-        bindingIsActive(
-            binding,
-            pressedKeys: pressedKeyCodes,
-            pressedModifiers: pressedModifierKeyCodes
-        )
-    }
-
-    private func bindingIsActive(
-        _ binding: ShortcutBinding,
-        pressedKeys: Set<UInt16>,
-        pressedModifiers: Set<UInt16>
-    ) -> Bool {
-        guard !binding.isDisabled else { return false }
-        let activeModifiers = currentModifiers(for: pressedModifiers)
-        guard activeModifiers.isSuperset(of: binding.modifiers) else {
-            return false
-        }
-
-        switch binding.kind {
-        case .disabled:
-            return false
-        case .key:
-            return pressedKeys.contains(binding.keyCode)
-        case .modifierKey:
-            return pressedModifiers.contains(binding.keyCode)
-        }
-    }
-
-    private var currentModifiers: ShortcutModifiers {
-        currentModifiers(for: pressedModifierKeyCodes)
-    }
-
-    private func currentModifiers(for pressedModifiers: Set<UInt16>) -> ShortcutModifiers {
-        var modifiers: ShortcutModifiers = []
-        if pressedModifiers.contains(54) || pressedModifiers.contains(55) {
-            modifiers.insert(.command)
-        }
-        if pressedModifiers.contains(59) || pressedModifiers.contains(62) {
-            modifiers.insert(.control)
-        }
-        if pressedModifiers.contains(58) || pressedModifiers.contains(61) {
-            modifiers.insert(.option)
-        }
-        if pressedModifiers.contains(56) || pressedModifiers.contains(60) {
-            modifiers.insert(.shift)
-        }
-        if pressedModifiers.contains(63) {
-            modifiers.insert(.function)
-        }
-        return modifiers
-    }
-
-    private func shouldConsumeKeyEvent(
-        for keyCode: UInt16,
-        pressedKeys: Set<UInt16>,
-        pressedModifiers: Set<UInt16>
-    ) -> Bool {
-        relevantBindings(for: keyCode, kind: .key).contains {
-            bindingIsActive($0, pressedKeys: pressedKeys, pressedModifiers: pressedModifiers)
-        }
-    }
-
-    private func shouldConsumeModifierEvent(
-        for keyCode: UInt16,
-        pressedKeys: Set<UInt16>,
-        pressedModifiers: Set<UInt16>
-    ) -> Bool {
-        relevantBindings(for: keyCode, kind: .modifierKey).contains {
-            bindingIsActive($0, pressedKeys: pressedKeys, pressedModifiers: pressedModifiers)
-        }
-    }
-
-    private func relevantBindings(for keyCode: UInt16, kind: ShortcutBindingKind) -> [ShortcutBinding] {
-        [configuration.hold, configuration.toggle].filter { binding in
-            binding.kind == kind && binding.keyCode == keyCode
-        }
-    }
-
-    private func shortcutReferencesKeyCode(_ keyCode: UInt16) -> Bool {
-        configuration.hold.kind == .key && configuration.hold.keyCode == keyCode
-            || configuration.toggle.kind == .key && configuration.toggle.keyCode == keyCode
-    }
-
-    private func shortcutReferencesModifierKeyCode(_ keyCode: UInt16) -> Bool {
-        configuration.hold.kind == .modifierKey && configuration.hold.keyCode == keyCode
-            || configuration.toggle.kind == .modifierKey && configuration.toggle.keyCode == keyCode
-            || modifierFlagsForKeyCode(keyCode).map { configuration.hold.modifiers.contains($0) || configuration.toggle.modifiers.contains($0) } == true
-    }
-
-    private func modifierFlagsForKeyCode(_ keyCode: UInt16) -> ShortcutModifiers? {
-        switch keyCode {
-        case 54, 55:
-            return .command
-        case 59, 62:
-            return .control
-        case 58, 61:
-            return .option
-        case 56, 60:
-            return .shift
-        case 63:
-            return .function
-        default:
-            return nil
-        }
+        return result.consumeDecision
     }
 }

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -19,7 +19,7 @@ final class HotkeyManager {
         inputState.hasPressedShortcutInputs(configuration: configuration)
     }
 
-    func start(configuration: ShortcutConfiguration) {
+    func start(configuration: ShortcutConfiguration) throws {
         stop()
         self.configuration = configuration
         backend.onInputEvent = { [weak self] event in
@@ -28,7 +28,14 @@ final class HotkeyManager {
         backend.onEscapeKeyPressed = { [weak self] in
             self?.onEscapeKeyPressed?() ?? false
         }
-        backend.start()
+        do {
+            try backend.start()
+        } catch {
+            backend.onInputEvent = nil
+            backend.onEscapeKeyPressed = nil
+            inputState = ShortcutInputState()
+            throw error
+        }
     }
 
     func stop() {

--- a/Sources/LocalShortcutCaptureBackend.swift
+++ b/Sources/LocalShortcutCaptureBackend.swift
@@ -1,0 +1,62 @@
+import AppKit
+
+final class LocalShortcutCaptureBackend {
+    private var localFlagsMonitor: Any?
+    private var localKeyDownMonitor: Any?
+    private var pressedModifierKeyCodes: Set<UInt16> = []
+
+    var onInputEvent: ((ShortcutInputEvent) -> Void)?
+    var onKeyDownEvent: ((NSEvent) -> Void)?
+
+    func start() {
+        stop()
+
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.handleFlagsChanged(event)
+            return nil
+        }
+
+        localKeyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyDown(event)
+            return nil
+        }
+    }
+
+    func stop() {
+        if let monitor = localKeyDownMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        if let monitor = localFlagsMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        localKeyDownMonitor = nil
+        localFlagsMonitor = nil
+        pressedModifierKeyCodes.removeAll()
+    }
+
+    deinit {
+        stop()
+    }
+
+    private func handleFlagsChanged(_ event: NSEvent) {
+        guard ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return }
+
+        let isDown: Bool
+        if pressedModifierKeyCodes.contains(event.keyCode) {
+            pressedModifierKeyCodes.remove(event.keyCode)
+            isDown = false
+        } else {
+            pressedModifierKeyCodes.insert(event.keyCode)
+            isDown = true
+        }
+
+        onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown))
+    }
+
+    private func handleKeyDown(_ event: NSEvent) {
+        if !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) {
+            onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat))
+        }
+        onKeyDownEvent?(event)
+    }
+}

--- a/Sources/LocalShortcutCaptureBackend.swift
+++ b/Sources/LocalShortcutCaptureBackend.swift
@@ -39,15 +39,13 @@ final class LocalShortcutCaptureBackend {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        guard ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return }
+        guard ShortcutBinding.modifierKeyCodes.contains(event.keyCode),
+              let isDown = ModifierKeyEventState.isKeyDown(for: event) else { return }
 
-        let isDown: Bool
-        if pressedModifierKeyCodes.contains(event.keyCode) {
-            pressedModifierKeyCodes.remove(event.keyCode)
-            isDown = false
-        } else {
+        if isDown {
             pressedModifierKeyCodes.insert(event.keyCode)
-            isDown = true
+        } else {
+            pressedModifierKeyCodes.remove(event.keyCode)
         }
 
         onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown))

--- a/Sources/LocalShortcutCaptureBackend.swift
+++ b/Sources/LocalShortcutCaptureBackend.swift
@@ -53,6 +53,7 @@ final class LocalShortcutCaptureBackend {
 
     private func handleKeyDown(_ event: NSEvent) {
         if !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) {
+            onInputEvent?(.modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(for: event)))
             onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat))
         }
         onKeyDownEvent?(event)

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -292,8 +292,3 @@ struct MenuBarView: View {
         .padding(4)
     }
 }
-
-extension Notification.Name {
-    static let showSetup = Notification.Name("showSetup")
-    static let showSettings = Notification.Name("showSettings")
-}

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -80,6 +80,15 @@ struct MenuBarView: View {
             }
             .disabled(appState.isTranscribing)
 
+            if let hotkeyError = appState.hotkeyMonitoringErrorMessage {
+                Divider()
+                Text(hotkeyError)
+                    .foregroundStyle(.red)
+                    .font(.caption)
+                    .padding(.horizontal, 16)
+                    .lineLimit(3)
+            }
+
             if let error = appState.errorMessage {
                 Divider()
                 Text(error)

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -9,6 +9,15 @@ enum ModifierKeyEventState {
         return event.modifierFlags.contains(mappedFlag)
     }
 
+    static func pressedModifierKeyCodes(for event: NSEvent) -> Set<UInt16> {
+        ShortcutBinding.modifierKeyCodes.filter { keyCode in
+            guard let mappedFlag = mappedFlag(for: keyCode) else {
+                return false
+            }
+            return event.modifierFlags.contains(mappedFlag)
+        }
+    }
+
     private static func mappedFlag(for keyCode: UInt16) -> NSEvent.ModifierFlags? {
         switch keyCode {
         case 54:

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -1,0 +1,47 @@
+import AppKit
+import Carbon.HIToolbox
+
+enum ModifierKeyEventState {
+    static func isKeyDown(for event: NSEvent) -> Bool? {
+        guard let mappedFlag = mappedFlag(for: event.keyCode) else {
+            return nil
+        }
+        return event.modifierFlags.contains(mappedFlag)
+    }
+
+    private static func mappedFlag(for keyCode: UInt16) -> NSEvent.ModifierFlags? {
+        switch keyCode {
+        case 54:
+            return .rightCommand
+        case 55:
+            return .leftCommand
+        case 56:
+            return .leftShift
+        case 58:
+            return .leftOption
+        case 59:
+            return .leftControl
+        case 60:
+            return .rightShift
+        case 61:
+            return .rightOption
+        case 62:
+            return .rightControl
+        case 63:
+            return .function
+        default:
+            return nil
+        }
+    }
+}
+
+private extension NSEvent.ModifierFlags {
+    static let leftControl = Self(rawValue: UInt(NX_DEVICELCTLKEYMASK))
+    static let leftShift = Self(rawValue: UInt(NX_DEVICELSHIFTKEYMASK))
+    static let rightShift = Self(rawValue: UInt(NX_DEVICERSHIFTKEYMASK))
+    static let leftCommand = Self(rawValue: UInt(NX_DEVICELCMDKEYMASK))
+    static let rightCommand = Self(rawValue: UInt(NX_DEVICERCMDKEYMASK))
+    static let leftOption = Self(rawValue: UInt(NX_DEVICELALTKEYMASK))
+    static let rightOption = Self(rawValue: UInt(NX_DEVICERALTKEYMASK))
+    static let rightControl = Self(rawValue: UInt(NX_DEVICERCTLKEYMASK))
+}

--- a/Sources/Notification+VoiceToText.swift
+++ b/Sources/Notification+VoiceToText.swift
@@ -1,4 +1,6 @@
 import Foundation
 
-// Notification names defined in MenuBarView.swift:
-// .showSetup, .showSettings
+extension Notification.Name {
+    static let showSetup = Notification.Name("showSetup")
+    static let showSettings = Notification.Name("showSettings")
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -910,10 +910,8 @@ struct GeneralSettingsView: View {
                 icon: "mic.fill",
                 granted: micPermissionGranted,
                 action: {
-                    AVCaptureDevice.requestAccess(for: .audio) { granted in
-                        DispatchQueue.main.async {
-                            micPermissionGranted = granted
-                        }
+                    appState.requestMicrophoneAccess { granted in
+                        micPermissionGranted = granted
                     }
                 }
             )

--- a/Sources/SetupTestHotkeyHarness.swift
+++ b/Sources/SetupTestHotkeyHarness.swift
@@ -17,6 +17,9 @@ final class SetupTestHotkeyHarness: ObservableObject {
             guard let action else { return }
             self.handle(action: action, startDelay: startDelay)
         }
+        cancelPendingStart()
+        sessionController.reset()
+        isTranscribing = false
         try hotkeyManager.start(configuration: configuration)
     }
 

--- a/Sources/SetupTestHotkeyHarness.swift
+++ b/Sources/SetupTestHotkeyHarness.swift
@@ -10,14 +10,14 @@ final class SetupTestHotkeyHarness: ObservableObject {
     var isTranscribing = false
     var onAction: ((DictationShortcutAction) -> Void)?
 
-    func start(configuration: ShortcutConfiguration, startDelay: TimeInterval) {
+    func start(configuration: ShortcutConfiguration, startDelay: TimeInterval) throws {
         hotkeyManager.onShortcutEvent = { [weak self] event in
             guard let self else { return }
             let action = self.sessionController.handle(event: event, isTranscribing: self.isTranscribing)
             guard let action else { return }
             self.handle(action: action, startDelay: startDelay)
         }
-        hotkeyManager.start(configuration: configuration)
+        try hotkeyManager.start(configuration: configuration)
     }
 
     func stop() {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -529,13 +529,6 @@ struct SetupView: View {
             .background(Color(nsColor: .controlBackgroundColor))
             .cornerRadius(8)
 
-            if !accessibilityGranted {
-                Text("Note: If you rebuilt the app, you may need to\nremove and re-add it in Accessibility settings.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-
         }
         .onAppear {
             startAccessibilityPolling()
@@ -1100,10 +1093,8 @@ struct SetupView: View {
     }
 
     func requestMicPermission() {
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
-            DispatchQueue.main.async {
-                micPermissionGranted = granted
-            }
+        appState.requestMicrophoneAccess { granted in
+            micPermissionGranted = granted
         }
     }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1243,10 +1243,15 @@ struct SetupView: View {
             }
         }
 
-        testHotkeyHarness.start(configuration: ShortcutConfiguration(
-            hold: appState.holdShortcut,
-            toggle: appState.toggleShortcut
-        ), startDelay: appState.shortcutStartDelay)
+        do {
+            try testHotkeyHarness.start(configuration: ShortcutConfiguration(
+                hold: appState.holdShortcut,
+                toggle: appState.toggleShortcut
+            ), startDelay: appState.shortcutStartDelay)
+        } catch {
+            testError = error.localizedDescription
+            testPhase = .done
+        }
     }
 
     private func stopTestHotkeyMonitoring() {

--- a/Sources/ShortcutBinding.swift
+++ b/Sources/ShortcutBinding.swift
@@ -1,67 +1,5 @@
 import AppKit
 
-struct ShortcutModifiers: OptionSet, Hashable, Codable {
-    let rawValue: Int
-
-    static let command = ShortcutModifiers(rawValue: 1 << 0)
-    static let control = ShortcutModifiers(rawValue: 1 << 1)
-    static let option = ShortcutModifiers(rawValue: 1 << 2)
-    static let shift = ShortcutModifiers(rawValue: 1 << 3)
-    static let function = ShortcutModifiers(rawValue: 1 << 4)
-
-    init(rawValue: Int) {
-        self.rawValue = rawValue
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.init(rawValue: try container.decode(Int.self))
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(rawValue)
-    }
-
-    init(eventFlags: NSEvent.ModifierFlags) {
-        var value: ShortcutModifiers = []
-        if eventFlags.contains(.command) { value.insert(.command) }
-        if eventFlags.contains(.control) { value.insert(.control) }
-        if eventFlags.contains(.option) { value.insert(.option) }
-        if eventFlags.contains(.shift) { value.insert(.shift) }
-        if eventFlags.contains(.function) { value.insert(.function) }
-        self = value
-    }
-
-    var orderedDisplayNames: [String] {
-        var names: [String] = []
-        if contains(.command) { names.append("⌘") }
-        if contains(.control) { names.append("⌃") }
-        if contains(.option) { names.append("⌥") }
-        if contains(.shift) { names.append("⇧") }
-        if contains(.function) { names.append("fn") }
-        return names
-    }
-}
-
-enum ShortcutBindingKind: String, Codable {
-    case disabled
-    case key
-    case modifierKey
-}
-
-enum RecordingTriggerMode: String, Codable {
-    case hold
-    case toggle
-
-    var badgeTitle: String {
-        switch self {
-        case .hold: return "Hold"
-        case .toggle: return "Tap"
-        }
-    }
-}
-
 enum CommandModeStyle: String, CaseIterable, Codable, Identifiable {
     case automatic
     case manual
@@ -103,134 +41,19 @@ enum CommandModeManualModifier: String, CaseIterable, Codable, Identifiable {
     }
 }
 
-enum ShortcutRole {
-    case hold
-    case toggle
-
-    var title: String {
-        switch self {
-        case .hold: return "Hold to Talk"
-        case .toggle: return "Tap to Toggle"
-        }
+extension ShortcutModifiers {
+    init(eventFlags: NSEvent.ModifierFlags) {
+        var value: ShortcutModifiers = []
+        if eventFlags.contains(.command) { value.insert(.command) }
+        if eventFlags.contains(.control) { value.insert(.control) }
+        if eventFlags.contains(.option) { value.insert(.option) }
+        if eventFlags.contains(.shift) { value.insert(.shift) }
+        if eventFlags.contains(.function) { value.insert(.function) }
+        self = value
     }
 }
 
-enum ShortcutEvent {
-    case holdActivated
-    case holdDeactivated
-    case toggleActivated
-    case toggleDeactivated
-}
-
-struct ShortcutConfiguration {
-    let hold: ShortcutBinding
-    let toggle: ShortcutBinding
-}
-
-enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
-    case fnKey = "fn"
-    case rightOption = "rightOption"
-    case f5 = "f5"
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .fnKey: return "Fn (Globe) Key"
-        case .rightOption: return "Right Option Key"
-        case .f5: return "F5 Key"
-        }
-    }
-
-    var binding: ShortcutBinding {
-        switch self {
-        case .fnKey:
-            return ShortcutBinding(
-                keyCode: 63,
-                keyDisplay: "Fn",
-                modifiers: [],
-                kind: .modifierKey,
-                preset: self
-            )
-        case .rightOption:
-            return ShortcutBinding(
-                keyCode: 61,
-                keyDisplay: "Right Option",
-                modifiers: [],
-                kind: .modifierKey,
-                preset: self
-            )
-        case .f5:
-            return ShortcutBinding(
-                keyCode: 96,
-                keyDisplay: "F5",
-                modifiers: [],
-                kind: .key,
-                preset: self
-            )
-        }
-    }
-}
-
-struct ShortcutBinding: Codable, Hashable, Identifiable {
-    let keyCode: UInt16
-    let keyDisplay: String
-    let modifiers: ShortcutModifiers
-    let kind: ShortcutBindingKind
-    let preset: ShortcutPreset?
-
-    var id: String {
-        "\(kind.rawValue):\(keyCode):\(modifiers.rawValue):\(preset?.rawValue ?? "custom")"
-    }
-
-    var displayName: String {
-        if isDisabled { return "Disabled" }
-        let parts = modifiers.orderedDisplayNames + [keyDisplay]
-        return parts.joined(separator: " + ")
-    }
-
-    var selectionTitle: String {
-        preset?.title ?? displayName
-    }
-
-    var isCustom: Bool {
-        preset == nil && !isDisabled
-    }
-
-    var isDisabled: Bool {
-        kind == .disabled
-    }
-
-    var specificityScore: Int {
-        modifiers.orderedDisplayNames.count
-    }
-
-    var usesFnKey: Bool {
-        guard !isDisabled else { return false }
-        return keyCode == 63 || modifiers.contains(.function)
-    }
-
-    func withAddedModifiers(_ extraModifiers: ShortcutModifiers) -> ShortcutBinding {
-        guard !isDisabled else { return self }
-        return ShortcutBinding(
-            keyCode: keyCode,
-            keyDisplay: keyDisplay,
-            modifiers: modifiers.union(extraModifiers),
-            kind: kind,
-            preset: preset
-        )
-    }
-
-    static let disabled = ShortcutBinding(
-        keyCode: 0,
-        keyDisplay: "Disabled",
-        modifiers: [],
-        kind: .disabled,
-        preset: nil
-    )
-    static let defaultHold = ShortcutPreset.fnKey.binding
-    static let defaultToggle = ShortcutPreset.fnKey.binding.withAddedModifiers(.command)
-
+extension ShortcutBinding {
     static func from(event: NSEvent) -> ShortcutBinding? {
         guard !event.isARepeat else { return nil }
         guard !Self.modifierKeyCodes.contains(event.keyCode) else { return nil }
@@ -253,7 +76,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable {
         allowBareModifier: Bool = false
     ) -> ShortcutBinding? {
         guard modifierKeyCodes.contains(keyCode),
-              let primaryModifier = modifierFlag(forKeyCode: keyCode) else {
+              let primaryModifier = logicalModifier(forKeyCode: keyCode) else {
             return nil
         }
 
@@ -270,14 +93,12 @@ struct ShortcutBinding: Codable, Hashable, Identifiable {
 
         return ShortcutBinding(
             keyCode: keyCode,
-            keyDisplay: modifierDisplayLabel(for: keyCode),
+            keyDisplay: displayLabel(for: keyCode),
             modifiers: extraModifiers,
             kind: .modifierKey,
             preset: nil
         )
     }
-
-    static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
 
     static func displayLabel(for keyCode: UInt16, event: NSEvent? = nil) -> String {
         if let modifierName = modifierKeyNames[keyCode] {
@@ -298,37 +119,6 @@ struct ShortcutBinding: Codable, Hashable, Identifiable {
             return trimmed.uppercased()
         }
         return trimmed
-    }
-
-    private static func modifierFlag(forKeyCode keyCode: UInt16) -> ShortcutModifiers? {
-        switch keyCode {
-        case 54, 55:
-            return .command
-        case 59, 62:
-            return .control
-        case 58, 61:
-            return .option
-        case 56, 60:
-            return .shift
-        case 63:
-            return .function
-        default:
-            return nil
-        }
-    }
-
-    private static func modifiers(for pressedModifierKeyCodes: Set<UInt16>) -> ShortcutModifiers {
-        var modifiers: ShortcutModifiers = []
-        for keyCode in pressedModifierKeyCodes {
-            if let modifier = modifierFlag(forKeyCode: keyCode) {
-                modifiers.insert(modifier)
-            }
-        }
-        return modifiers
-    }
-
-    private static func modifierDisplayLabel(for keyCode: UInt16) -> String {
-        modifierKeyNames[keyCode] ?? "Modifier"
     }
 
     private static let modifierKeyNames: [UInt16: String] = [

--- a/Sources/ShortcutBinding.swift
+++ b/Sources/ShortcutBinding.swift
@@ -54,19 +54,22 @@ extension ShortcutModifiers {
 }
 
 extension ShortcutBinding {
-    static func from(event: NSEvent) -> ShortcutBinding? {
+    static func from(event: NSEvent, pressedModifierKeyCodes: Set<UInt16>) -> ShortcutBinding? {
         guard !event.isARepeat else { return nil }
         guard !Self.modifierKeyCodes.contains(event.keyCode) else { return nil }
 
         let label = Self.displayLabel(for: event.keyCode, event: event)
         guard !label.isEmpty else { return nil }
 
+        let exactModifierKeyCodes = Self.normalizedExactModifierKeyCodes(pressedModifierKeyCodes)
+
         return ShortcutBinding(
             keyCode: event.keyCode,
             keyDisplay: label,
-            modifiers: ShortcutModifiers(eventFlags: event.modifierFlags),
+            modifiers: Self.modifiers(for: pressedModifierKeyCodes),
             kind: .key,
-            preset: nil
+            preset: nil,
+            exactModifierKeyCodes: exactModifierKeyCodes
         )
     }
 
@@ -96,7 +99,8 @@ extension ShortcutBinding {
             keyDisplay: displayLabel(for: keyCode),
             modifiers: extraModifiers,
             kind: .modifierKey,
-            preset: nil
+            preset: nil,
+            exactModifierKeyCodes: normalizedExactModifierKeyCodes(pressedModifierKeyCodes)
         )
     }
 

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -148,9 +148,8 @@ private struct ShortcutCaptureRow: View {
     let onSelectSaved: (ShortcutBinding) -> Void
     let onCapture: (ShortcutBinding) -> Void
 
-    @State private var localKeyMonitor: Any?
-    @State private var localFlagsMonitor: Any?
-    @State private var pressedModifierKeyCodes: Set<UInt16> = []
+    @State private var captureBackend: LocalShortcutCaptureBackend?
+    @State private var captureInputState = ShortcutInputState()
     @State private var currentBinding: ShortcutBinding?
 
     var body: some View {
@@ -225,52 +224,52 @@ private struct ShortcutCaptureRow: View {
     private func startCapture() {
         stopCapture(clearCaptureState: false)
         isCapturing = true
-        pressedModifierKeyCodes.removeAll()
+        captureInputState = ShortcutInputState()
         currentBinding = nil
 
-        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
-            if ShortcutBinding.modifierKeyCodes.contains(event.keyCode) {
-                if pressedModifierKeyCodes.contains(event.keyCode) {
-                    pressedModifierKeyCodes.remove(event.keyCode)
-                } else {
-                    pressedModifierKeyCodes.insert(event.keyCode)
-                }
-            }
+        let backend = LocalShortcutCaptureBackend()
+        backend.onInputEvent = { inputEvent in
+            let result = ShortcutMatcher.reduce(
+                state: captureInputState,
+                event: inputEvent,
+                configuration: .disabled
+            )
+            captureInputState = result.state
 
+            guard case .modifierChanged(let keyCode, _) = inputEvent else { return }
             if let binding = ShortcutBinding.fromModifierKeyCode(
-                event.keyCode,
-                pressedModifierKeyCodes: pressedModifierKeyCodes,
+                keyCode,
+                pressedModifierKeyCodes: captureInputState.pressedModifierKeyCodes,
                 allowBareModifier: true
             ) {
                 currentBinding = binding
             }
-            return nil
         }
-
-        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+        backend.onKeyDownEvent = { event in
             let isReturnKey = event.keyCode == 36 || event.keyCode == 76
             let hasPendingCapture = currentBinding != nil
 
             if isReturnKey && hasPendingCapture {
                 finishCapture()
-                return nil
+                return
             }
             if event.keyCode == 53 && hasPendingCapture {
                 finishCapture()
-                return nil
+                return
             }
 
             guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else {
-                return nil
+                return
             }
 
             guard let binding = ShortcutBinding.from(event: event) else {
-                return nil
+                return
             }
 
             currentBinding = binding
-            return nil
         }
+        backend.start()
+        captureBackend = backend
     }
 
     private func finishCapture() {
@@ -287,15 +286,9 @@ private struct ShortcutCaptureRow: View {
     }
 
     private func stopCapture(clearCaptureState: Bool) {
-        if let monitor = localKeyMonitor {
-            NSEvent.removeMonitor(monitor)
-            localKeyMonitor = nil
-        }
-        if let monitor = localFlagsMonitor {
-            NSEvent.removeMonitor(monitor)
-            localFlagsMonitor = nil
-        }
-        pressedModifierKeyCodes.removeAll()
+        captureBackend?.stop()
+        captureBackend = nil
+        captureInputState = ShortcutInputState()
         currentBinding = nil
         if clearCaptureState {
             isCapturing = false

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -262,7 +262,10 @@ private struct ShortcutCaptureRow: View {
                 return
             }
 
-            guard let binding = ShortcutBinding.from(event: event) else {
+            guard let binding = ShortcutBinding.from(
+                event: event,
+                pressedModifierKeyCodes: captureInputState.pressedModifierKeyCodes
+            ) else {
                 return
             }
 

--- a/Sources/ShortcutCore/DictationShortcutSessionController.swift
+++ b/Sources/ShortcutCore/DictationShortcutSessionController.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum DictationShortcutAction {
+enum DictationShortcutAction: Equatable {
     case start(RecordingTriggerMode)
     case stop
     case switchedToToggle

--- a/Sources/ShortcutCore/DictationShortcutSessionController.swift
+++ b/Sources/ShortcutCore/DictationShortcutSessionController.swift
@@ -27,7 +27,9 @@ final class DictationShortcutSessionController {
             }
         }
 
-        switch activeMode {
+        guard let mode = activeMode else { return nil }
+
+        switch mode {
         case .hold:
             switch event {
             case .toggleActivated:
@@ -53,9 +55,6 @@ final class DictationShortcutSessionController {
             case .holdActivated, .holdDeactivated:
                 return nil
             }
-
-        case .none:
-            return nil
         }
     }
 

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -1,0 +1,286 @@
+import Foundation
+
+enum ShortcutInputEvent: Equatable {
+    case modifierChanged(keyCode: UInt16, isDown: Bool)
+    case keyChanged(keyCode: UInt16, isDown: Bool, isRepeat: Bool)
+    case backendReset
+}
+
+enum ShortcutConsumeDecision: Equatable {
+    case consume
+    case passthrough
+}
+
+struct ShortcutInputState: Equatable {
+    var pressedKeyCodes: Set<UInt16> = []
+    var pressedModifierKeyCodes: Set<UInt16> = []
+    var holdIsActive = false
+    var toggleIsActive = false
+
+    var currentModifiers: ShortcutModifiers {
+        ShortcutBinding.modifiers(for: pressedModifierKeyCodes)
+    }
+
+    func hasPressedShortcutInputs(configuration: ShortcutConfiguration) -> Bool {
+        let currentModifiers = currentModifiers
+        let keyReferenceHeld = pressedKeyCodes.contains { keyCode in
+            configuration.hold.kind == .key && configuration.hold.keyCode == keyCode
+                || configuration.toggle.kind == .key && configuration.toggle.keyCode == keyCode
+        }
+        if keyReferenceHeld {
+            return true
+        }
+
+        if configuration.hold.referencesPressedModifiers(
+            pressedModifierKeyCodes: pressedModifierKeyCodes,
+            currentModifiers: currentModifiers
+        ) {
+            return true
+        }
+
+        if configuration.toggle.referencesPressedModifiers(
+            pressedModifierKeyCodes: pressedModifierKeyCodes,
+            currentModifiers: currentModifiers
+        ) {
+            return true
+        }
+
+        return false
+    }
+}
+
+struct ShortcutMatchResult: Equatable {
+    let state: ShortcutInputState
+    let emittedEvents: [ShortcutEvent]
+    let consumeDecision: ShortcutConsumeDecision
+}
+
+enum ShortcutMatcher {
+    static func reduce(
+        state: ShortcutInputState,
+        event: ShortcutInputEvent,
+        configuration: ShortcutConfiguration
+    ) -> ShortcutMatchResult {
+        switch event {
+        case .backendReset:
+            return reduceBackendReset(state: state, configuration: configuration)
+
+        case .modifierChanged(let keyCode, let isDown):
+            let shouldConsumeBefore = shouldConsumeModifierEvent(
+                for: keyCode,
+                state: state,
+                configuration: configuration
+            )
+
+            var nextState = state
+            if isDown {
+                nextState.pressedModifierKeyCodes.insert(keyCode)
+            } else {
+                nextState.pressedModifierKeyCodes.remove(keyCode)
+            }
+
+            let shouldConsumeAfter = shouldConsumeModifierEvent(
+                for: keyCode,
+                state: nextState,
+                configuration: configuration
+            )
+            let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+            return ShortcutMatchResult(
+                state: nextState,
+                emittedEvents: emittedEvents,
+                consumeDecision: (shouldConsumeBefore || shouldConsumeAfter) ? .consume : .passthrough
+            )
+
+        case .keyChanged(let keyCode, let isDown, let isRepeat):
+            let shouldConsumeBefore = shouldConsumeKeyEvent(
+                for: keyCode,
+                state: state,
+                configuration: configuration
+            )
+
+            var nextState = state
+            if isRepeat {
+                return ShortcutMatchResult(
+                    state: nextState,
+                    emittedEvents: [],
+                    consumeDecision: shouldConsumeBefore ? .consume : .passthrough
+                )
+            }
+
+            if isDown {
+                nextState.pressedKeyCodes.insert(keyCode)
+            } else {
+                nextState.pressedKeyCodes.remove(keyCode)
+            }
+
+            let shouldConsumeAfter = shouldConsumeKeyEvent(
+                for: keyCode,
+                state: nextState,
+                configuration: configuration
+            )
+            let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+            return ShortcutMatchResult(
+                state: nextState,
+                emittedEvents: emittedEvents,
+                consumeDecision: (shouldConsumeBefore || shouldConsumeAfter) ? .consume : .passthrough
+            )
+        }
+    }
+
+    private static func reduceBackendReset(
+        state: ShortcutInputState,
+        configuration: ShortcutConfiguration
+    ) -> ShortcutMatchResult {
+        var nextState = state
+        nextState.pressedKeyCodes.removeAll()
+        nextState.pressedModifierKeyCodes.removeAll()
+        let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+        return ShortcutMatchResult(
+            state: nextState,
+            emittedEvents: emittedEvents,
+            consumeDecision: .passthrough
+        )
+    }
+
+    private static func updateActiveBindings(
+        in state: inout ShortcutInputState,
+        configuration: ShortcutConfiguration
+    ) -> [ShortcutEvent] {
+        let previousHold = state.holdIsActive
+        let previousToggle = state.toggleIsActive
+
+        state.holdIsActive = bindingIsActive(configuration.hold, state: state)
+        state.toggleIsActive = bindingIsActive(configuration.toggle, state: state)
+
+        return emitChanges(
+            previousHold: previousHold,
+            previousToggle: previousToggle,
+            currentHold: state.holdIsActive,
+            currentToggle: state.toggleIsActive,
+            configuration: configuration
+        )
+    }
+
+    private static func emitChanges(
+        previousHold: Bool,
+        previousToggle: Bool,
+        currentHold: Bool,
+        currentToggle: Bool,
+        configuration: ShortcutConfiguration
+    ) -> [ShortcutEvent] {
+        var activations: [(ShortcutEvent, Int)] = []
+        var deactivations: [(ShortcutEvent, Int)] = []
+
+        if !previousHold && currentHold {
+            activations.append((.holdActivated, configuration.hold.specificityScore))
+        }
+        if !previousToggle && currentToggle {
+            activations.append((.toggleActivated, configuration.toggle.specificityScore))
+        }
+        if previousHold && !currentHold {
+            deactivations.append((.holdDeactivated, configuration.hold.specificityScore))
+        }
+        if previousToggle && !currentToggle {
+            deactivations.append((.toggleDeactivated, configuration.toggle.specificityScore))
+        }
+
+        let orderedActivations = activations.sorted(by: { $0.1 > $1.1 }).map(\.0)
+        let orderedDeactivations = deactivations.sorted(by: { $0.1 < $1.1 }).map(\.0)
+        return orderedActivations + orderedDeactivations
+    }
+
+    private static func bindingIsActive(_ binding: ShortcutBinding, state: ShortcutInputState) -> Bool {
+        guard !binding.isDisabled else { return false }
+        let activeModifiers = state.currentModifiers
+        guard activeModifiers.isSuperset(of: binding.modifiers) else {
+            return false
+        }
+
+        switch binding.kind {
+        case .disabled:
+            return false
+        case .key:
+            return state.pressedKeyCodes.contains(binding.keyCode)
+        case .modifierKey:
+            if binding.requiresExactModifierMatch {
+                return state.pressedModifierKeyCodes.contains(binding.keyCode)
+            }
+            guard let logicalModifier = ShortcutBinding.logicalModifier(forKeyCode: binding.keyCode) else {
+                return state.pressedModifierKeyCodes.contains(binding.keyCode)
+            }
+            return activeModifiers.contains(logicalModifier)
+        }
+    }
+
+    private static func shouldConsumeKeyEvent(
+        for keyCode: UInt16,
+        state: ShortcutInputState,
+        configuration: ShortcutConfiguration
+    ) -> Bool {
+        relevantKeyBindings(for: keyCode, configuration: configuration).contains {
+            bindingIsActive($0, state: state)
+        }
+    }
+
+    private static func shouldConsumeModifierEvent(
+        for keyCode: UInt16,
+        state: ShortcutInputState,
+        configuration: ShortcutConfiguration
+    ) -> Bool {
+        relevantModifierBindings(for: keyCode, configuration: configuration).contains {
+            bindingIsActive($0, state: state)
+        }
+    }
+
+    private static func relevantKeyBindings(
+        for keyCode: UInt16,
+        configuration: ShortcutConfiguration
+    ) -> [ShortcutBinding] {
+        [configuration.hold, configuration.toggle].filter { binding in
+            binding.kind == .key && binding.keyCode == keyCode
+        }
+    }
+
+    private static func relevantModifierBindings(
+        for keyCode: UInt16,
+        configuration: ShortcutConfiguration
+    ) -> [ShortcutBinding] {
+        [configuration.hold, configuration.toggle].filter { binding in
+            binding.kind == .modifierKey && modifierEvent(for: keyCode, affects: binding)
+        }
+    }
+
+    private static func modifierEvent(for keyCode: UInt16, affects binding: ShortcutBinding) -> Bool {
+        if binding.requiresExactModifierMatch {
+            return binding.keyCode == keyCode
+        }
+
+        guard let eventLogicalModifier = ShortcutBinding.logicalModifier(forKeyCode: keyCode),
+              let bindingLogicalModifier = ShortcutBinding.logicalModifier(forKeyCode: binding.keyCode) else {
+            return binding.keyCode == keyCode
+        }
+
+        return eventLogicalModifier == bindingLogicalModifier
+    }
+}
+
+private extension ShortcutBinding {
+    func referencesPressedModifiers(
+        pressedModifierKeyCodes: Set<UInt16>,
+        currentModifiers: ShortcutModifiers
+    ) -> Bool {
+        if modifiers.intersection(currentModifiers).isEmpty == false {
+            return true
+        }
+
+        guard kind == .modifierKey else { return false }
+        if requiresExactModifierMatch {
+            return pressedModifierKeyCodes.contains(keyCode)
+        }
+
+        guard let logicalModifier = ShortcutBinding.logicalModifier(forKeyCode: keyCode) else {
+            return pressedModifierKeyCodes.contains(keyCode)
+        }
+        return currentModifiers.contains(logicalModifier)
+    }
+}

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -262,7 +262,12 @@ enum ShortcutMatcher {
         configuration: ShortcutConfiguration
     ) -> [ShortcutBinding] {
         [configuration.hold, configuration.toggle].filter { binding in
-            binding.kind == .modifierKey && modifierEvent(for: keyCode, affects: binding)
+            switch binding.kind {
+            case .key, .modifierKey:
+                return modifierEvent(for: keyCode, affects: binding)
+            case .disabled:
+                return false
+            }
         }
     }
 
@@ -294,23 +299,14 @@ private extension ShortcutBinding {
             return true
         }
 
-        if pressedModifierKeyCodes == exactModifierKeyCodes {
+        if ShortcutBinding.exactModifierKeyCodesMatch(
+            pressedModifierKeyCodes,
+            exactModifierKeyCodes: exactModifierKeyCodes,
+            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+        ) {
             return true
         }
-
-        guard !permittedAdditionalExactMatchModifiers.isEmpty else {
-            return false
-        }
-
-        let additionalModifierKeyCodes = ShortcutBinding.matchingModifierKeyCodes(
-            for: permittedAdditionalExactMatchModifiers
-        )
-        let extraPressedModifierKeyCodes = pressedModifierKeyCodes.subtracting(exactModifierKeyCodes)
-        guard !extraPressedModifierKeyCodes.isEmpty else {
-            return false
-        }
-
-        return extraPressedModifierKeyCodes.isSubset(of: additionalModifierKeyCodes)
+        return false
     }
 
     func referencesPressedModifiers(

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -192,7 +192,10 @@ enum ShortcutMatcher {
     private static func bindingIsActive(_ binding: ShortcutBinding, state: ShortcutInputState) -> Bool {
         guard !binding.isDisabled else { return false }
         let activeModifiers = state.currentModifiers
-        guard activeModifiers.isSuperset(of: binding.modifiers) else {
+        guard binding.modifiersAreActive(
+            pressedModifierKeyCodes: state.pressedModifierKeyCodes,
+            currentModifiers: activeModifiers
+        ) else {
             return false
         }
 
@@ -202,13 +205,7 @@ enum ShortcutMatcher {
         case .key:
             return state.pressedKeyCodes.contains(binding.keyCode)
         case .modifierKey:
-            if binding.requiresExactModifierMatch {
-                return state.pressedModifierKeyCodes.contains(binding.keyCode)
-            }
-            guard let logicalModifier = ShortcutBinding.logicalModifier(forKeyCode: binding.keyCode) else {
-                return state.pressedModifierKeyCodes.contains(binding.keyCode)
-            }
-            return activeModifiers.contains(logicalModifier)
+            return state.pressedModifierKeyCodes.contains(binding.keyCode)
         }
     }
 
@@ -251,36 +248,39 @@ enum ShortcutMatcher {
     }
 
     private static func modifierEvent(for keyCode: UInt16, affects binding: ShortcutBinding) -> Bool {
-        if binding.requiresExactModifierMatch {
-            return binding.keyCode == keyCode
-        }
-
-        guard let eventLogicalModifier = ShortcutBinding.logicalModifier(forKeyCode: keyCode),
-              let bindingLogicalModifier = ShortcutBinding.logicalModifier(forKeyCode: binding.keyCode) else {
-            return binding.keyCode == keyCode
-        }
-
-        return eventLogicalModifier == bindingLogicalModifier
+        return binding.keyCode == keyCode
     }
 }
 
 private extension ShortcutBinding {
+    func modifiersAreActive(
+        pressedModifierKeyCodes: Set<UInt16>,
+        currentModifiers: ShortcutModifiers
+    ) -> Bool {
+        guard currentModifiers.isSuperset(of: modifiers) else {
+            return false
+        }
+
+        guard let exactModifierKeyCodes = exactModifierKeyCodes else {
+            return true
+        }
+
+        return pressedModifierKeyCodes.isSuperset(of: exactModifierKeyCodes)
+    }
+
     func referencesPressedModifiers(
         pressedModifierKeyCodes: Set<UInt16>,
         currentModifiers: ShortcutModifiers
     ) -> Bool {
-        if modifiers.intersection(currentModifiers).isEmpty == false {
+        if let exactModifierKeyCodes = exactModifierKeyCodes {
+            if exactModifierKeyCodes.intersection(pressedModifierKeyCodes).isEmpty == false {
+                return true
+            }
+        } else if modifiers.intersection(currentModifiers).isEmpty == false {
             return true
         }
 
         guard kind == .modifierKey else { return false }
-        if requiresExactModifierMatch {
-            return pressedModifierKeyCodes.contains(keyCode)
-        }
-
-        guard let logicalModifier = ShortcutBinding.logicalModifier(forKeyCode: keyCode) else {
-            return pressedModifierKeyCodes.contains(keyCode)
-        }
-        return currentModifiers.contains(logicalModifier)
+        return pressedModifierKeyCodes.contains(keyCode)
     }
 }

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -248,7 +248,17 @@ enum ShortcutMatcher {
     }
 
     private static func modifierEvent(for keyCode: UInt16, affects binding: ShortcutBinding) -> Bool {
-        return binding.keyCode == keyCode
+        if binding.keyCode == keyCode {
+            return true
+        }
+
+        if let exactModifierKeyCodes = binding.exactModifierKeyCodes,
+           exactModifierKeyCodes.contains(keyCode) {
+            return true
+        }
+
+        return ShortcutBinding.modifierKeyCodes.contains(keyCode)
+            && ShortcutBinding.logicalModifier(forKeyCode: keyCode).map(binding.modifiers.contains) == true
     }
 }
 
@@ -265,7 +275,7 @@ private extension ShortcutBinding {
             return true
         }
 
-        return pressedModifierKeyCodes.isSuperset(of: exactModifierKeyCodes)
+        return pressedModifierKeyCodes == exactModifierKeyCodes
     }
 
     func referencesPressedModifiers(

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -273,10 +273,10 @@ private extension ShortcutBinding {
         currentModifiers: ShortcutModifiers
     ) -> Bool {
         if let exactModifierKeyCodes = exactModifierKeyCodes {
-            if exactModifierKeyCodes.intersection(pressedModifierKeyCodes).isEmpty == false {
+            if !exactModifierKeyCodes.isDisjoint(with: pressedModifierKeyCodes) {
                 return true
             }
-        } else if modifiers.intersection(currentModifiers).isEmpty == false {
+        } else if !modifiers.isDisjoint(with: currentModifiers) {
             return true
         }
 

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -252,9 +252,8 @@ enum ShortcutMatcher {
             return true
         }
 
-        if let exactModifierKeyCodes = binding.exactModifierKeyCodes,
-           exactModifierKeyCodes.contains(keyCode) {
-            return true
+        if binding.exactModifierKeyCodes != nil {
+            return ShortcutBinding.modifierKeyCodes.contains(keyCode)
         }
 
         return ShortcutBinding.modifierKeyCodes.contains(keyCode)

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum ShortcutInputEvent: Equatable {
     case modifierChanged(keyCode: UInt16, isDown: Bool)
+    case modifierSnapshot(Set<UInt16>)
     case keyChanged(keyCode: UInt16, isDown: Bool, isRepeat: Bool)
     case backendReset
 }
@@ -33,14 +34,16 @@ struct ShortcutInputState: Equatable {
 
         if configuration.hold.referencesPressedModifiers(
             pressedModifierKeyCodes: pressedModifierKeyCodes,
-            currentModifiers: currentModifiers
+            currentModifiers: currentModifiers,
+            permittedAdditionalExactMatchModifiers: configuration.permittedAdditionalExactMatchModifiers
         ) {
             return true
         }
 
         if configuration.toggle.referencesPressedModifiers(
             pressedModifierKeyCodes: pressedModifierKeyCodes,
-            currentModifiers: currentModifiers
+            currentModifiers: currentModifiers,
+            permittedAdditionalExactMatchModifiers: configuration.permittedAdditionalExactMatchModifiers
         ) {
             return true
         }
@@ -64,6 +67,17 @@ enum ShortcutMatcher {
         switch event {
         case .backendReset:
             return reduceBackendReset(state: state, configuration: configuration)
+
+        case .modifierSnapshot(let pressedModifierKeyCodes):
+            var nextState = state
+            nextState.pressedModifierKeyCodes = pressedModifierKeyCodes
+
+            let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+            return ShortcutMatchResult(
+                state: nextState,
+                emittedEvents: emittedEvents,
+                consumeDecision: emittedEvents.isEmpty ? .passthrough : .consume
+            )
 
         case .modifierChanged(let keyCode, let isDown):
             let shouldConsumeBefore = shouldConsumeModifierEvent(
@@ -149,8 +163,8 @@ enum ShortcutMatcher {
         let previousHold = state.holdIsActive
         let previousToggle = state.toggleIsActive
 
-        state.holdIsActive = bindingIsActive(configuration.hold, state: state)
-        state.toggleIsActive = bindingIsActive(configuration.toggle, state: state)
+        state.holdIsActive = bindingIsActive(configuration.hold, state: state, configuration: configuration)
+        state.toggleIsActive = bindingIsActive(configuration.toggle, state: state, configuration: configuration)
 
         return emitChanges(
             previousHold: previousHold,
@@ -189,12 +203,17 @@ enum ShortcutMatcher {
         return orderedActivations + orderedDeactivations
     }
 
-    private static func bindingIsActive(_ binding: ShortcutBinding, state: ShortcutInputState) -> Bool {
+    private static func bindingIsActive(
+        _ binding: ShortcutBinding,
+        state: ShortcutInputState,
+        configuration: ShortcutConfiguration
+    ) -> Bool {
         guard !binding.isDisabled else { return false }
         let activeModifiers = state.currentModifiers
         guard binding.modifiersAreActive(
             pressedModifierKeyCodes: state.pressedModifierKeyCodes,
-            currentModifiers: activeModifiers
+            currentModifiers: activeModifiers,
+            permittedAdditionalExactMatchModifiers: configuration.permittedAdditionalExactMatchModifiers
         ) else {
             return false
         }
@@ -215,7 +234,7 @@ enum ShortcutMatcher {
         configuration: ShortcutConfiguration
     ) -> Bool {
         relevantKeyBindings(for: keyCode, configuration: configuration).contains {
-            bindingIsActive($0, state: state)
+            bindingIsActive($0, state: state, configuration: configuration)
         }
     }
 
@@ -225,7 +244,7 @@ enum ShortcutMatcher {
         configuration: ShortcutConfiguration
     ) -> Bool {
         relevantModifierBindings(for: keyCode, configuration: configuration).contains {
-            bindingIsActive($0, state: state)
+            bindingIsActive($0, state: state, configuration: configuration)
         }
     }
 
@@ -264,7 +283,8 @@ enum ShortcutMatcher {
 private extension ShortcutBinding {
     func modifiersAreActive(
         pressedModifierKeyCodes: Set<UInt16>,
-        currentModifiers: ShortcutModifiers
+        currentModifiers: ShortcutModifiers,
+        permittedAdditionalExactMatchModifiers: ShortcutModifiers
     ) -> Bool {
         guard currentModifiers.isSuperset(of: modifiers) else {
             return false
@@ -274,16 +294,41 @@ private extension ShortcutBinding {
             return true
         }
 
-        return pressedModifierKeyCodes == exactModifierKeyCodes
+        if pressedModifierKeyCodes == exactModifierKeyCodes {
+            return true
+        }
+
+        guard !permittedAdditionalExactMatchModifiers.isEmpty else {
+            return false
+        }
+
+        let additionalModifierKeyCodes = ShortcutBinding.matchingModifierKeyCodes(
+            for: permittedAdditionalExactMatchModifiers
+        )
+        let extraPressedModifierKeyCodes = pressedModifierKeyCodes.subtracting(exactModifierKeyCodes)
+        guard !extraPressedModifierKeyCodes.isEmpty else {
+            return false
+        }
+
+        return extraPressedModifierKeyCodes.isSubset(of: additionalModifierKeyCodes)
     }
 
     func referencesPressedModifiers(
         pressedModifierKeyCodes: Set<UInt16>,
-        currentModifiers: ShortcutModifiers
+        currentModifiers: ShortcutModifiers,
+        permittedAdditionalExactMatchModifiers: ShortcutModifiers
     ) -> Bool {
         if let exactModifierKeyCodes = exactModifierKeyCodes {
             if !exactModifierKeyCodes.isDisjoint(with: pressedModifierKeyCodes) {
                 return true
+            }
+            if !permittedAdditionalExactMatchModifiers.isEmpty {
+                let additionalModifierKeyCodes = ShortcutBinding.matchingModifierKeyCodes(
+                    for: permittedAdditionalExactMatchModifiers
+                )
+                if !additionalModifierKeyCodes.isDisjoint(with: pressedModifierKeyCodes) {
+                    return true
+                }
             }
         } else if !modifiers.isDisjoint(with: currentModifiers) {
             return true

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+struct ShortcutModifiers: OptionSet, Hashable, Codable {
+    let rawValue: Int
+
+    static let command = ShortcutModifiers(rawValue: 1 << 0)
+    static let control = ShortcutModifiers(rawValue: 1 << 1)
+    static let option = ShortcutModifiers(rawValue: 1 << 2)
+    static let shift = ShortcutModifiers(rawValue: 1 << 3)
+    static let function = ShortcutModifiers(rawValue: 1 << 4)
+
+    init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(rawValue: try container.decode(Int.self))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    var orderedDisplayNames: [String] {
+        var names: [String] = []
+        if contains(.command) { names.append("⌘") }
+        if contains(.control) { names.append("⌃") }
+        if contains(.option) { names.append("⌥") }
+        if contains(.shift) { names.append("⇧") }
+        if contains(.function) { names.append("fn") }
+        return names
+    }
+}
+
+enum ShortcutBindingKind: String, Codable {
+    case disabled
+    case key
+    case modifierKey
+}
+
+enum RecordingTriggerMode: String, Codable {
+    case hold
+    case toggle
+
+    var badgeTitle: String {
+        switch self {
+        case .hold: return "Hold"
+        case .toggle: return "Tap"
+        }
+    }
+}
+
+enum ShortcutRole {
+    case hold
+    case toggle
+
+    var title: String {
+        switch self {
+        case .hold: return "Hold to Talk"
+        case .toggle: return "Tap to Toggle"
+        }
+    }
+}
+
+enum ShortcutEvent: Equatable {
+    case holdActivated
+    case holdDeactivated
+    case toggleActivated
+    case toggleDeactivated
+}
+
+struct ShortcutConfiguration: Equatable {
+    let hold: ShortcutBinding
+    let toggle: ShortcutBinding
+
+    static let disabled = ShortcutConfiguration(hold: .disabled, toggle: .disabled)
+}
+
+enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
+    case fnKey = "fn"
+    case rightOption = "rightOption"
+    case f5 = "f5"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .fnKey: return "Fn (Globe) Key"
+        case .rightOption: return "Right Option Key"
+        case .f5: return "F5 Key"
+        }
+    }
+
+    var binding: ShortcutBinding {
+        switch self {
+        case .fnKey:
+            return ShortcutBinding(
+                keyCode: 63,
+                keyDisplay: "Fn",
+                modifiers: [],
+                kind: .modifierKey,
+                preset: self
+            )
+        case .rightOption:
+            return ShortcutBinding(
+                keyCode: 61,
+                keyDisplay: "Right Option",
+                modifiers: [],
+                kind: .modifierKey,
+                preset: self
+            )
+        case .f5:
+            return ShortcutBinding(
+                keyCode: 96,
+                keyDisplay: "F5",
+                modifiers: [],
+                kind: .key,
+                preset: self
+            )
+        }
+    }
+}
+
+struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
+    let keyCode: UInt16
+    let keyDisplay: String
+    let modifiers: ShortcutModifiers
+    let kind: ShortcutBindingKind
+    let preset: ShortcutPreset?
+
+    var id: String {
+        "\(kind.rawValue):\(keyCode):\(modifiers.rawValue):\(preset?.rawValue ?? "custom")"
+    }
+
+    var displayName: String {
+        if isDisabled { return "Disabled" }
+        let parts = modifiers.orderedDisplayNames + [keyDisplay]
+        return parts.joined(separator: " + ")
+    }
+
+    var selectionTitle: String {
+        preset?.title ?? displayName
+    }
+
+    var isCustom: Bool {
+        preset == nil && !isDisabled
+    }
+
+    var isDisabled: Bool {
+        kind == .disabled
+    }
+
+    var specificityScore: Int {
+        modifiers.orderedDisplayNames.count
+    }
+
+    var usesFnKey: Bool {
+        guard !isDisabled else { return false }
+        return keyCode == 63 || modifiers.contains(.function)
+    }
+
+    var requiresExactModifierMatch: Bool {
+        kind == .modifierKey
+    }
+
+    func withAddedModifiers(_ extraModifiers: ShortcutModifiers) -> ShortcutBinding {
+        guard !isDisabled else { return self }
+        return ShortcutBinding(
+            keyCode: keyCode,
+            keyDisplay: keyDisplay,
+            modifiers: modifiers.union(extraModifiers),
+            kind: kind,
+            preset: preset
+        )
+    }
+
+    func normalizedForStorageMigration() -> ShortcutBinding {
+        self
+    }
+
+    static let disabled = ShortcutBinding(
+        keyCode: 0,
+        keyDisplay: "Disabled",
+        modifiers: [],
+        kind: .disabled,
+        preset: nil
+    )
+    static let defaultHold = ShortcutPreset.fnKey.binding
+    static let defaultToggle = ShortcutPreset.fnKey.binding.withAddedModifiers(.command)
+
+    static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
+
+    static func logicalModifier(forKeyCode keyCode: UInt16) -> ShortcutModifiers? {
+        switch keyCode {
+        case 54, 55:
+            return .command
+        case 59, 62:
+            return .control
+        case 58, 61:
+            return .option
+        case 56, 60:
+            return .shift
+        case 63:
+            return .function
+        default:
+            return nil
+        }
+    }
+
+    static func modifiers(for pressedModifierKeyCodes: Set<UInt16>) -> ShortcutModifiers {
+        var modifiers: ShortcutModifiers = []
+        for keyCode in pressedModifierKeyCodes {
+            if let modifier = logicalModifier(forKeyCode: keyCode) {
+                modifiers.insert(modifier)
+            }
+        }
+        return modifiers
+    }
+
+    static func canonicalModifierKeyCode(for keyCode: UInt16) -> UInt16 {
+        switch keyCode {
+        case 54:
+            return 55
+        case 60:
+            return 56
+        case 61:
+            return 58
+        case 62:
+            return 59
+        default:
+            return keyCode
+        }
+    }
+
+    static func logicalModifierDisplayLabel(for keyCode: UInt16) -> String {
+        switch keyCode {
+        case 55:
+            return "Command"
+        case 59:
+            return "Control"
+        case 58:
+            return "Option"
+        case 56:
+            return "Shift"
+        case 63:
+            return "Fn"
+        default:
+            return "Modifier"
+        }
+    }
+}

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -215,7 +215,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         )
     }
 
-    func overlaps(with other: ShortcutBinding) -> Bool {
+    func conflicts(with other: ShortcutBinding) -> Bool {
         guard !isDisabled, !other.isDisabled else { return false }
         guard primaryInputOverlaps(with: other) else { return false }
 
@@ -228,7 +228,9 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
                 pressedModifierKeyCodes.insert(keyCode)
             }
 
-            if canActivate(with: pressedModifierKeyCodes) && other.canActivate(with: pressedModifierKeyCodes) {
+            let selfActive = isActive(for: pressedModifierKeyCodes)
+            let otherActive = other.isActive(for: pressedModifierKeyCodes)
+            if selfActive && otherActive && specificityScore == other.specificityScore {
                 return true
             }
         }
@@ -265,14 +267,14 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         }
     }
 
-    private func canActivate(with pressedModifierKeyCodes: Set<UInt16>) -> Bool {
+    private func isActive(for pressedModifierKeyCodes: Set<UInt16>) -> Bool {
         let currentModifiers = Self.modifiers(for: pressedModifierKeyCodes)
         guard currentModifiers.isSuperset(of: modifiers) else {
             return false
         }
 
         if let exactModifierKeyCodes = exactModifierKeyCodes,
-           !pressedModifierKeyCodes.isSuperset(of: exactModifierKeyCodes) {
+           pressedModifierKeyCodes != exactModifierKeyCodes {
             return false
         }
 

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -202,7 +202,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         let updatedExactModifierKeyCodes: Set<UInt16>?
         if let exactModifierKeyCodes, !exactModifierKeyCodes.isEmpty {
             updatedExactModifierKeyCodes = Self.normalizedExactModifierKeyCodes(
-                exactModifierKeyCodes.union(Self.exactModifierKeyCodes(for: extraModifiers))
+                exactModifierKeyCodes.union(Self.exactModifierKeyCodesPreservingSides(for: extraModifiers))
             )
         } else {
             updatedExactModifierKeyCodes = exactModifierKeyCodes
@@ -311,7 +311,10 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         }
 
         if let exactModifierKeyCodes = exactModifierKeyCodes,
-           pressedModifierKeyCodes != exactModifierKeyCodes {
+           !Self.exactModifierKeyCodesMatch(
+            pressedModifierKeyCodes,
+            exactModifierKeyCodes: exactModifierKeyCodes
+           ) {
             return false
         }
 
@@ -389,6 +392,16 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         return keyCodes
     }
 
+    static func exactModifierKeyCodesPreservingSides(for modifiers: ShortcutModifiers) -> Set<UInt16> {
+        var keyCodes: Set<UInt16> = []
+        if modifiers.contains(.command) { keyCodes.formUnion([54, 55]) }
+        if modifiers.contains(.control) { keyCodes.formUnion([59, 62]) }
+        if modifiers.contains(.option) { keyCodes.formUnion([58, 61]) }
+        if modifiers.contains(.shift) { keyCodes.formUnion([56, 60]) }
+        if modifiers.contains(.function) { keyCodes.insert(63) }
+        return keyCodes
+    }
+
     static func matchingModifierKeyCodes(for modifiers: ShortcutModifiers) -> Set<UInt16> {
         modifierKeyCodes.filter { keyCode in
             logicalModifier(forKeyCode: keyCode).map(modifiers.contains) == true
@@ -447,6 +460,37 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         modifierDisplayOrder.filter(exactModifierKeyCodes.contains)
     }
 
+    static func exactModifierKeyCodesMatch(
+        _ pressedModifierKeyCodes: Set<UInt16>,
+        exactModifierKeyCodes: Set<UInt16>,
+        permittedAdditionalExactMatchModifiers: ShortcutModifiers = []
+    ) -> Bool {
+        let normalizedExactModifierKeyCodes = normalizedExactModifierKeyCodes(exactModifierKeyCodes) ?? []
+
+        for spec in modifierKeyCodeMatchSpecs {
+            let exactKeyCodes = normalizedExactModifierKeyCodes.intersection(spec.keyCodes)
+            let pressedKeyCodes = pressedModifierKeyCodes.intersection(spec.keyCodes)
+
+            if exactKeyCodes.isEmpty {
+                if !pressedKeyCodes.isEmpty && !permittedAdditionalExactMatchModifiers.contains(spec.logicalModifier) {
+                    return false
+                }
+                continue
+            }
+
+            if exactKeyCodes.count == spec.keyCodes.count {
+                guard !pressedKeyCodes.isEmpty,
+                      pressedKeyCodes.isSubset(of: exactKeyCodes) else {
+                    return false
+                }
+            } else if pressedKeyCodes != exactKeyCodes {
+                return false
+            }
+        }
+
+        return true
+    }
+
     static func modifierDisplayNames(
         for modifiers: ShortcutModifiers,
         exactModifierKeyCodes: Set<UInt16>?
@@ -455,6 +499,13 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         var names: [String] = []
 
         for spec in modifierDisplaySpecs {
+            let exactKeyCodes = Set(spec.exactDisplayNames.map(\.0))
+            let matchingExactKeyCodes = normalizedExactModifierKeyCodes.intersection(exactKeyCodes)
+            if matchingExactKeyCodes.count == exactKeyCodes.count {
+                names.append(spec.genericDisplayName)
+                continue
+            }
+
             let exactNames = spec.exactDisplayNames.compactMap { keyCode, displayName in
                 normalizedExactModifierKeyCodes.contains(keyCode) ? displayName : nil
             }
@@ -469,6 +520,14 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     }
 
     private static let modifierDisplayOrder: [UInt16] = [55, 54, 59, 62, 58, 61, 56, 60, 63]
+
+    private static let modifierKeyCodeMatchSpecs: [(logicalModifier: ShortcutModifiers, keyCodes: Set<UInt16>)] = [
+        (.command, [54, 55]),
+        (.control, [59, 62]),
+        (.option, [58, 61]),
+        (.shift, [56, 60]),
+        (.function, [63])
+    ]
 
     private static let modifierDisplaySpecs: [(logicalModifier: ShortcutModifiers, genericDisplayName: String, exactDisplayNames: [(UInt16, String)])] = [
         (.command, "⌘", [(55, "⌘"), (54, "⌘ →")]),

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -188,6 +188,14 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     func withAddedModifiers(_ extraModifiers: ShortcutModifiers) -> ShortcutBinding {
         guard !isDisabled else { return self }
         let updatedModifiers = modifiers.union(extraModifiers)
+        let updatedExactModifierKeyCodes: Set<UInt16>?
+        if let exactModifierKeyCodes, !exactModifierKeyCodes.isEmpty {
+            updatedExactModifierKeyCodes = Self.normalizedExactModifierKeyCodes(
+                exactModifierKeyCodes.union(Self.exactModifierKeyCodes(for: extraModifiers))
+            )
+        } else {
+            updatedExactModifierKeyCodes = exactModifierKeyCodes
+        }
 
         return ShortcutBinding(
             keyCode: keyCode,
@@ -195,7 +203,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             modifiers: updatedModifiers,
             kind: kind,
             preset: preset,
-            exactModifierKeyCodes: exactModifierKeyCodes
+            exactModifierKeyCodes: updatedExactModifierKeyCodes
         )
     }
 
@@ -278,8 +286,10 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         switch kind {
         case .disabled:
             return false
-        case .key, .modifierKey:
+        case .key:
             return keyCode == other.keyCode
+        case .modifierKey:
+            return true
         }
     }
 

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -74,6 +74,17 @@ enum ShortcutEvent: Equatable {
 struct ShortcutConfiguration: Equatable {
     let hold: ShortcutBinding
     let toggle: ShortcutBinding
+    let permittedAdditionalExactMatchModifiers: ShortcutModifiers
+
+    init(
+        hold: ShortcutBinding,
+        toggle: ShortcutBinding,
+        permittedAdditionalExactMatchModifiers: ShortcutModifiers = []
+    ) {
+        self.hold = hold
+        self.toggle = toggle
+        self.permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiers
+    }
 
     static let disabled = ShortcutConfiguration(hold: .disabled, toggle: .disabled)
 }
@@ -376,6 +387,12 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         if modifiers.contains(.shift) { keyCodes.insert(56) }
         if modifiers.contains(.function) { keyCodes.insert(63) }
         return keyCodes
+    }
+
+    static func matchingModifierKeyCodes(for modifiers: ShortcutModifiers) -> Set<UInt16> {
+        modifierKeyCodes.filter { keyCode in
+            logicalModifier(forKeyCode: keyCode).map(modifiers.contains) == true
+        }
     }
 
     static func logicalModifierDisplayLabel(for keyCode: UInt16) -> String {

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -188,9 +188,6 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     func withAddedModifiers(_ extraModifiers: ShortcutModifiers) -> ShortcutBinding {
         guard !isDisabled else { return self }
         let updatedModifiers = modifiers.union(extraModifiers)
-        let updatedExactModifierKeyCodes = exactModifierKeyCodes.map { existingExactModifierKeyCodes in
-            existingExactModifierKeyCodes.union(Self.exactModifierKeyCodes(for: extraModifiers))
-        }
 
         return ShortcutBinding(
             keyCode: keyCode,
@@ -198,7 +195,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             modifiers: updatedModifiers,
             kind: kind,
             preset: preset,
-            exactModifierKeyCodes: updatedExactModifierKeyCodes
+            exactModifierKeyCodes: exactModifierKeyCodes
         )
     }
 

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -129,14 +129,34 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     let modifiers: ShortcutModifiers
     let kind: ShortcutBindingKind
     let preset: ShortcutPreset?
+    let exactModifierKeyCodes: Set<UInt16>?
+
+    init(
+        keyCode: UInt16,
+        keyDisplay: String,
+        modifiers: ShortcutModifiers,
+        kind: ShortcutBindingKind,
+        preset: ShortcutPreset?,
+        exactModifierKeyCodes: Set<UInt16>? = nil
+    ) {
+        self.keyCode = keyCode
+        self.keyDisplay = keyDisplay
+        self.modifiers = modifiers
+        self.kind = kind
+        self.preset = preset
+        self.exactModifierKeyCodes = exactModifierKeyCodes
+    }
 
     var id: String {
-        "\(kind.rawValue):\(keyCode):\(modifiers.rawValue):\(preset?.rawValue ?? "custom")"
+        let exactModifierID = Self.orderedExactModifierKeyCodes(
+            exactModifierKeyCodes ?? []
+        ).map(String.init).joined(separator: ",")
+        return "\(kind.rawValue):\(keyCode):\(modifiers.rawValue):\(preset?.rawValue ?? "custom"):\(exactModifierID)"
     }
 
     var displayName: String {
         if isDisabled { return "Disabled" }
-        let parts = modifiers.orderedDisplayNames + [keyDisplay]
+        let parts = modifierDisplayNames + [keyDisplay]
         return parts.joined(separator: " + ")
     }
 
@@ -153,7 +173,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     }
 
     var specificityScore: Int {
-        modifiers.orderedDisplayNames.count
+        modifierDisplayNames.count
     }
 
     var usesFnKey: Bool {
@@ -162,7 +182,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     }
 
     var requiresExactModifierMatch: Bool {
-        kind == .modifierKey
+        kind == .modifierKey || exactModifierKeyCodes != nil
     }
 
     func withAddedModifiers(_ extraModifiers: ShortcutModifiers) -> ShortcutBinding {
@@ -172,12 +192,45 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             keyDisplay: keyDisplay,
             modifiers: modifiers.union(extraModifiers),
             kind: kind,
-            preset: preset
+            preset: preset,
+            exactModifierKeyCodes: exactModifierKeyCodes
         )
     }
 
     func normalizedForStorageMigration() -> ShortcutBinding {
-        self
+        let normalizedExactModifierKeyCodes = Self.normalizedExactModifierKeyCodes(exactModifierKeyCodes)
+        let normalizedModifiers = modifiers.union(Self.modifiers(for: normalizedExactModifierKeyCodes ?? []))
+
+        guard normalizedExactModifierKeyCodes != exactModifierKeyCodes || normalizedModifiers != modifiers else {
+            return self
+        }
+
+        return ShortcutBinding(
+            keyCode: keyCode,
+            keyDisplay: keyDisplay,
+            modifiers: normalizedModifiers,
+            kind: kind,
+            preset: preset,
+            exactModifierKeyCodes: normalizedExactModifierKeyCodes
+        )
+    }
+
+    var modifierDisplayNames: [String] {
+        Self.modifierDisplayNames(
+            for: modifiers,
+            exactModifierKeyCodes: displayedExactModifierKeyCodes
+        )
+    }
+
+    private var displayedExactModifierKeyCodes: Set<UInt16>? {
+        guard let exactModifierKeyCodes else { return nil }
+        let filteredModifierKeyCodes: Set<UInt16>
+        if kind == .modifierKey {
+            filteredModifierKeyCodes = exactModifierKeyCodes.subtracting([keyCode])
+        } else {
+            filteredModifierKeyCodes = exactModifierKeyCodes
+        }
+        return Self.normalizedExactModifierKeyCodes(filteredModifierKeyCodes)
     }
 
     static let disabled = ShortcutBinding(
@@ -250,4 +303,45 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             return "Modifier"
         }
     }
+
+    static func normalizedExactModifierKeyCodes(_ exactModifierKeyCodes: Set<UInt16>?) -> Set<UInt16>? {
+        guard let exactModifierKeyCodes else { return nil }
+        let normalized = exactModifierKeyCodes.filter { modifierKeyCodes.contains($0) }
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    static func orderedExactModifierKeyCodes(_ exactModifierKeyCodes: Set<UInt16>) -> [UInt16] {
+        modifierDisplayOrder.filter(exactModifierKeyCodes.contains)
+    }
+
+    static func modifierDisplayNames(
+        for modifiers: ShortcutModifiers,
+        exactModifierKeyCodes: Set<UInt16>?
+    ) -> [String] {
+        let normalizedExactModifierKeyCodes = normalizedExactModifierKeyCodes(exactModifierKeyCodes) ?? []
+        var names: [String] = []
+
+        for spec in modifierDisplaySpecs {
+            let exactNames = spec.exactDisplayNames.compactMap { keyCode, displayName in
+                normalizedExactModifierKeyCodes.contains(keyCode) ? displayName : nil
+            }
+            if !exactNames.isEmpty {
+                names.append(contentsOf: exactNames)
+            } else if modifiers.contains(spec.logicalModifier) {
+                names.append(spec.genericDisplayName)
+            }
+        }
+
+        return names
+    }
+
+    private static let modifierDisplayOrder: [UInt16] = [55, 54, 59, 62, 58, 61, 56, 60, 63]
+
+    private static let modifierDisplaySpecs: [(logicalModifier: ShortcutModifiers, genericDisplayName: String, exactDisplayNames: [(UInt16, String)])] = [
+        (.command, "⌘", [(55, "⌘"), (54, "⌘ →")]),
+        (.control, "⌃", [(59, "⌃"), (62, "⌃ →")]),
+        (.option, "⌥", [(58, "⌥"), (61, "⌥ →")]),
+        (.shift, "⇧", [(56, "⇧"), (60, "⇧ →")]),
+        (.function, "fn", [(63, "fn")])
+    ]
 }

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -156,7 +156,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
 
     var displayName: String {
         if isDisabled { return "Disabled" }
-        let parts = modifierDisplayNames + [keyDisplay]
+        let parts = modifierDisplayNames + [primaryDisplayName]
         return parts.joined(separator: " + ")
     }
 
@@ -187,19 +187,30 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
 
     func withAddedModifiers(_ extraModifiers: ShortcutModifiers) -> ShortcutBinding {
         guard !isDisabled else { return self }
+        let updatedModifiers = modifiers.union(extraModifiers)
+        let updatedExactModifierKeyCodes = exactModifierKeyCodes.map { existingExactModifierKeyCodes in
+            existingExactModifierKeyCodes.union(Self.exactModifierKeyCodes(for: extraModifiers))
+        }
+
         return ShortcutBinding(
             keyCode: keyCode,
             keyDisplay: keyDisplay,
-            modifiers: modifiers.union(extraModifiers),
+            modifiers: updatedModifiers,
             kind: kind,
             preset: preset,
-            exactModifierKeyCodes: exactModifierKeyCodes
+            exactModifierKeyCodes: updatedExactModifierKeyCodes
         )
     }
 
     func normalizedForStorageMigration() -> ShortcutBinding {
         let normalizedExactModifierKeyCodes = Self.normalizedExactModifierKeyCodes(exactModifierKeyCodes)
-        let normalizedModifiers = modifiers.union(Self.modifiers(for: normalizedExactModifierKeyCodes ?? []))
+        let normalizedExtraModifierKeyCodes: Set<UInt16>
+        if kind == .modifierKey {
+            normalizedExtraModifierKeyCodes = (normalizedExactModifierKeyCodes ?? []).subtracting([keyCode])
+        } else {
+            normalizedExtraModifierKeyCodes = normalizedExactModifierKeyCodes ?? []
+        }
+        let normalizedModifiers = modifiers.union(Self.modifiers(for: normalizedExtraModifierKeyCodes))
 
         guard normalizedExactModifierKeyCodes != exactModifierKeyCodes || normalizedModifiers != modifiers else {
             return self
@@ -243,6 +254,14 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             for: modifiers,
             exactModifierKeyCodes: displayedExactModifierKeyCodes
         )
+    }
+
+    private var primaryDisplayName: String {
+        guard kind == .modifierKey,
+              let exactDisplayName = Self.exactModifierDisplayLabel(for: keyCode) else {
+            return keyDisplay
+        }
+        return exactDisplayName
     }
 
     private var displayedExactModifierKeyCodes: Set<UInt16>? {
@@ -342,6 +361,16 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         }
     }
 
+    static func exactModifierKeyCodes(for modifiers: ShortcutModifiers) -> Set<UInt16> {
+        var keyCodes: Set<UInt16> = []
+        if modifiers.contains(.command) { keyCodes.insert(55) }
+        if modifiers.contains(.control) { keyCodes.insert(59) }
+        if modifiers.contains(.option) { keyCodes.insert(58) }
+        if modifiers.contains(.shift) { keyCodes.insert(56) }
+        if modifiers.contains(.function) { keyCodes.insert(63) }
+        return keyCodes
+    }
+
     static func logicalModifierDisplayLabel(for keyCode: UInt16) -> String {
         switch keyCode {
         case 55:
@@ -356,6 +385,31 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             return "Fn"
         default:
             return "Modifier"
+        }
+    }
+
+    static func exactModifierDisplayLabel(for keyCode: UInt16) -> String? {
+        switch keyCode {
+        case 55:
+            return "\u{2318}"
+        case 54:
+            return "\u{2318} \u{2192}"
+        case 59:
+            return "\u{2303}"
+        case 62:
+            return "\u{2303} \u{2192}"
+        case 58:
+            return "\u{2325}"
+        case 61:
+            return "\u{2325} \u{2192}"
+        case 56:
+            return "\u{21E7}"
+        case 60:
+            return "\u{21E7} \u{2192}"
+        case 63:
+            return "fn"
+        default:
+            return nil
         }
     }
 

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -215,6 +215,27 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         )
     }
 
+    func overlaps(with other: ShortcutBinding) -> Bool {
+        guard !isDisabled, !other.isDisabled else { return false }
+        guard primaryInputOverlaps(with: other) else { return false }
+
+        let orderedModifierKeyCodes = Array(Self.modifierKeyCodes).sorted()
+        let combinations = 1 << orderedModifierKeyCodes.count
+
+        for mask in 0..<combinations {
+            var pressedModifierKeyCodes: Set<UInt16> = []
+            for (index, keyCode) in orderedModifierKeyCodes.enumerated() where (mask & (1 << index)) != 0 {
+                pressedModifierKeyCodes.insert(keyCode)
+            }
+
+            if canActivate(with: pressedModifierKeyCodes) && other.canActivate(with: pressedModifierKeyCodes) {
+                return true
+            }
+        }
+
+        return false
+    }
+
     var modifierDisplayNames: [String] {
         Self.modifierDisplayNames(
             for: modifiers,
@@ -231,6 +252,38 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             filteredModifierKeyCodes = exactModifierKeyCodes
         }
         return Self.normalizedExactModifierKeyCodes(filteredModifierKeyCodes)
+    }
+
+    private func primaryInputOverlaps(with other: ShortcutBinding) -> Bool {
+        guard kind == other.kind else { return false }
+
+        switch kind {
+        case .disabled:
+            return false
+        case .key, .modifierKey:
+            return keyCode == other.keyCode
+        }
+    }
+
+    private func canActivate(with pressedModifierKeyCodes: Set<UInt16>) -> Bool {
+        let currentModifiers = Self.modifiers(for: pressedModifierKeyCodes)
+        guard currentModifiers.isSuperset(of: modifiers) else {
+            return false
+        }
+
+        if let exactModifierKeyCodes = exactModifierKeyCodes,
+           !pressedModifierKeyCodes.isSuperset(of: exactModifierKeyCodes) {
+            return false
+        }
+
+        switch kind {
+        case .disabled:
+            return false
+        case .key:
+            return true
+        case .modifierKey:
+            return pressedModifierKeyCodes.contains(keyCode)
+        }
     }
 
     static let disabled = ShortcutBinding(


### PR DESCRIPTION
## Summary

This PR refactors FreeFlow's shortcut pipeline to make global hotkeys more reliable and easier to reason about.

The main user-facing outcome is improved shortcut stability: it fixes cases where shortcuts could become unstable, modifier state could get out of sync, or keys could effectively get "stuck" after permission prompts, event tap resets, or overlapping shortcut configurations.

## What changed

- split shortcut handling into clearer pieces:
  - `GlobalShortcutBackend` for global event tap monitoring
  - `LocalShortcutCaptureBackend` for shortcut capture in setup
  - `ShortcutMatcher` for input-state reduction and shortcut matching
  - `DictationShortcutSessionController` for hold/toggle session behavior
- moved shortcut models/core logic into `ShortcutCore` so matching and state transitions are centralized instead of spread across UI and manager code
- added explicit modifier-key state tracking, including exact modifier combinations and better left/right modifier handling
- reset shortcut state when the event tap is disabled or restarted, which prevents stale pressed-key state from lingering
- improved overlap detection so hold/tap shortcuts and command-mode variants are rejected when they can conflict in practice, not just when they are exactly equal
- suspended hotkey monitoring while the macOS microphone permission prompt is open, then resumed cleanly afterward
- handled hotkey-monitor startup failures gracefully and surfaced those errors in the menu bar UI/setup flow
- updated shortcut capture and setup test harness code to use the new backend/session flow
- updated the build source discovery so nested shortcut core files are included

## Why

The previous shortcut logic had grown into a mix of event monitoring, matching, and session state management. That made edge cases harder to handle cleanly, especially around:

- permission prompts interrupting keyboard monitoring
- event tap resets/timeouts
- modifier-only shortcuts
- left/right modifier specificity
- overlapping shortcut definitions

By separating those responsibilities and making shortcut state transitions explicit, the app behaves more predictably and is much less likely to end up in a bad state where shortcuts stop responding correctly or keys appear stuck.

## Notes

This also improves permission gating for dictation/command flows so we fail earlier and more clearly when required permissions are missing, rather than leaving shortcut state in a partially active state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized shortcut capture and matching for more reliable detection and conflict resolution (local and global).
* **Improvements**
  * Hotkey monitoring surfaces errors in the menu and handles microphone/screen permission flows more robustly.
  * Build file discovery made deterministic; additional .build paths now ignored.
* **Bug Fixes**
  * Fewer unexpected hotkey restarts and improved fatal permission handling.
* **Chores**
  * Setup/test startup failures are now surfaced and handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->