### PR TITLE
Stop Fn-bound shortcut from triggering on arrow keys

### DIFF
--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -28,6 +28,7 @@ final class GlobalShortcutBackend {
     func start() throws {
         stop()
         try installEventTap()
+        fnKeyIsDown = ModifierKeyEventState.currentFunctionKeyIsDown()
     }
 
     func stop() {
@@ -104,6 +105,7 @@ final class GlobalShortcutBackend {
             notifyBackendReset()
             if let tap = eventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)
+                fnKeyIsDown = ModifierKeyEventState.currentFunctionKeyIsDown()
             }
             return Unmanaged.passUnretained(event)
 

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -20,6 +20,7 @@ enum GlobalShortcutBackendError: LocalizedError {
 final class GlobalShortcutBackend {
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
+    private var fnKeyIsDown = false
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
     var onEscapeKeyPressed: (() -> Bool)?
@@ -93,6 +94,7 @@ final class GlobalShortcutBackend {
     }
 
     private func notifyBackendReset() {
+        fnKeyIsDown = false
         _ = onInputEvent?(.backendReset)
     }
 
@@ -135,6 +137,10 @@ final class GlobalShortcutBackend {
             return false
         }
 
+        if event.keyCode == ModifierKeyEventState.fnKeyCode {
+            fnKeyIsDown = isDown
+        }
+
         return onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown)) == .consume
     }
 
@@ -146,7 +152,10 @@ final class GlobalShortcutBackend {
 
         guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
         let snapshotDecision = onInputEvent?(
-            .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(for: event))
+            .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
+                for: event,
+                trustedFunctionKeyIsDown: fnKeyIsDown
+            ))
         ) ?? .passthrough
         let keyDecision = onInputEvent?(
             .keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat)
@@ -157,7 +166,10 @@ final class GlobalShortcutBackend {
     private func handleKeyUp(_ event: NSEvent) -> Bool {
         guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
         let snapshotDecision = onInputEvent?(
-            .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(for: event))
+            .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
+                for: event,
+                trustedFunctionKeyIsDown: fnKeyIsDown
+            ))
         ) ?? .passthrough
         let keyDecision = onInputEvent?(
             .keyChanged(keyCode: event.keyCode, isDown: false, isRepeat: false)

--- a/Sources/LocalShortcutCaptureBackend.swift
+++ b/Sources/LocalShortcutCaptureBackend.swift
@@ -11,6 +11,10 @@ final class LocalShortcutCaptureBackend {
     func start() {
         stop()
 
+        if ModifierKeyEventState.currentFunctionKeyIsDown() {
+            pressedModifierKeyCodes.insert(ModifierKeyEventState.fnKeyCode)
+        }
+
         localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             self?.handleFlagsChanged(event)
             return nil

--- a/Sources/LocalShortcutCaptureBackend.swift
+++ b/Sources/LocalShortcutCaptureBackend.swift
@@ -53,7 +53,11 @@ final class LocalShortcutCaptureBackend {
 
     private func handleKeyDown(_ event: NSEvent) {
         if !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) {
-            onInputEvent?(.modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(for: event)))
+            let trustedFn = pressedModifierKeyCodes.contains(ModifierKeyEventState.fnKeyCode)
+            onInputEvent?(.modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
+                for: event,
+                trustedFunctionKeyIsDown: trustedFn
+            )))
             onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat))
         }
         onKeyDownEvent?(event)

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -31,6 +31,13 @@ enum ModifierKeyEventState {
 
     static let fnKeyCode: UInt16 = 63
 
+    /// Reads the current system-wide Fn state. Useful for seeding a backend's
+    /// tracked Fn state at start or after a tap reset, since flagsChanged events
+    /// don't fire for keys already held when a monitor begins.
+    static func currentFunctionKeyIsDown() -> Bool {
+        NSEvent.modifierFlags.contains(.function)
+    }
+
     private static func mappedFlag(for keyCode: UInt16) -> NSEvent.ModifierFlags? {
         switch keyCode {
         case 54:

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -9,14 +9,27 @@ enum ModifierKeyEventState {
         return event.modifierFlags.contains(mappedFlag)
     }
 
-    static func pressedModifierKeyCodes(for event: NSEvent) -> Set<UInt16> {
+    static func pressedModifierKeyCodes(
+        for event: NSEvent,
+        trustedFunctionKeyIsDown: Bool? = nil
+    ) -> Set<UInt16> {
         ShortcutBinding.modifierKeyCodes.filter { keyCode in
+            // macOS sets NSEvent.ModifierFlags.function for arrow keys, F-keys,
+            // and navigation keys (Home/End/Page Up/Page Down/Forward Delete)
+            // regardless of whether the physical Fn key is held. When the caller
+            // can provide an authoritative Fn-down state (tracked from
+            // flagsChanged events), prefer it over the unreliable event flag.
+            if keyCode == fnKeyCode, let trustedFunctionKeyIsDown {
+                return trustedFunctionKeyIsDown
+            }
             guard let mappedFlag = mappedFlag(for: keyCode) else {
                 return false
             }
             return event.modifierFlags.contains(mappedFlag)
         }
     }
+
+    static let fnKeyCode: UInt16 = 63
 
     private static func mappedFlag(for keyCode: UInt16) -> NSEvent.ModifierFlags? {
         switch keyCode {


### PR DESCRIPTION
## Summary

On macOS, `NSEvent.ModifierFlags.function` is set automatically for arrow keys, F-keys, and navigation keys (Home/End/Page Up/Page Down/Forward Delete) regardless of whether the physical Fn key is held. The shortcut matcher derived its pressed-modifier snapshot from that flag on every `keyDown`/`keyUp`, so if the user had configured a Fn-based hold or toggle binding (the default), pressing any arrow key would falsely activate the binding and start recording.

## Repro (before this PR)

1. Keep default shortcut (hold Fn to talk) or set any binding that references Fn.
2. Press any arrow key (←, →, ↑, ↓) in any text field.
3. FreeFlow starts a recording session.

Same for Home/End/Page Up/Page Down/Forward Delete and the F-row keys.

## Fix

- Track the physical Fn state inside each backend using `flagsChanged` events for keyCode 63 — those events are authoritative.
- Pass that trusted state into `ModifierKeyEventState.pressedModifierKeyCodes(for:trustedFunctionKeyIsDown:)` when building the snapshot, so the `.function` flag on arrow/nav/F-key events is ignored in favor of the backend's real Fn state.
- Reset the tracked Fn state on backend reset.

`LocalShortcutCaptureBackend` already maintained its own `pressedModifierKeyCodes` set from `flagsChanged`, so it simply reuses that. `GlobalShortcutBackend` gains a small `fnKeyIsDown` field.

## Test plan

- [x] `swiftc -typecheck` clean on all Swift sources
- [x] Full `swiftc` build produces a binary
- [ ] With Fn-hold binding: pressing ←/→/↑/↓ does not start a recording
- [ ] With Fn-hold binding: holding Fn still starts a recording
- [ ] With Fn-hold binding: holding Fn then pressing an arrow still keeps the recording session active (trusted Fn state preserved across the snapshot)
- [ ] Cmd+Fn toggle still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Function (Fn) key detection and tracking for more accurate modifier recognition when recording and detecting shortcuts.
  * Fn state is now initialized and re-evaluated when capture starts or resumes, included in modifier snapshots, and reliably reset on backend reset to reduce incorrect shortcut interpretations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->