### PR TITLE
Delay clipboard restore to prevent wrong paste

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -189,7 +189,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let commandModeStyleStorageKey = "command_mode_style"
     private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
     private let transcribingIndicatorDelay: TimeInterval = 0.25
-    private let clipboardRestoreDelay: TimeInterval = 0.15
+    private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
+    private let clipboardRestoreDelay: TimeInterval = 1.0
     let maxPipelineHistoryCount = 20
     static let defaultContextScreenshotMaxDimension = Int(AppContextService.defaultScreenshotMaxDimension)
     static let contextScreenshotDimensionOptions = [1024, 768, 640, 512]
@@ -2364,6 +2365,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func restoreClipboardIfNeeded(_ pendingRestore: PendingClipboardRestore?) {
         guard let pendingRestore else { return }
 
+        // Some apps consume Cmd-V asynchronously, so restoring too quickly can paste
+        // the pre-dictation clipboard instead of the transcript.
         DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
             let pasteboard = NSPasteboard.general
             guard pasteboard.changeCount == pendingRestore.expectedChangeCount else { return }
@@ -2380,7 +2383,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + pasteAfterShortcutReleaseDelay) { [weak self] in
             self?.pasteAtCursor()
             completion?()
         }


### PR DESCRIPTION
## Summary
- Delay clipboard restoration longer after paste to avoid races with apps that consume `Cmd+V` asynchronously.
- Extract the shortcut-release delay into a named constant for clarity.
- Add a code comment explaining why the restore delay needs to be conservative.

## Testing
- Not run
- Reviewed the diff to confirm the paste timing and clipboard restore timing now use separate constants
- Verified the change is limited to `Sources/AppState.swift`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard restoration timing to provide better compatibility with applications that process paste commands with variable delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->