### PR TITLE
Add build diagnostics section to Settings

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -487,9 +487,6 @@ struct GeneralSettingsView: View {
                 SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
                     updatesSection
                 }
-                SettingsCard("Build", icon: "info.circle.fill") {
-                    buildInfoSection
-                }
                 SettingsCard("API Key", icon: "key.fill") {
                     apiKeySection
                 }
@@ -513,6 +510,9 @@ struct GeneralSettingsView: View {
                 }
                 SettingsCard("Permissions", icon: "lock.shield.fill") {
                     permissionsSection
+                }
+                SettingsCard("Build", icon: "info.circle.fill") {
+                    buildInfoSection
                 }
             }
             .padding(24)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -321,9 +321,45 @@ struct GeneralSettingsView: View {
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
+    @State private var copiedBuildInfo = false
     @StateObject private var githubCache = GitHubMetadataCache.shared
     @ObservedObject private var updateManager = UpdateManager.shared
     private let freeflowRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!
+
+    private var appDisplayName: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+            ?? "FreeFlow"
+    }
+
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    }
+
+    private var appBuildNumber: String {
+        Bundle.main.object(forInfoDictionaryKey: "FreeFlowBuildTag") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+            ?? "unknown"
+    }
+
+    private var macOSVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+
+    private var appArchitecture: String {
+        #if arch(arm64)
+        return "arm64"
+        #elseif arch(x86_64)
+        return "x86_64"
+        #else
+        return "unknown"
+        #endif
+    }
+
+    private var buildDiagnosticsText: String {
+        "\(appDisplayName) \(appVersion) (\(appBuildNumber))\nmacOS \(macOSVersion) (\(appArchitecture))"
+    }
 
     var body: some View {
         ScrollView {
@@ -338,7 +374,7 @@ struct GeneralSettingsView: View {
                     Text("FreeFlow")
                         .font(.system(size: 20, weight: .bold, design: .rounded))
 
-                    Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")")
+                    Text("v\(appVersion)")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
@@ -450,6 +486,9 @@ struct GeneralSettingsView: View {
                 }
                 SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
                     updatesSection
+                }
+                SettingsCard("Build", icon: "info.circle.fill") {
+                    buildInfoSection
                 }
                 SettingsCard("API Key", icon: "key.fill") {
                     apiKeySection
@@ -624,6 +663,48 @@ struct GeneralSettingsView: View {
                 .background(Color.blue.opacity(0.1))
                 .cornerRadius(6)
             }
+        }
+    }
+
+    // MARK: Build
+
+    private var buildInfoSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Build number")
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(appBuildNumber)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            HStack(alignment: .top, spacing: 12) {
+                Text(buildDiagnosticsText)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+
+                Spacer()
+
+                Button {
+                    copyBuildDiagnostics()
+                } label: {
+                    Label(copiedBuildInfo ? "Copied" : "Copy", systemImage: copiedBuildInfo ? "checkmark" : "doc.on.doc")
+                }
+                .font(.caption)
+            }
+        }
+    }
+
+    private func copyBuildDiagnostics() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(buildDiagnosticsText, forType: .string)
+        copiedBuildInfo = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            copiedBuildInfo = false
         }
     }
 


### PR DESCRIPTION
## Summary
- Added a new Build section to Settings showing the app build number and copyable diagnostics.
- Included app name, app version, build tag, macOS version, and CPU architecture in a monospaced diagnostics string.
- Wired the displayed version text to the shared app version helper for consistency.

## Testing
- Not run
- Verified the diff for `Sources/SettingsView.swift` to confirm the new Build card and copy action are wired into the settings view.
- Not run: UI validation of clipboard copy behavior and the temporary copied state reset.

Closes #110 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Build information section in General Settings showing app version, build number, macOS version, and architecture.
  * Build diagnostics are selectable and can be copied to the clipboard.
  * Copy action provides brief visual "Copied" confirmation before resetting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->