### PR TITLE
Add dictation audio interruption controls

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -120,6 +120,20 @@ private enum CommandInvocation: String {
     case manual
 }
 
+enum DictationAudioInterruptionMode: String, CaseIterable, Identifiable {
+    case mute
+    case pause
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .mute: return "Mute"
+        case .pause: return "Pause"
+        }
+    }
+}
+
 private enum SessionIntent {
     case dictation
     case command(invocation: CommandInvocation, selectedText: String)
@@ -177,6 +191,11 @@ private enum SessionIntent {
 }
 
 final class AppState: ObservableObject, @unchecked Sendable {
+    private enum ActiveAudioInterruption {
+        case muted(previouslyMuted: Bool)
+        case paused
+    }
+
     private let apiKeyStorageKey = "groq_api_key"
     private let apiBaseURLStorageKey = "api_base_url"
     private let transcriptionModelStorageKey = "transcription_model"
@@ -207,6 +226,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
+    private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
+    private let dictationAudioInterruptionModeStorageKey = "dictation_audio_interruption_mode"
     private let transcribingIndicatorDelay: TimeInterval = 0.25
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -392,6 +413,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var dictationAudioInterruptionEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(
+                dictationAudioInterruptionEnabled,
+                forKey: dictationAudioInterruptionEnabledStorageKey
+            )
+        }
+    }
+
+    @Published var dictationAudioInterruptionMode: DictationAudioInterruptionMode {
+        didSet {
+            UserDefaults.standard.set(
+                dictationAudioInterruptionMode.rawValue,
+                forKey: dictationAudioInterruptionModeStorageKey
+            )
+        }
+    }
 
     @Published var preserveClipboard: Bool {
         didSet {
@@ -489,6 +527,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
     private var realtimeService: RealtimeTranscriptionService?
+    private var activeAudioInterruption: ActiveAudioInterruption?
     private var pendingOverlayDismissToken: UUID?
     private var shouldMonitorHotkeys = false
     private var isCapturingShortcut = false
@@ -544,6 +583,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
+        let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
+            forKey: dictationAudioInterruptionEnabledStorageKey
+        )
+        let dictationAudioInterruptionMode = DictationAudioInterruptionMode(
+            rawValue: UserDefaults.standard.string(forKey: dictationAudioInterruptionModeStorageKey) ?? ""
+        ) ?? .mute
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -609,6 +654,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.preserveClipboard = preserveClipboard
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
+        self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
+        self.dictationAudioInterruptionMode = dictationAudioInterruptionMode
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
@@ -1456,6 +1503,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         overlayManager.dismiss()
         tearDownRealtimeService()
         audioRecorder.cancelRecording()
+        restoreAudioInterruptionIfNeeded()
         refreshAvailableMicrophonesIfNeeded()
         if !isRecording && !isTranscribing && statusText == "Cancelled" {
             scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
@@ -1616,6 +1664,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         ) else { return }
         guard ensureMicrophoneAccess() else { return }
         os_log(.info, log: recordingLog, "mic access check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+        applyAudioInterruptionIfNeeded()
         beginRecording(triggerMode: triggerMode)
         os_log(.info, log: recordingLog, "startRecording() finished: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
     }
@@ -1718,6 +1767,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                                 manualCommandRequested: pendingManualCommandRequested
                             ) else { return }
                             strongSelf.shortcutSessionController.beginManual(mode: .toggle)
+                            strongSelf.applyAudioInterruptionIfNeeded()
                             strongSelf.beginRecording(triggerMode: .toggle)
                         } else {
                             strongSelf.currentSessionIntent = .dictation
@@ -1767,6 +1817,38 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
         overlayManager.dismiss()
+    }
+
+    private func applyAudioInterruptionIfNeeded() {
+        guard dictationAudioInterruptionEnabled, activeAudioInterruption == nil else { return }
+
+        switch dictationAudioInterruptionMode {
+        case .mute:
+            let wasMuted = SystemAudioStatus.isDefaultOutputMuted()
+            if wasMuted {
+                activeAudioInterruption = .muted(previouslyMuted: true)
+            } else if SystemAudioStatus.setDefaultOutputMuted(true) {
+                activeAudioInterruption = .muted(previouslyMuted: false)
+            }
+        case .pause:
+            guard SystemAudioStatus.isDefaultOutputRunningSomewhere() else { return }
+            SystemAudioStatus.sendMediaPlayPauseKey()
+            activeAudioInterruption = .paused
+        }
+    }
+
+    private func restoreAudioInterruptionIfNeeded() {
+        guard let activeAudioInterruption else { return }
+        self.activeAudioInterruption = nil
+
+        switch activeAudioInterruption {
+        case .muted(let previouslyMuted):
+            if !previouslyMuted {
+                _ = SystemAudioStatus.setDefaultOutputMuted(false)
+            }
+        case .paused:
+            SystemAudioStatus.sendMediaPlayPauseKey()
+        }
     }
 
     private func beginRecording(triggerMode: RecordingTriggerMode) {
@@ -1867,6 +1949,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         capturedContext = nil
         tearDownRealtimeService()
         audioRecorder.cleanup()
+        restoreAudioInterruptionIfNeeded()
         isRecording = false
         isTranscribing = false
         transcriptionTask?.cancel()
@@ -2134,6 +2217,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         lastContextScreenshotDataURL = nil
         lastContextScreenshotStatus = "No screenshot"
         isRecording = false
+        restoreAudioInterruptionIfNeeded()
         isTranscribing = true
         statusText = "Preparing audio..."
         errorMessage = nil
@@ -2571,6 +2655,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextCaptureTask = nil
             capturedContext = nil
             isRecording = false
+            restoreAudioInterruptionIfNeeded()
             shortcutSessionController.reset()
             activeRecordingTriggerMode = nil
             statusText = "Screenshot Required"

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -620,6 +620,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
                 }
+                SettingsCard("Audio During Dictation", icon: "speaker.slash.fill") {
+                    dictationAudioSection
+                }
                 SettingsCard("Edit Mode", icon: "pencil") {
                     commandModeSection
                 }
@@ -968,6 +971,28 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+    }
+
+    private var dictationAudioSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(
+                "Mute or pause audio when dictation starts",
+                isOn: $appState.dictationAudioInterruptionEnabled
+            )
+
+            Picker("Audio Action", selection: $appState.dictationAudioInterruptionMode) {
+                ForEach(DictationAudioInterruptionMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .disabled(!appState.dictationAudioInterruptionEnabled)
+            .opacity(appState.dictationAudioInterruptionEnabled ? 1 : 0.5)
+
+            Text("FreeFlow restores the audio state it changed when dictation ends.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/SystemAudioStatus.swift
+++ b/Sources/SystemAudioStatus.swift
@@ -1,6 +1,11 @@
+import AppKit
 import CoreAudio
 
 enum SystemAudioStatus {
+    private static let nxKeyTypePlay = 16
+    private static let mediaKeyDown = 0xA
+    private static let mediaKeyUp = 0xB
+
     static func isDefaultOutputMuted() -> Bool {
         guard let deviceID = defaultOutputDeviceID() else { return false }
 
@@ -27,6 +32,30 @@ enum SystemAudioStatus {
         return muteValue == 1
     }
 
+    static func setDefaultOutputMuted(_ muted: Bool) -> Bool {
+        guard let deviceID = defaultOutputDeviceID() else { return false }
+
+        var muteValue: UInt32 = muted ? 1 : 0
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+
+        let status = AudioObjectSetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            UInt32(MemoryLayout<UInt32>.size),
+            &muteValue
+        )
+
+        return status == noErr
+    }
+
     static func defaultOutputVolume() -> Float? {
         guard let deviceID = defaultOutputDeviceID() else { return nil }
 
@@ -41,6 +70,54 @@ enum SystemAudioStatus {
             }
         }
         return maxChannelVolume
+    }
+
+    static func isDefaultOutputRunningSomewhere() -> Bool {
+        guard let deviceID = defaultOutputDeviceID() else { return false }
+
+        var isRunning: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &size,
+            &isRunning
+        )
+
+        guard status == noErr else { return false }
+        return isRunning != 0
+    }
+
+    static func sendMediaPlayPauseKey() {
+        postMediaPlayPauseKey(state: mediaKeyDown)
+        postMediaPlayPauseKey(state: mediaKeyUp)
+    }
+
+    private static func postMediaPlayPauseKey(state: Int) {
+        let data1 = (nxKeyTypePlay << 16) | (state << 8)
+        guard let event = NSEvent.otherEvent(
+            with: .systemDefined,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            subtype: 8,
+            data1: data1,
+            data2: -1
+        ) else { return }
+
+        event.cgEvent?.post(tap: .cghidEventTap)
     }
 
     private static func readVolume(deviceID: AudioDeviceID, element: AudioObjectPropertyElement) -> Float? {


### PR DESCRIPTION
## Summary
- Added a new dictation audio interruption setting with `Mute` and `Pause` modes.
- Persisted the setting in `UserDefaults` and surfaced it in General Settings under a dedicated Audio During Dictation card.
- Implemented system audio controls to mute/unmute the default output device or send media play/pause key events when dictation starts and ends.
- Restored any audio state changed by the app when dictation finishes, cancels, or is interrupted.

## Testing
- Not run (not requested).
- Verified the new settings UI is wired to `appState.dictationAudioInterruptionEnabled` and `appState.dictationAudioInterruptionMode`.
- Verified audio interruption state is applied on recording start and restored on cleanup/cancel paths.

Closes #108 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added audio interruption controls for dictation. Users can now enable automatic audio interruption when dictation begins, choosing between mute or media pause modes. The original audio state is automatically restored once dictation ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->