### PR TITLE
Add run log transcript copy action

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1814,9 +1814,18 @@ struct RunLogEntryView: View {
     @State private var isRetrying = false
     @State private var showContextPrompt = false
     @State private var showPostProcessingPrompt = false
+    @State private var copiedTranscript = false
+    @State private var copiedTranscriptResetWorkItem: DispatchWorkItem?
 
     private var isError: Bool {
         item.postProcessingStatus.hasPrefix("Error:")
+    }
+
+    private var copyableTranscript: String {
+        if !item.postProcessedTranscript.isEmpty {
+            return item.postProcessedTranscript
+        }
+        return item.rawTranscript
     }
 
     @ViewBuilder
@@ -1913,6 +1922,15 @@ struct RunLogEntryView: View {
                             item: item,
                             audioDirURL: AppState.audioStorageDirectory()
                         )
+                    }
+
+                    actionIconButton(
+                        systemName: copiedTranscript ? "checkmark" : "doc.on.doc",
+                        color: copiedTranscript ? .green : .secondary,
+                        help: copiedTranscript ? "Copied transcript" : "Copy transcript",
+                        disabled: copyableTranscript.isEmpty
+                    ) {
+                        copyTranscriptToPasteboard()
                     }
 
                     actionIconButton(systemName: "trash", help: "Delete this run") {
@@ -2117,6 +2135,22 @@ struct RunLogEntryView: View {
         text.components(separatedBy: CharacterSet(charactersIn: ",;\n"))
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+    }
+
+    private func copyTranscriptToPasteboard() {
+        guard !copyableTranscript.isEmpty else { return }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(copyableTranscript, forType: .string)
+        copiedTranscript = true
+
+        copiedTranscriptResetWorkItem?.cancel()
+        let resetWorkItem = DispatchWorkItem {
+            copiedTranscript = false
+            copiedTranscriptResetWorkItem = nil
+        }
+        copiedTranscriptResetWorkItem = resetWorkItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: resetWorkItem)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a copy-to-clipboard action for run log transcripts in `RunLogEntryView`.
- Prefer the post-processed transcript when available, and fall back to the raw transcript otherwise.
- Show transient copied-state feedback by swapping the icon to a checkmark and resetting it after 1.5 seconds.

## Testing
- Not run (not requested).
- Manually verify the copy button is disabled when no transcript is available.
- Manually verify clicking the button copies the expected transcript text and the icon reverts after the timeout.

Closes #126 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy transcript action to each run entry. Users can now easily copy either the post-processed or raw transcript to their clipboard with visual confirmation that persists briefly before resetting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->