### PR TITLE
Add configurable context screenshot resolution

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -34,6 +34,7 @@ If details are missing, state uncertainty instead of inventing facts.
 Return only two sentences, no labels, no markdown, no extra commentary.
 """
     static let defaultContextPromptDate = "2026-02-24"
+    static let defaultScreenshotMaxDimension: CGFloat = 1024
 
     private let apiKey: String
     private let baseURL: String
@@ -42,13 +43,21 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     private let visionModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let maxScreenshotDataURILength = 500_000
     private let screenshotCompressionPrimary = 0.5
-    private let screenshotMaxDimension: CGFloat = 1024
+    private let screenshotMaxDimension: CGFloat
     private let contextRequestTimeoutSeconds: TimeInterval = 20
 
-    init(apiKey: String, baseURL: String = "https://api.groq.com/openai/v1", customContextPrompt: String = "") {
+    init(
+        apiKey: String,
+        baseURL: String = "https://api.groq.com/openai/v1",
+        customContextPrompt: String = "",
+        screenshotMaxDimension: CGFloat = AppContextService.defaultScreenshotMaxDimension
+    ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.customContextPrompt = customContextPrompt
+        self.screenshotMaxDimension = screenshotMaxDimension > 0
+            ? screenshotMaxDimension
+            : AppContextService.defaultScreenshotMaxDimension
     }
 
     func collectSelectionSnapshot() -> AppSelectionSnapshot {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -175,6 +175,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let customContextPromptStorageKey = "custom_context_prompt"
     private let customSystemPromptLastModifiedStorageKey = "custom_system_prompt_last_modified"
     private let customContextPromptLastModifiedStorageKey = "custom_context_prompt_last_modified"
+    private let contextScreenshotMaxDimensionStorageKey = "context_screenshot_max_dimension"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
@@ -186,6 +187,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let transcribingIndicatorDelay: TimeInterval = 0.25
     private let clipboardRestoreDelay: TimeInterval = 0.15
     let maxPipelineHistoryCount = 20
+    static let defaultContextScreenshotMaxDimension = Int(AppContextService.defaultScreenshotMaxDimension)
+    static let contextScreenshotDimensionOptions = [1024, 768, 640, 512]
 
     @Published var hasCompletedSetup: Bool {
         didSet {
@@ -196,14 +199,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var apiKey: String {
         didSet {
             persistAPIKey(apiKey)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
         }
     }
 
     @Published var apiBaseURL: String {
         didSet {
             persistAPIBaseURL(apiBaseURL)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
         }
     }
 
@@ -266,7 +269,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var customContextPrompt: String {
         didSet {
             UserDefaults.standard.set(customContextPrompt, forKey: customContextPromptStorageKey)
-            contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+            rebuildContextService()
+        }
+    }
+
+    @Published var contextScreenshotMaxDimension: Int {
+        didSet {
+            UserDefaults.standard.set(contextScreenshotMaxDimension, forKey: contextScreenshotMaxDimensionStorageKey)
+            rebuildContextService()
         }
     }
 
@@ -393,6 +403,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let customContextPrompt = UserDefaults.standard.string(forKey: customContextPromptStorageKey) ?? ""
         let customSystemPromptLastModified = UserDefaults.standard.string(forKey: customSystemPromptLastModifiedStorageKey) ?? ""
         let customContextPromptLastModified = UserDefaults.standard.string(forKey: customContextPromptLastModifiedStorageKey) ?? ""
+        let storedContextScreenshotMaxDimension = UserDefaults.standard.object(forKey: contextScreenshotMaxDimensionStorageKey) != nil
+            ? UserDefaults.standard.integer(forKey: contextScreenshotMaxDimensionStorageKey)
+            : Self.defaultContextScreenshotMaxDimension
+        let contextScreenshotMaxDimension = Self.contextScreenshotDimensionOptions.contains(storedContextScreenshotMaxDimension)
+            ? storedContextScreenshotMaxDimension
+            : Self.defaultContextScreenshotMaxDimension
         let shortcutStartDelay = max(0, UserDefaults.standard.double(forKey: shortcutStartDelayStorageKey))
         let isCommandModeEnabled = UserDefaults.standard.object(forKey: commandModeEnabledStorageKey) == nil
             ? false
@@ -435,7 +451,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
 
-        self.contextService = AppContextService(apiKey: apiKey, baseURL: apiBaseURL, customContextPrompt: customContextPrompt)
+        self.contextService = AppContextService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            customContextPrompt: customContextPrompt,
+            screenshotMaxDimension: CGFloat(contextScreenshotMaxDimension)
+        )
         self.hasCompletedSetup = hasCompletedSetup
         self.apiKey = apiKey
         self.apiBaseURL = apiBaseURL
@@ -449,6 +470,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.customVocabulary = customVocabulary
         self.customSystemPrompt = customSystemPrompt
         self.customContextPrompt = customContextPrompt
+        self.contextScreenshotMaxDimension = contextScreenshotMaxDimension
         self.customSystemPromptLastModified = customSystemPromptLastModified
         self.customContextPromptLastModified = customContextPromptLastModified
         self.shortcutStartDelay = shortcutStartDelay
@@ -542,6 +564,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return nil
         }
         return try? JSONDecoder().decode(ShortcutBinding.self, from: data)
+    }
+
+    private func rebuildContextService() {
+        contextService = AppContextService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            customContextPrompt: customContextPrompt,
+            screenshotMaxDimension: CGFloat(contextScreenshotMaxDimension)
+        )
     }
 
     private func persistAPIBaseURL(_ value: String) {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -311,7 +311,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             let normalizedDimension = Self.normalizedContextScreenshotMaxDimension(contextScreenshotMaxDimension)
             if normalizedDimension != contextScreenshotMaxDimension {
                 contextScreenshotMaxDimension = normalizedDimension
-                return
             }
             UserDefaults.standard.set(contextScreenshotMaxDimension, forKey: contextScreenshotMaxDimensionStorageKey)
             rebuildContextService()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -448,9 +448,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let storedContextScreenshotMaxDimension = UserDefaults.standard.object(forKey: contextScreenshotMaxDimensionStorageKey) != nil
             ? UserDefaults.standard.integer(forKey: contextScreenshotMaxDimensionStorageKey)
             : Self.defaultContextScreenshotMaxDimension
-        let contextScreenshotMaxDimension = Self.contextScreenshotDimensionOptions.contains(storedContextScreenshotMaxDimension)
-            ? storedContextScreenshotMaxDimension
-            : Self.defaultContextScreenshotMaxDimension
+        let contextScreenshotMaxDimension = Self.normalizedContextScreenshotMaxDimension(storedContextScreenshotMaxDimension)
         let shortcutStartDelay = max(0, UserDefaults.standard.double(forKey: shortcutStartDelayStorageKey))
         let isCommandModeEnabled = UserDefaults.standard.object(forKey: commandModeEnabledStorageKey) == nil
             ? false

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -308,6 +308,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @Published var contextScreenshotMaxDimension: Int {
         didSet {
+            let normalizedDimension = Self.normalizedContextScreenshotMaxDimension(contextScreenshotMaxDimension)
+            if normalizedDimension != contextScreenshotMaxDimension {
+                contextScreenshotMaxDimension = normalizedDimension
+                return
+            }
             UserDefaults.standard.set(contextScreenshotMaxDimension, forKey: contextScreenshotMaxDimensionStorageKey)
             rebuildContextService()
         }
@@ -488,12 +493,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
 
-        self.contextService = AppContextService(
+        self.contextService = Self.makeAppContextService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
             customContextPrompt: customContextPrompt,
             contextModel: contextModel,
-            screenshotMaxDimension: CGFloat(contextScreenshotMaxDimension)
+            contextScreenshotMaxDimension: contextScreenshotMaxDimension
         )
         self.hasCompletedSetup = hasCompletedSetup
         self.apiKey = apiKey
@@ -608,14 +613,40 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return try? JSONDecoder().decode(ShortcutBinding.self, from: data)
     }
 
-    private func rebuildContextService() {
-        contextService = AppContextService(
+    static func normalizedContextScreenshotMaxDimension(_ value: Int) -> Int {
+        contextScreenshotDimensionOptions.contains(value)
+            ? value
+            : defaultContextScreenshotMaxDimension
+    }
+
+    static func makeAppContextService(
+        apiKey: String,
+        baseURL: String,
+        customContextPrompt: String,
+        contextModel: String,
+        contextScreenshotMaxDimension: Int
+    ) -> AppContextService {
+        AppContextService(
+            apiKey: apiKey,
+            baseURL: baseURL,
+            customContextPrompt: customContextPrompt,
+            contextModel: contextModel,
+            screenshotMaxDimension: CGFloat(normalizedContextScreenshotMaxDimension(contextScreenshotMaxDimension))
+        )
+    }
+
+    func makeAppContextService() -> AppContextService {
+        Self.makeAppContextService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
             customContextPrompt: customContextPrompt,
             contextModel: contextModel,
-            screenshotMaxDimension: CGFloat(contextScreenshotMaxDimension)
+            contextScreenshotMaxDimension: contextScreenshotMaxDimension
         )
+    }
+
+    private func rebuildContextService() {
+        contextService = makeAppContextService()
     }
 
     private func persistAPIBaseURL(_ value: String) {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1150,6 +1150,44 @@ struct PromptsSettingsView: View {
 
             Divider()
 
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Screenshot Resolution")
+                    .font(.caption.weight(.semibold))
+
+                Text("Controls the maximum image dimension sent for context inference.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Picker("", selection: $appState.contextScreenshotMaxDimension) {
+                    ForEach(AppState.contextScreenshotDimensionOptions, id: \.self) { dimension in
+                        Text("\(dimension) px").tag(dimension)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+
+                HStack {
+                    if appState.contextScreenshotMaxDimension == AppState.defaultContextScreenshotMaxDimension {
+                        Label("Using default", systemImage: "checkmark.circle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Label("Using custom value", systemImage: "pencil")
+                            .font(.caption)
+                            .foregroundStyle(.blue)
+                    }
+                    Spacer()
+                    if appState.contextScreenshotMaxDimension != AppState.defaultContextScreenshotMaxDimension {
+                        Button("Reset to Default") {
+                            appState.contextScreenshotMaxDimension = AppState.defaultContextScreenshotMaxDimension
+                        }
+                        .font(.caption)
+                    }
+                }
+            }
+
+            Divider()
+
             // Test section
             VStack(alignment: .leading, spacing: 8) {
                 Text("Test Context Prompt")
@@ -1223,7 +1261,8 @@ struct PromptsSettingsView: View {
         let service = AppContextService(
             apiKey: appState.apiKey,
             baseURL: appState.apiBaseURL,
-            customContextPrompt: appState.customContextPrompt
+            customContextPrompt: appState.customContextPrompt,
+            screenshotMaxDimension: CGFloat(appState.contextScreenshotMaxDimension)
         )
 
         Task {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1386,6 +1386,7 @@ struct PromptsSettingsView: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                .accessibilityLabel("Screenshot Resolution")
 
                 HStack {
                     if appState.contextScreenshotMaxDimension == AppState.defaultContextScreenshotMaxDimension {
@@ -1479,13 +1480,7 @@ struct PromptsSettingsView: View {
         contextTestError = nil
         contextTestPrompt = nil
 
-        let service = AppContextService(
-            apiKey: appState.apiKey,
-            baseURL: appState.apiBaseURL,
-            customContextPrompt: appState.customContextPrompt,
-            contextModel: appState.contextModel,
-            screenshotMaxDimension: CGFloat(appState.contextScreenshotMaxDimension)
-        )
+        let service = appState.makeAppContextService()
 
         Task {
             let context = await service.collectContext()


### PR DESCRIPTION
## Summary

This PR adds a user-facing setting to choose the maximum screenshot resolution used for context inference.

The selected value is persisted in app settings, wired into `AppContextService`, and applied both during normal context capture and from the in-settings context prompt test flow.

## What Changed

- Added a configurable `screenshotMaxDimension` to `AppContextService`.
- Added persisted app state for `contextScreenshotMaxDimension`.
- Added a segmented control in Settings with the available sizes:
  - `1024 px`
  - `768 px`
  - `640 px`
  - `512 px`
- Added reset-to-default behavior in Settings.
- Updated the context prompt test path to use the selected resolution.

## Why

This makes screenshot payload size tunable without changing the rest of the context pipeline.

It is useful when balancing:

- screenshot detail for context inference
- payload size / latency
- reliability on stricter API limits or slower connections

## Verification

- Manually tested in app: changing the setting works.
- Confirmed the in-settings context prompt test also uses the selected value.
- `swiftc -parse-as-library -typecheck Sources/*.swift` passes.

<img width="553" height="405" alt="image" src="https://github.com/user-attachments/assets/ef4b656f-31fd-4149-8a41-89efd015838b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable "Screenshot Resolution" setting in Context Prompt settings with selectable options (1024, 768, 640, 512) and a "Reset to Default" action.
  * The chosen resolution is persisted and automatically normalized to a valid option; invalid values fall back to the default (1024).
  * The selected resolution is applied to context/screenshot behavior across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->