### PR TITLE
Expand transcription hallucination filters

### DIFF
--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -243,8 +243,14 @@ class TranscriptionService {
     // Normal speech included audios have very low no_speech_prob.
     private let hallucinationPhrases = [
         "thank you",
+        "thank you for watching",
         "thank you very much",
         "thank you so much",
+        "thanks for watching",
+        "please subscribe",
+        "like and subscribe",
+        "subtitles by",
+        "subtitles by the amara.org community",
         "you"
     ]
 


### PR DESCRIPTION
## Summary
- Added several additional hallucination filter phrases to `TranscriptionService`.
- The new phrases cover common outro spam such as subscribe prompts and subtitle credits.
- This should reduce false positive speech output from low-confidence audio segments.

## Testing
- Not run
- Reviewed the diff to confirm the new phrases were added to the hallucination filter list in `Sources/TranscriptionService.swift`

Closes #111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription accuracy by expanding hallucination detection to filter additional common false phrases in transcriptions, resulting in higher quality transcribed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->