### PR TITLE
Show hint when Preview is clicked while system audio is muted

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -321,6 +321,7 @@ struct GeneralSettingsView: View {
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
+    @State private var showMutedHint = false
     @StateObject private var githubCache = GitHubMetadataCache.shared
     @ObservedObject private var updateManager = UpdateManager.shared
     private let freeflowRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!
@@ -868,11 +869,29 @@ struct GeneralSettingsView: View {
             .disabled(!appState.alertSoundsEnabled)
             .opacity(appState.alertSoundsEnabled ? 1 : 0.5)
 
-            Button("Preview") {
-                appState.playAlertSound(named: "Tink")
+            HStack(spacing: 8) {
+                Button("Preview") {
+                    let muted = SystemAudioStatus.isDefaultOutputMuted()
+                    let volume = SystemAudioStatus.defaultOutputVolume()
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showMutedHint = muted || (volume ?? 1) < 0.10
+                    }
+                    appState.playAlertSound(named: "Tink")
+                }
+                .font(.caption)
+                .disabled(!appState.alertSoundsEnabled)
+
+                if showMutedHint {
+                    HStack(spacing: 4) {
+                        Image(systemName: "speaker.slash.fill")
+                            .foregroundStyle(.orange)
+                        Text("System volume is muted or very low. Unmute to hear the preview.")
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.caption)
+                    .transition(.opacity)
+                }
             }
-            .font(.caption)
-            .disabled(!appState.alertSoundsEnabled)
         }
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -893,6 +893,9 @@ struct GeneralSettingsView: View {
                 }
             }
         }
+        .onChange(of: appState.alertSoundsEnabled) { enabled in
+            if !enabled { showMutedHint = false }
+        }
     }
 
     // MARK: Custom Vocabulary

--- a/Sources/SystemAudioStatus.swift
+++ b/Sources/SystemAudioStatus.swift
@@ -1,0 +1,89 @@
+import CoreAudio
+
+enum SystemAudioStatus {
+    static func isDefaultOutputMuted() -> Bool {
+        guard let deviceID = defaultOutputDeviceID() else { return false }
+
+        var muteValue: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &size,
+            &muteValue
+        )
+
+        guard status == noErr else { return false }
+        return muteValue == 1
+    }
+
+    static func defaultOutputVolume() -> Float? {
+        guard let deviceID = defaultOutputDeviceID() else { return nil }
+
+        if let volume = readVolume(deviceID: deviceID, element: kAudioObjectPropertyElementMain) {
+            return volume
+        }
+
+        var maxChannelVolume: Float?
+        for channel in 1...2 {
+            if let volume = readVolume(deviceID: deviceID, element: AudioObjectPropertyElement(channel)) {
+                maxChannelVolume = max(maxChannelVolume ?? 0, volume)
+            }
+        }
+        return maxChannelVolume
+    }
+
+    private static func readVolume(deviceID: AudioDeviceID, element: AudioObjectPropertyElement) -> Float? {
+        var value: Float32 = 0
+        var size = UInt32(MemoryLayout<Float32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: element
+        )
+
+        guard AudioObjectHasProperty(deviceID, &address) else { return nil }
+
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &size,
+            &value
+        )
+
+        return status == noErr ? value : nil
+    }
+
+    private static func defaultOutputDeviceID() -> AudioDeviceID? {
+        var deviceID: AudioDeviceID = 0
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &size,
+            &deviceID
+        )
+
+        return status == noErr ? deviceID : nil
+    }
+}


### PR DESCRIPTION
Closes #106.

## What

When the **Preview** button in Settings > Sound Volume is clicked while the system is muted (or volume is below 10%), an inline hint appears next to the button:

> 🔇 System volume is muted or very low. Unmute to hear the preview.

This matches the suggestion in the issue — the button appearing to do nothing when system audio is muted was confusing. Now the user gets immediate feedback.

## How

- New `SystemAudioStatus` enum namespace in `Sources/SystemAudioStatus.swift` with two Core Audio helpers: `isDefaultOutputMuted()` and `defaultOutputVolume()`.
- Both fail gracefully (return `false` / `nil`) if a property can't be read, so the hint never falsely appears on devices that don't expose mute/volume (HDMI, some Bluetooth setups).
- `defaultOutputVolume()` falls back to reading channels 1 and 2 if the main element doesn't expose volume — common on many external output devices.
- Threshold: 10%. macOS volume steps are ~6.25%, so the first tick above mute (6.25%) triggers the hint, but the second tick (12.5%) does not.

## Testing

Tested on macOS with built-in speakers. All combinations behave correctly:

| System state | Click Preview | Result |
|---|---|---|
| Muted | ✓ | Hint appears |
| Volume 1 notch up (below 10%) | ✓ | Hint appears |
| Volume well above 10% | ✓ | No hint, sound plays |
| Back to muted | ✓ | Hint appears again |
| Toggle mute + various volume levels | ✓ | All correct |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio status indicator in Settings: when previewing alert sounds, a warning hint with a speaker icon appears if the system output is muted or volume is very low.
  * Preview controls now reflect alert-sound enablement and show the hint only while previewing or when alerts are enabled/disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->