### PR TITLE
Add optional "press enter" voice command

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -110,6 +110,11 @@ private struct PendingClipboardRestore {
     let expectedChangeCount: Int
 }
 
+private struct TranscriptCommandParsingResult {
+    let transcript: String
+    let shouldPressEnterAfterPaste: Bool
+}
+
 private enum CommandInvocation: String {
     case automatic
     case manual
@@ -182,6 +187,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let contextScreenshotMaxDimensionStorageKey = "context_screenshot_max_dimension"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
+    private let pressEnterVoiceCommandStorageKey = "press_enter_voice_command_enabled"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
     private let voiceMacrosStorageKey = "voice_macros"
@@ -190,6 +196,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
     private let transcribingIndicatorDelay: TimeInterval = 0.25
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
+    private let pressEnterAfterPasteDelay: TimeInterval = 0.08
     private let clipboardRestoreDelay: TimeInterval = 1.0
     let maxPipelineHistoryCount = 20
     static let defaultContextScreenshotMaxDimension = Int(AppContextService.defaultScreenshotMaxDimension)
@@ -198,6 +205,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static let defaultPostProcessingModel = "openai/gpt-oss-20b"
     static let defaultPostProcessingFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     static let defaultContextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    private static let trailingPressEnterCommandPattern = try! NSRegularExpression(
+        pattern: #"(?i)(?:^|[ \t\r\n,;:\-]+)press[ \t\r\n]+enter[\s\p{P}]*$"#
+    )
 
     @Published var hasCompletedSetup: Bool {
         didSet {
@@ -345,6 +355,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var isPressEnterVoiceCommandEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(isPressEnterVoiceCommandEnabled, forKey: pressEnterVoiceCommandStorageKey)
+        }
+    }
+
     @Published var alertSoundsEnabled: Bool {
         didSet {
             UserDefaults.standard.set(alertSoundsEnabled, forKey: alertSoundsEnabledStorageKey)
@@ -472,6 +488,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
+        let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
         let soundVolume: Float = UserDefaults.standard.object(forKey: soundVolumeStorageKey) != nil
             ? UserDefaults.standard.float(forKey: soundVolumeStorageKey) : 1.0
         let alertSoundsEnabled = UserDefaults.standard.object(forKey: alertSoundsEnabledStorageKey) != nil
@@ -530,6 +549,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.customContextPromptLastModified = customContextPromptLastModified
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
+        self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
@@ -820,6 +840,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     transcriptionModel: transcriptionModel
                 )
                 let rawTranscript = try await transcriptionService.transcribe(fileURL: audioURL)
+                let parsedTranscript = Self.parseTranscriptCommands(
+                    from: rawTranscript,
+                    pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                )
 
                 let finalTranscript: String
                 let processingStatus: String
@@ -829,7 +853,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     selectedText: item.selectedText
                 )
                 let result = await self.processTranscript(
-                    rawTranscript,
+                    parsedTranscript.transcript,
                     intent: restoredIntent,
                     context: restoredContext,
                     postProcessingService: postProcessingService,
@@ -846,7 +870,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         selectedText: item.selectedText,
                         id: item.id,
                         timestamp: item.timestamp,
-                        rawTranscript: rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
+                        rawTranscript: parsedTranscript.transcript,
                         postProcessedTranscript: finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
                         postProcessingPrompt: postProcessingPrompt,
                         contextSummary: item.contextSummary,
@@ -1798,6 +1822,37 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return strippedPunctuation.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private static func parseTranscriptCommands(
+        from transcript: String,
+        pressEnterCommandEnabled: Bool
+    ) -> TranscriptCommandParsingResult {
+        guard pressEnterCommandEnabled else {
+            return TranscriptCommandParsingResult(
+                transcript: transcript.trimmingCharacters(in: .whitespacesAndNewlines),
+                shouldPressEnterAfterPaste: false
+            )
+        }
+
+        let fullRange = NSRange(transcript.startIndex..<transcript.endIndex, in: transcript)
+        guard
+            let match = trailingPressEnterCommandPattern.firstMatch(in: transcript, range: fullRange),
+            let commandRange = Range(match.range, in: transcript)
+        else {
+            return TranscriptCommandParsingResult(
+                transcript: transcript.trimmingCharacters(in: .whitespacesAndNewlines),
+                shouldPressEnterAfterPaste: false
+            )
+        }
+
+        var strippedTranscript = transcript
+        strippedTranscript.removeSubrange(commandRange)
+
+        return TranscriptCommandParsingResult(
+            transcript: strippedTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
+            shouldPressEnterAfterPaste: true
+        )
+    }
+
     func playAlertSound(named name: String) {
         guard alertSoundsEnabled else { return }
 
@@ -1968,6 +2023,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     )
                     async let transcript = transcriptionService.transcribe(fileURL: transcriptionFileURL)
                     let rawTranscript = try await transcript
+                    let parsedTranscript = Self.parseTranscriptCommands(
+                        from: rawTranscript,
+                        pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                    )
                     try Task.checkCancellation()
                     let appContext: AppContext
                     if let sessionContext {
@@ -1982,7 +2041,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self?.debugStatusMessage = "Running post-processing"
                     }
                     let result = await self.processTranscript(
-                        rawTranscript,
+                        parsedTranscript.transcript,
                         intent: sessionIntent,
                         context: appContext,
                         postProcessingService: postProcessingService,
@@ -1997,7 +2056,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.lastContextScreenshotDataURL = appContext.screenshotDataURL
                         self.lastContextScreenshotStatus = appContext.screenshotError
                             ?? "available (\(appContext.screenshotMimeType ?? "image"))"
-                        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let trimmedRawTranscript = parsedTranscript.transcript
                         let trimmedFinalTranscript = result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
                         let processingStatus = result.outcome.statusMessage()
                         self.lastPostProcessingPrompt = result.prompt
@@ -2021,6 +2080,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.isTranscribing = false
                         self.debugStatusMessage = "Done"
                         let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
+                        let enterOnlyStatusText = "Pressed Enter"
+                        let shouldPressEnterAfterPaste = parsedTranscript.shouldPressEnterAfterPaste
 
                         let shouldPersistRawDictationFallback: Bool
                         switch result.outcome {
@@ -2031,9 +2092,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         }
 
                         if trimmedFinalTranscript.isEmpty {
-                            self.statusText = "Nothing to transcribe"
+                            self.statusText = shouldPressEnterAfterPaste ? enterOnlyStatusText : "Nothing to transcribe"
                             self.clearPendingOverlayDismissToken()
                             self.overlayManager.dismiss()
+                            if shouldPressEnterAfterPaste {
+                                self.pressEnterWhenShortcutReleased()
+                            }
                         } else {
                             self.statusText = completionStatusText
                             if shouldPersistRawDictationFallback {
@@ -2045,14 +2109,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
                             let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
                             self.pasteAtCursorWhenShortcutReleased {
-                                self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                                if shouldPressEnterAfterPaste {
+                                    self.pressEnterAfterPaste {
+                                        self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                                    }
+                                } else {
+                                    self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                                }
                             }
                         }
 
                         self.audioRecorder.cleanup()
                         self.refreshAvailableMicrophonesIfNeeded()
 
-                        self.scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe"])
+                        self.scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe", enterOnlyStatusText])
                     }
                 } catch is CancellationError {
                     await MainActor.run {
@@ -2351,6 +2421,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         keyUp?.post(tap: .cgSessionEventTap)
     }
 
+    private func pressEnter() {
+        let source = CGEventSource(stateID: .hidSystemState)
+
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true)
+        keyDown?.post(tap: .cgSessionEventTap)
+
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false)
+        keyUp?.post(tap: .cgSessionEventTap)
+    }
+
     private func writeTranscriptToPasteboard(_ transcript: String) -> PendingClipboardRestore? {
         let pasteboard = NSPasteboard.general
         let snapshot = preserveClipboard ? PreservedPasteboardSnapshot(pasteboard: pasteboard) : nil
@@ -2374,17 +2454,37 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private func pasteAtCursorWhenShortcutReleased(attempt: Int = 0, completion: (() -> Void)? = nil) {
+    private func performAfterShortcutReleased(attempt: Int = 0, action: @escaping () -> Void) {
         let maxAttempts = 24
         if hotkeyManager.hasPressedShortcutInputs && attempt < maxAttempts {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.025) { [weak self] in
-                self?.pasteAtCursorWhenShortcutReleased(attempt: attempt + 1, completion: completion)
+                self?.performAfterShortcutReleased(attempt: attempt + 1, action: action)
             }
             return
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + pasteAfterShortcutReleaseDelay) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + pasteAfterShortcutReleaseDelay) {
+            action()
+        }
+    }
+
+    private func pasteAtCursorWhenShortcutReleased(completion: (() -> Void)? = nil) {
+        performAfterShortcutReleased { [weak self] in
             self?.pasteAtCursor()
+            completion?()
+        }
+    }
+
+    private func pressEnterWhenShortcutReleased(completion: (() -> Void)? = nil) {
+        performAfterShortcutReleased { [weak self] in
+            self?.pressEnter()
+            completion?()
+        }
+    }
+
+    private func pressEnterAfterPaste(completion: (() -> Void)? = nil) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + pressEnterAfterPasteDelay) { [weak self] in
+            self?.pressEnter()
             completion?()
         }
     }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -861,7 +861,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     customSystemPrompt: capturedCustomSystemPrompt
                 )
                 finalTranscript = result.finalTranscript
-                processingStatus = result.outcome.statusMessage(isRetry: true)
+                processingStatus = Self.statusMessage(
+                    for: result.outcome,
+                    parsedTranscript: parsedTranscript,
+                    isRetry: true
+                )
                 postProcessingPrompt = result.prompt
 
                 await MainActor.run {
@@ -1853,6 +1857,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
+    private static func statusMessage(
+        for outcome: TranscriptProcessingOutcome,
+        parsedTranscript: TranscriptCommandParsingResult,
+        isRetry: Bool = false
+    ) -> String {
+        let status = outcome.statusMessage(isRetry: isRetry)
+        guard parsedTranscript.shouldPressEnterAfterPaste else { return status }
+        return "\(status); detected press enter command"
+    }
+
     func playAlertSound(named name: String) {
         guard alertSoundsEnabled else { return }
 
@@ -2058,7 +2072,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             ?? "available (\(appContext.screenshotMimeType ?? "image"))"
                         let trimmedRawTranscript = parsedTranscript.transcript
                         let trimmedFinalTranscript = result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                        let processingStatus = result.outcome.statusMessage()
+                        let processingStatus = Self.statusMessage(
+                            for: result.outcome,
+                            parsedTranscript: parsedTranscript
+                        )
                         self.lastPostProcessingPrompt = result.prompt
                         self.lastRawTranscript = trimmedRawTranscript
                         self.lastPostProcessedTranscript = trimmedFinalTranscript

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -903,6 +903,15 @@ struct GeneralSettingsView: View {
             Text("FreeFlow will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, FreeFlow leaves it alone.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            Divider()
+                .padding(.vertical, 2)
+
+            Toggle("Say \"press enter\" to submit after paste", isOn: $appState.isPressEnterVoiceCommandEnabled)
+
+            Text("When the transcription ends with \"press enter\", FreeFlow removes those words before cleanup, pastes the remaining transcript, then presses Return.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 


### PR DESCRIPTION
## Summary
- Added an opt-in voice command that detects a trailing `press enter` phrase in the transcript.
- When enabled, FreeFlow strips the command from the pasted text and triggers Return after paste, or presses Return on its own if there is no remaining transcript.
- Added a General settings toggle to enable or disable the behavior, with persistence in user defaults.
- Updated status messaging to reflect when the `press enter` command was detected.

## Testing
- Not run.
- Verified the code paths for normal transcription, empty transcript handling, and post-paste Return behavior were updated consistently.
- Verified the new settings toggle is wired to persisted app state.

Closes #112 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Voice-activated key press commands: End dictation with "press enter" to automatically paste transcribed text and trigger an Enter key press.
  * New setting in General Settings allows users to enable or disable detection of voice-activated key press commands at the end of dictation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->