### PR TITLE
Add semantic release workflow and changelog-driven update notes

### DIFF
--- a/.agents/skills/freeflow-release/SKILL.md
+++ b/.agents/skills/freeflow-release/SKILL.md
@@ -62,7 +62,7 @@ Use this skill to prepare a FreeFlow release from the local repository. FreeFlow
 5. Validate locally before commit/tag:
    ```bash
    .github/scripts/changelog-section.sh <version>
-   ~/.codex/skills/freeflow-release/scripts/freeflow-release-check.sh <version>
+   .agents/skills/freeflow-release/scripts/freeflow-release-check.sh <version>
    git diff --check
    make clean
    make ARCH="$(uname -m)" CODESIGN_IDENTITY=-
@@ -90,4 +90,4 @@ Use this skill to prepare a FreeFlow release from the local repository. FreeFlow
 
 ## Helper Script
 
-Run `scripts/freeflow-release-check.sh <version>` from the FreeFlow repo root to check release preconditions. It validates semver shape, required files, changelog extraction, workflow trigger basics, and tag availability.
+Run `.agents/skills/freeflow-release/scripts/freeflow-release-check.sh <version>` from the FreeFlow repo root to check release preconditions. It validates semver shape, required files, changelog extraction, workflow trigger basics, and tag availability.

--- a/.agents/skills/freeflow-release/SKILL.md
+++ b/.agents/skills/freeflow-release/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: freeflow-release
+description: Prepare and publish FreeFlow app releases. Use when the user asks to release FreeFlow, prepare a new version, bump the FreeFlow version, write or update FreeFlow changelog entries, validate a FreeFlow semver release, create a vX.Y.Z tag, or publish a signed FreeFlow DMG through the repository GitHub Actions release workflow.
+---
+
+# FreeFlow Release
+
+## Overview
+
+Use this skill to prepare a FreeFlow release from the local repository. FreeFlow releases are semver-tag driven: pushing a tag like `v0.3.1` triggers `.github/workflows/release.yml`, which stamps the app bundle, extracts the matching `CHANGELOG.md` section, builds/signs/notarizes the DMG, and creates the GitHub Release.
+
+## Ground Rules
+
+- Treat `CHANGELOG.md` as the release notes source of truth.
+- Keep changelog language user-facing. Avoid implementation details unless they affect maintainers or troubleshooting.
+- Do not edit `README.md` or unrelated docs unless the user explicitly asks.
+- Do not push tags or branches until the user has approved the exact release version and changelog.
+- Never use `git reset --hard` or destructive cleanup while preparing a release.
+- Preserve unrelated working tree changes. If unrelated changes exist, report them and avoid staging them.
+
+## Release Workflow
+
+1. Inspect current state:
+   ```bash
+   git status --short --branch
+   git log --oneline --decorate -n 20
+   ```
+
+2. Find the last version bump:
+   ```bash
+   git log --oneline --decorate -- Info.plist CHANGELOG.md .github/workflows/release.yml
+   git blame -L 11,14 Info.plist
+   ```
+   Use the last commit that changed `CFBundleShortVersionString`, `CFBundleVersion`, or the prior release section as the start of the changelog range.
+
+3. Determine the next version:
+   - `PATCH` for fixes, polish, release-system updates, and small user-visible improvements.
+   - `MINOR` for notable new user-facing capabilities.
+   - `MAJOR` only for breaking behavior or major compatibility changes.
+   Confirm the version with the user if it was not specified.
+
+4. Build the changelog from the commit range:
+   ```bash
+   git log --first-parent --reverse --oneline <last-version-commit>..HEAD
+   git log --reverse --oneline <last-version-commit>..HEAD
+   git diff --stat <last-version-commit>..HEAD
+   ```
+   Prefer first-parent merge commits for feature grouping, then inspect individual commits for details. Write a concise section:
+   ```md
+   ## [0.3.1] - YYYY-MM-DD
+
+   ### Added
+   - User-facing new capabilities.
+
+   ### Improved
+   - User-facing improvements and reliability work.
+
+   ### Fixed
+   - User-visible bugs and update/release fixes.
+   ```
+
+5. Validate locally before commit/tag:
+   ```bash
+   .github/scripts/changelog-section.sh <version>
+   ~/.codex/skills/freeflow-release/scripts/freeflow-release-check.sh <version>
+   git diff --check
+   make clean
+   make ARCH="$(uname -m)" CODESIGN_IDENTITY=-
+   ```
+
+6. Commit only release-prep files:
+   ```bash
+   git add CHANGELOG.md
+   git commit -m "Prepare v<version> release"
+   ```
+   Include other files only when they are deliberately part of the release prep.
+
+7. After user approval, tag and push:
+   ```bash
+   git tag v<version>
+   git push origin main
+   git push origin v<version>
+   ```
+
+8. After GitHub Actions finishes, verify:
+   - GitHub Release `v<version>` exists and is marked latest.
+   - `FreeFlow.dmg` is attached.
+   - Release body starts with the matching `CHANGELOG.md` section.
+   - A previous app version detects the update and shows What’s New.
+
+## Helper Script
+
+Run `scripts/freeflow-release-check.sh <version>` from the FreeFlow repo root to check release preconditions. It validates semver shape, required files, changelog extraction, workflow trigger basics, and tag availability.

--- a/.agents/skills/freeflow-release/agents/openai.yaml
+++ b/.agents/skills/freeflow-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "FreeFlow Release"
+  short_description: "Prepare and publish FreeFlow semver releases."
+  default_prompt: "Prepare a new FreeFlow release."

--- a/.agents/skills/freeflow-release/scripts/freeflow-release-check.sh
+++ b/.agents/skills/freeflow-release/scripts/freeflow-release-check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>" >&2
+  echo "Example: $0 0.3.1" >&2
+  exit 2
+fi
+
+version="$1"
+tag="v$version"
+
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+  echo "Invalid semantic version: $version" >&2
+  exit 1
+fi
+
+for path in CHANGELOG.md Info.plist .github/workflows/release.yml .github/scripts/changelog-section.sh; do
+  if [[ ! -f "$path" ]]; then
+    echo "Missing required release file: $path" >&2
+    exit 1
+  fi
+done
+
+if git rev-parse "$tag" >/dev/null 2>&1; then
+  echo "Tag already exists locally: $tag" >&2
+  exit 1
+fi
+
+if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+  echo "Tag already exists on origin: $tag" >&2
+  exit 1
+fi
+
+if ! grep -q 'tags:' .github/workflows/release.yml || ! grep -q 'v\*\.\*\.\*' .github/workflows/release.yml; then
+  echo "Release workflow does not appear to be semver tag-triggered." >&2
+  exit 1
+fi
+
+if ! .github/scripts/changelog-section.sh "$version" >/tmp/freeflow-release-notes.md; then
+  echo "Could not extract CHANGELOG.md section for $version" >&2
+  exit 1
+fi
+
+if [[ ! -s /tmp/freeflow-release-notes.md ]]; then
+  echo "Extracted changelog section is empty for $version" >&2
+  exit 1
+fi
+
+if ! grep -q "^## \\[$version\\]" /tmp/freeflow-release-notes.md; then
+  echo "Extracted changelog section has an unexpected heading." >&2
+  exit 1
+fi
+
+echo "Release checks passed for $tag"
+echo
+cat /tmp/freeflow-release-notes.md

--- a/.agents/skills/freeflow-release/scripts/freeflow-release-check.sh
+++ b/.agents/skills/freeflow-release/scripts/freeflow-release-check.sh
@@ -10,7 +10,7 @@ fi
 version="$1"
 tag="v$version"
 
-if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Invalid semantic version: $version" >&2
   exit 1
 fi
@@ -27,9 +27,19 @@ if git rev-parse "$tag" >/dev/null 2>&1; then
   exit 1
 fi
 
-if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+set +e
+git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1
+ls_remote_status=$?
+set -e
+
+if [[ $ls_remote_status -eq 0 ]]; then
   echo "Tag already exists on origin: $tag" >&2
   exit 1
+elif [[ $ls_remote_status -eq 2 ]]; then
+  :
+else
+  echo "git ls-remote failed while checking origin tag $tag" >&2
+  exit "$ls_remote_status"
 fi
 
 if ! grep -q 'tags:' .github/workflows/release.yml || ! grep -q 'v\*\.\*\.\*' .github/workflows/release.yml; then

--- a/.github/scripts/changelog-section.sh
+++ b/.github/scripts/changelog-section.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 2
+fi
+
+version="$1"
+changelog="CHANGELOG.md"
+
+if [[ ! -f "$changelog" ]]; then
+  echo "Missing $changelog" >&2
+  exit 1
+fi
+
+awk -v version="$version" '
+  BEGIN {
+    in_section = 0
+    found = 0
+  }
+
+  /^## / {
+    if (in_section) {
+      exit
+    }
+
+    if ($0 ~ "^## \\[?" version "\\]?([[:space:]-]|$)") {
+      in_section = 1
+      found = 1
+      print
+      next
+    }
+  }
+
+  in_section {
+    print
+  }
+
+  END {
+    if (!found) {
+      print "No changelog section found for version " version > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$changelog"

--- a/.github/scripts/changelog-section.sh
+++ b/.github/scripts/changelog-section.sh
@@ -25,7 +25,7 @@ awk -v version="$version" '
       exit
     }
 
-    if ($0 ~ "^## \\[?" version "\\]?([[:space:]-]|$)") {
+    if ($0 ~ "^## \\[" version "\\]([[:space:]-]|$)") {
       in_section = 1
       found = 1
       print

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: write
@@ -15,15 +16,39 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate version tag
+      - name: Resolve release version
         id: version
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          TAG="build-$(date -u +'%Y%m%d-%H%M%S')-${SHORT_SHA}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
 
-      - name: Embed build tag in Info.plist
-        run: plutil -insert FreeFlowBuildTag -string "${{ steps.version.outputs.tag }}" Info.plist
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Release tags must use semantic versioning, for example v0.3.1 or v1.0.0-beta.1." >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp app version
+        run: |
+          plutil -replace CFBundleShortVersionString -string "${{ steps.version.outputs.version }}" Info.plist
+          plutil -replace CFBundleVersion -string "${{ github.run_number }}" Info.plist
+          plutil -replace FreeFlowBuildTag -string "${{ steps.version.outputs.tag }}" Info.plist
+
+      - name: Build release notes from changelog
+        id: release_notes
+        run: |
+          .github/scripts/changelog-section.sh "${{ steps.version.outputs.version }}" > "$RUNNER_TEMP/release-notes.md"
+          {
+            echo "body<<EOF"
+            cat "$RUNNER_TEMP/release-notes.md"
+            echo
+            echo "## Download"
+            echo
+            echo "**[FreeFlow.dmg](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install build tools
         run: brew install create-dmg fileicon
@@ -112,12 +137,9 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ steps.version.outputs.tag }}
-          name: FreeFlow ${{ steps.version.outputs.tag }}
-          body: |
-            ## Download
-
-            **[FreeFlow.dmg](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg)** — Universal build for all Macs (Apple Silicon + Intel).
-          generate_release_notes: true
+          name: FreeFlow ${{ steps.version.outputs.version }}
+          body: ${{ steps.release_notes.outputs.body }}
+          generate_release_notes: false
           make_latest: true
           files: |
             FreeFlow.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
-            echo "Release tags must use semantic versioning, for example v0.3.1 or v1.0.0-beta.1." >&2
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must use semantic versioning, for example v0.3.1." >&2
             exit 1
           fi
 
@@ -46,7 +46,7 @@ jobs:
             echo
             echo "## Download"
             echo
-            echo "**[FreeFlow.dmg](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
+            echo "**[FreeFlow.dmg](https://github.com/zachlatta/freeflow/releases/download/${{ steps.version.outputs.tag }}/FreeFlow.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to FreeFlow are documented here.
+
+This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATCH`, where:
+
+- `MAJOR` changes include breaking behavior or major compatibility changes.
+- `MINOR` changes add user-visible features and improvements.
+- `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
+
+## [0.3.0] - 2026-04-23
+
+### Added
+
+- Dictation audio controls for muting or pausing audio while recording.
+- Run log transcript copy actions.
+- Export support for pipeline test cases.
+- Realtime transcription improvements.
+
+### Improved
+
+- More reliable transcription cancellation and realtime finalization.
+- Better run log ergonomics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,38 @@ This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATC
 - `MINOR` changes add user-visible features and improvements.
 - `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
 
-## [0.3.0] - 2026-04-23
+## [0.3.1] - 2026-04-23
 
 ### Added
 
-- Dictation audio controls for muting or pausing audio while recording.
-- Run log transcript copy actions.
-- Export support for pipeline test cases.
-- Realtime transcription improvements.
+- Faster live dictation with realtime transcription support.
+- A setting for choosing the realtime transcription model.
+- Run log exports, so you can save a full dictation run for debugging or sharing.
+- A Copy Transcript action in the run log.
+- A voice command for submitting text: say "press enter" at the end of a dictation.
+- Audio controls that can mute or pause other audio while you dictate, then restore it when recording stops.
+- Build details in Settings for easier troubleshooting.
+- Direct shortcuts from FreeFlow to the right macOS permission settings.
+- A What’s New popup when an update is available.
 
 ### Improved
 
-- More reliable transcription cancellation and realtime finalization.
-- Better run log ergonomics.
+- Recording feedback now feels more responsive.
+- The run log is easier to scan and use.
+- Exported run logs include more useful context for reproducing issues.
+- Realtime transcription is more reliable when recordings are cancelled, retried, or finish with no text.
+- Provider settings are easier to edit without accidental whitespace or half-saved values.
+- FreeFlow now warns you if alert sounds may be hard to hear because system audio is muted or very low.
+- Update prompts now show the version, release date, and release notes more clearly.
+- FreeFlow now uses proper version numbers for updates instead of internal build names.
+
+### Fixed
+
+- Fixed cases where arrow or navigation keys could be mistaken for Fn shortcut input.
+- Fixed a clipboard timing issue that could paste the wrong content.
+- Fixed empty realtime transcriptions getting stuck instead of finishing cleanly.
+- Fixed waveform glitches caused by invalid audio levels.
+- Filtered out more common transcription artifacts.
+- Fixed alert sound hints staying visible after alert sounds are turned off.
+- Fixed update checks so users only see real app releases, not internal builds.
+- Fixed update checks so the app does not offer an older or already-installed version.

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -535,6 +535,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingMicrophonePermissionTriggerMode: RecordingTriggerMode?
     private var pendingMicrophonePermissionSelectionSnapshot: AppSelectionSnapshot?
     private var pendingMicrophonePermissionManualCommandRequested: Bool?
+    private let postTranscriptionUpdateReminderDuration: TimeInterval = 7
 
     init() {
         UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
@@ -686,6 +687,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         overlayManager.onStopButtonPressed = { [weak self] in
             DispatchQueue.main.async {
                 self?.handleOverlayStopButtonPressed()
+            }
+        }
+        overlayManager.onUpdateOverlayPressed = { [weak self] in
+            DispatchQueue.main.async {
+                self?.handleUpdateOverlayPressed()
             }
         }
     }
@@ -2376,7 +2382,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         if trimmedFinalTranscript.isEmpty {
                             self.statusText = shouldPressEnterAfterPaste ? enterOnlyStatusText : "Nothing to transcribe"
                             self.clearPendingOverlayDismissToken()
-                            self.overlayManager.dismiss()
+                            if !self.showPostTranscriptionUpdateReminderIfNeeded() {
+                                self.overlayManager.dismiss()
+                            }
                             if shouldPressEnterAfterPaste {
                                 self.pressEnterWhenShortcutReleased()
                             }
@@ -2386,7 +2394,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                                 self.scheduleOverlayDismissAfterFailureIndicator(after: 2.5)
                             } else {
                                 self.clearPendingOverlayDismissToken()
-                                self.overlayManager.dismiss()
+                                if !self.showPostTranscriptionUpdateReminderIfNeeded() {
+                                    self.overlayManager.dismiss()
+                                }
                             }
 
                             let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
@@ -2733,6 +2743,39 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func clearPendingOverlayDismissToken() {
         pendingOverlayDismissToken = nil
+    }
+
+    @MainActor
+    private func showPostTranscriptionUpdateReminderIfNeeded() -> Bool {
+        let updateManager = UpdateManager.shared
+        guard updateManager.shouldShowPostTranscriptionReminder() else { return false }
+
+        let dismissToken = UUID()
+        pendingOverlayDismissToken = dismissToken
+        updateManager.markPostTranscriptionReminderShown()
+        overlayManager.showUpdateAvailable(version: updateManager.latestReleaseVersion)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + postTranscriptionUpdateReminderDuration) { [weak self] in
+            guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
+            self.pendingOverlayDismissToken = nil
+            self.overlayManager.dismiss()
+        }
+
+        return true
+    }
+
+    @MainActor
+    private func handleUpdateOverlayPressed() {
+        clearPendingOverlayDismissToken()
+        overlayManager.dismiss()
+        selectedSettingsTab = .general
+        NotificationCenter.default.post(name: .showSettings, object: nil)
+
+        DispatchQueue.main.async {
+            if UpdateManager.shared.updateAvailable {
+                UpdateManager.shared.showUpdateAlert()
+            }
+        }
     }
 
     private func scheduleOverlayDismissAfterFailureIndicator(after delay: TimeInterval) {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -279,7 +279,7 @@ struct MenuBarView: View {
                     Button {
                         updateManager.showUpdateAlert()
                     } label: {
-                        Label("Update Available", systemImage: "arrow.down.circle.fill")
+                        Label("Update available", systemImage: "arrow.down.circle.fill")
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(.white)

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -9,6 +9,7 @@ final class RecordingOverlayState: ObservableObject {
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
     @Published var isCommandMode = false
     @Published var showsTranscribingSpinner = false
+    @Published var updateVersion: String = ""
 }
 
 enum OverlayPhase {
@@ -16,6 +17,7 @@ enum OverlayPhase {
     case recording
     case transcribing
     case feedback
+    case updateAvailable
 }
 
 // MARK: - Panel Helpers
@@ -63,6 +65,7 @@ final class RecordingOverlayManager {
     private var lockedOverlayWidth: CGFloat?
 
     var onStopButtonPressed: (() -> Void)?
+    var onUpdateOverlayPressed: (() -> Void)?
 
     private var screenHasNotch: Bool {
         guard let screen = NSScreen.main else { return false }
@@ -82,7 +85,8 @@ final class RecordingOverlayManager {
     }
 
     private var overlayAcceptsMouseEvents: Bool {
-        overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle
+        (overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle)
+            || overlayState.phase == .updateAvailable
     }
 
     func showInitializing(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
@@ -151,6 +155,17 @@ final class RecordingOverlayManager {
         }
     }
 
+    func showUpdateAvailable(version: String) {
+        DispatchQueue.main.async {
+            self.lockedOverlayWidth = nil
+            self.overlayState.isCommandMode = false
+            self.overlayState.showsTranscribingSpinner = false
+            self.overlayState.updateVersion = version
+            self.overlayState.phase = .updateAvailable
+            self.showOverlayPanel(animatedResize: true)
+        }
+    }
+
     func dismiss() {
         DispatchQueue.main.async {
             self.dismissAll()
@@ -214,6 +229,9 @@ final class RecordingOverlayManager {
                 state: overlayState,
                 onStopButtonPressed: { [weak self] in
                     self?.onStopButtonPressed?()
+                },
+                onUpdateOverlayPressed: { [weak self] in
+                    self?.onUpdateOverlayPressed?()
                 }
             )
             .padding(.top, screenHasNotch ? notchOverlap : 0)
@@ -254,6 +272,12 @@ final class RecordingOverlayManager {
             return max(notchWidth, feedbackWidth)
         }
 
+        if overlayState.phase == .updateAvailable {
+            let updateWidth: CGFloat = 190
+            guard screenHasNotch else { return updateWidth }
+            return max(notchWidth, updateWidth)
+        }
+
         let commandModeWidth: CGFloat = 180
         let toggleWidth: CGFloat = 150
         let defaultWidth: CGFloat = 92
@@ -281,6 +305,7 @@ final class RecordingOverlayManager {
         lockedOverlayWidth = nil
         overlayState.isCommandMode = false
         overlayState.showsTranscribingSpinner = false
+        overlayState.updateVersion = ""
         if let panel = overlayWindow {
             panel.orderOut(nil)
             overlayWindow = nil
@@ -425,6 +450,7 @@ struct InitializingDotsView: View {
 struct RecordingOverlayView: View {
     @ObservedObject var state: RecordingOverlayState
     let onStopButtonPressed: () -> Void
+    let onUpdateOverlayPressed: () -> Void
 
     private let leadingAccessoryWidth: CGFloat = 24
     private let trailingAccessoryWidth: CGFloat = 32
@@ -441,6 +467,8 @@ struct RecordingOverlayView: View {
         Group {
             if state.phase == .feedback {
                 FailureIndicatorView()
+            } else if state.phase == .updateAvailable {
+                UpdateAvailableOverlayView(onPress: onUpdateOverlayPressed)
             } else {
                 ZStack {
                     Group {
@@ -516,5 +544,26 @@ struct FailureIndicatorView: View {
             .frame(width: 20, height: 20)
             .background(Circle().fill(Color.red.opacity(0.92)))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct UpdateAvailableOverlayView: View {
+    let onPress: () -> Void
+
+    var body: some View {
+        Button(action: onPress) {
+            HStack(spacing: 7) {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+
+                Text("Update Available")
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -789,9 +789,15 @@ struct GeneralSettingsView: View {
                         HStack(spacing: 8) {
                             Image(systemName: "arrow.down.circle.fill")
                                 .foregroundStyle(.blue)
-                            Text("A new version of FreeFlow is available!")
+                            Text(updateManager.latestReleaseVersion.isEmpty
+                                ? "A new version of FreeFlow is available!"
+                                : "FreeFlow v\(updateManager.latestReleaseVersion) is available!")
                                 .font(.caption.weight(.semibold))
                             Spacer()
+                            Button("What's New") {
+                                updateManager.showReleaseNotes()
+                            }
+                            .font(.caption)
                             Button("Update Now") {
                                 if let release = updateManager.latestRelease {
                                     updateManager.downloadAndInstall(release: release)

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -6,6 +6,7 @@ import AppKit
 struct GitHubRelease: Decodable {
     let tagName: String
     let name: String?
+    let body: String?
     let htmlUrl: String
     let publishedAt: String
     let assets: [GitHubReleaseAsset]
@@ -13,9 +14,73 @@ struct GitHubRelease: Decodable {
     enum CodingKeys: String, CodingKey {
         case tagName = "tag_name"
         case name
+        case body
         case htmlUrl = "html_url"
         case publishedAt = "published_at"
         case assets
+    }
+}
+
+struct SemanticVersion: Comparable, Equatable {
+    let major: Int
+    let minor: Int
+    let patch: Int
+    let prerelease: [String]
+
+    init?(_ value: String) {
+        var normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.hasPrefix("v") || normalized.hasPrefix("V") {
+            normalized.removeFirst()
+        }
+
+        let withoutBuildMetadata = normalized.split(separator: "+", maxSplits: 1).first.map(String.init) ?? normalized
+        let versionAndPrerelease = withoutBuildMetadata.split(separator: "-", maxSplits: 1).map(String.init)
+        let coreComponents = versionAndPrerelease[0].split(separator: ".").map(String.init)
+
+        guard coreComponents.count == 3,
+              let major = Int(coreComponents[0]),
+              let minor = Int(coreComponents[1]),
+              let patch = Int(coreComponents[2]) else {
+            return nil
+        }
+
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        prerelease = versionAndPrerelease.count > 1
+            ? versionAndPrerelease[1].split(separator: ".").map(String.init)
+            : []
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        if lhs.patch != rhs.patch { return lhs.patch < rhs.patch }
+
+        if lhs.prerelease.isEmpty && rhs.prerelease.isEmpty { return false }
+        if lhs.prerelease.isEmpty { return false }
+        if rhs.prerelease.isEmpty { return true }
+
+        for index in 0..<min(lhs.prerelease.count, rhs.prerelease.count) {
+            let left = lhs.prerelease[index]
+            let right = rhs.prerelease[index]
+            if left == right { continue }
+
+            let leftNumber = Int(left)
+            let rightNumber = Int(right)
+            switch (leftNumber, rightNumber) {
+            case let (leftNumber?, rightNumber?):
+                return leftNumber < rightNumber
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            case (nil, nil):
+                return left < right
+            }
+        }
+
+        return lhs.prerelease.count < rhs.prerelease.count
     }
 }
 
@@ -49,6 +114,7 @@ final class UpdateManager: ObservableObject {
 
     @Published var updateAvailable = false
     @Published var latestRelease: GitHubRelease?
+    @Published var latestReleaseVersion: String = ""
     @Published var latestReleaseDate: String = ""
     @Published var isChecking = false
     @Published var downloadProgress: Double?
@@ -116,6 +182,7 @@ final class UpdateManager: ObservableObject {
 
     func checkForUpdates(userInitiated: Bool) async {
         let currentBuildTag = Bundle.main.infoDictionary?["FreeFlowBuildTag"] as? String
+        let currentVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
 
         // Dev builds (no embedded tag): skip auto-checks, but allow manual checks
         if !userInitiated && currentBuildTag == nil {
@@ -142,6 +209,8 @@ final class UpdateManager: ObservableObject {
                 lastCheckDate = Date()
                 updateAvailable = false
                 latestRelease = nil
+                latestReleaseVersion = ""
+                latestReleaseDate = ""
                 if userInitiated { showUpToDateAlert() }
                 return
             }
@@ -154,6 +223,23 @@ final class UpdateManager: ObservableObject {
             let decoder = JSONDecoder()
             let release = try decoder.decode(GitHubRelease.self, from: data)
             lastCheckDate = Date()
+            let releaseVersionString = release.tagName.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(
+                of: "^v",
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
+            )
+
+            guard let latestVersion = SemanticVersion(release.tagName),
+                  let currentVersion = SemanticVersion(currentVersionString) else {
+                updateAvailable = false
+                latestRelease = nil
+                latestReleaseVersion = ""
+                latestReleaseDate = ""
+                if userInitiated {
+                    showErrorAlert("The latest release does not use a semantic version tag.")
+                }
+                return
+            }
 
             // Parse the published date
             let iso8601 = ISO8601DateFormatter()
@@ -173,10 +259,21 @@ final class UpdateManager: ObservableObject {
             dateFormatter.timeStyle = .none
             let releaseDateString = dateFormatter.string(from: publishedDate)
 
-            // If this is the same build we're running, no update available
+            // If this is the same or an older semantic version, no update is available.
             if let currentTag = currentBuildTag, release.tagName == currentTag {
                 updateAvailable = false
                 latestRelease = nil
+                latestReleaseVersion = ""
+                latestReleaseDate = ""
+                if userInitiated { showUpToDateAlert() }
+                return
+            }
+
+            if latestVersion <= currentVersion {
+                updateAvailable = false
+                latestRelease = nil
+                latestReleaseVersion = ""
+                latestReleaseDate = ""
                 if userInitiated { showUpToDateAlert() }
                 return
             }
@@ -187,10 +284,14 @@ final class UpdateManager: ObservableObject {
                 if !userInitiated {
                     // Auto-check: silently skip, too new
                     updateAvailable = false
+                    latestRelease = nil
+                    latestReleaseVersion = ""
+                    latestReleaseDate = ""
                     return
                 }
                 // Manual check: let user know and offer the update anyway
                 latestRelease = release
+                latestReleaseVersion = releaseVersionString
                 latestReleaseDate = releaseDateString
                 updateAvailable = true
                 showRecentReleaseAlert(daysSincePublished: daysSincePublished)
@@ -200,10 +301,14 @@ final class UpdateManager: ObservableObject {
             // Check if user skipped this version (only for auto checks)
             if !userInitiated && skippedVersion == release.tagName {
                 updateAvailable = false
+                latestRelease = nil
+                latestReleaseVersion = ""
+                latestReleaseDate = ""
                 return
             }
 
             latestRelease = release
+            latestReleaseVersion = releaseVersionString
             latestReleaseDate = releaseDateString
             updateAvailable = true
 
@@ -224,10 +329,12 @@ final class UpdateManager: ObservableObject {
 
         let alert = NSAlert()
         alert.messageText = "A New Version is Available"
-        alert.informativeText = "A new version of FreeFlow (released \(latestReleaseDate)) is available.\n\nWould you like to download the update?"
+        let versionText = latestReleaseVersion.isEmpty ? release.tagName : "v\(latestReleaseVersion)"
+        alert.informativeText = "FreeFlow \(versionText) was released \(latestReleaseDate).\n\nWould you like to download the update?"
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "Download Update")
+        alert.addButton(withTitle: "What's New")
         alert.addButton(withTitle: "Remind Me Later")
         alert.addButton(withTitle: "Skip This Version")
 
@@ -235,12 +342,19 @@ final class UpdateManager: ObservableObject {
         switch response {
         case .alertFirstButtonReturn:
             downloadAndInstall(release: release)
+        case .alertSecondButtonReturn:
+            showReleaseNotes(for: release)
+            showUpdateAlert()
         case .alertThirdButtonReturn:
+            break // Remind me later — do nothing
+        case NSApplication.ModalResponse(rawValue: NSApplication.ModalResponse.alertThirdButtonReturn.rawValue + 1):
             skippedVersion = release.tagName
             updateAvailable = false
             latestRelease = nil
+            latestReleaseVersion = ""
+            latestReleaseDate = ""
         default:
-            break // Remind me later — do nothing
+            break
         }
     }
 
@@ -252,15 +366,23 @@ final class UpdateManager: ObservableObject {
 
         let alert = NSAlert()
         alert.messageText = "New Release Available"
-        alert.informativeText = "A new version of FreeFlow was released \(ageText). It's very recent — you can download it now or wait a few days for stability.\n\nWould you like to download it?"
+        let versionText = latestReleaseVersion.isEmpty ? release.tagName : "v\(latestReleaseVersion)"
+        alert.informativeText = "FreeFlow \(versionText) was released \(ageText). It's very recent — you can download it now or wait a few days for stability.\n\nWould you like to download it?"
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "Download Now")
+        alert.addButton(withTitle: "What's New")
         alert.addButton(withTitle: "Wait")
 
         let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
+        switch response {
+        case .alertFirstButtonReturn:
             downloadAndInstall(release: release)
+        case .alertSecondButtonReturn:
+            showReleaseNotes(for: release)
+            showRecentReleaseAlert(daysSincePublished: daysSincePublished)
+        default:
+            break
         }
     }
 
@@ -272,6 +394,64 @@ final class UpdateManager: ObservableObject {
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "OK")
         alert.runModal()
+    }
+
+    func showReleaseNotes() {
+        guard let release = latestRelease else { return }
+        showReleaseNotes(for: release)
+    }
+
+    private func showReleaseNotes(for release: GitHubRelease) {
+        let alert = NSAlert()
+        let versionText = latestReleaseVersion.isEmpty ? release.tagName : "v\(latestReleaseVersion)"
+        alert.messageText = "What's New in FreeFlow \(versionText)"
+        alert.informativeText = "Release notes from GitHub."
+        alert.alertStyle = .informational
+        alert.icon = NSApp.applicationIconImage
+        alert.accessoryView = releaseNotesView(text: releaseNotesText(for: release))
+        alert.addButton(withTitle: "OK")
+
+        if let releaseURL = URL(string: release.htmlUrl) {
+            alert.addButton(withTitle: "Open on GitHub")
+            let response = alert.runModal()
+            if response == .alertSecondButtonReturn {
+                NSWorkspace.shared.open(releaseURL)
+            }
+        } else {
+            alert.runModal()
+        }
+    }
+
+    private func releaseNotesText(for release: GitHubRelease) -> String {
+        guard let body = release.body?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !body.isEmpty else {
+            return "No release notes were published for this version."
+        }
+
+        if let downloadRange = body.range(of: "\n## Download") {
+            return String(body[..<downloadRange.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return body
+    }
+
+    private func releaseNotesView(text: String) -> NSView {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 520, height: 280))
+        scrollView.hasVerticalScroller = true
+        scrollView.borderType = .bezelBorder
+
+        let textView = NSTextView(frame: scrollView.bounds)
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = true
+        textView.backgroundColor = .textBackgroundColor
+        textView.textColor = .textColor
+        textView.font = .systemFont(ofSize: NSFont.systemFontSize)
+        textView.textContainerInset = NSSize(width: 10, height: 10)
+        textView.string = text
+
+        scrollView.documentView = textView
+        return scrollView
     }
 
     private func showErrorAlert(_ message: String) {

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -34,7 +34,9 @@ struct SemanticVersion: Comparable, Equatable {
         }
 
         let withoutBuildMetadata = normalized.split(separator: "+", maxSplits: 1).first.map(String.init) ?? normalized
-        let versionAndPrerelease = withoutBuildMetadata.split(separator: "-", maxSplits: 1).map(String.init)
+        let versionAndPrerelease = withoutBuildMetadata
+            .split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+            .map(String.init)
         let coreComponents = versionAndPrerelease[0].split(separator: ".").map(String.init)
 
         guard coreComponents.count == 3,
@@ -44,12 +46,22 @@ struct SemanticVersion: Comparable, Equatable {
             return nil
         }
 
+        let parsedPrerelease: [String]
+        if versionAndPrerelease.count > 1 {
+            let prereleaseRaw = versionAndPrerelease[1]
+            guard !prereleaseRaw.isEmpty else { return nil }
+            parsedPrerelease = prereleaseRaw
+                .split(separator: ".", omittingEmptySubsequences: false)
+                .map(String.init)
+            guard parsedPrerelease.allSatisfy({ !$0.isEmpty }) else { return nil }
+        } else {
+            parsedPrerelease = []
+        }
+
         self.major = major
         self.minor = minor
         self.patch = patch
-        prerelease = versionAndPrerelease.count > 1
-            ? versionAndPrerelease[1].split(separator: ".").map(String.init)
-            : []
+        prerelease = parsedPrerelease
     }
 
     static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -108,6 +108,14 @@ struct GitHubReleaseAsset: Decodable {
     }
 }
 
+private struct SemanticRelease {
+    let release: GitHubRelease
+    let version: SemanticVersion
+    let versionString: String
+    let publishedDate: Date
+    let releaseDateString: String
+}
+
 // MARK: - Update Status
 
 enum UpdateStatus: Equatable {
@@ -159,7 +167,7 @@ final class UpdateManager: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: "updateLastPostTranscriptionReminderDate") }
     }
 
-    private let releasesURL = URL(string: "https://api.github.com/repos/zachlatta/freeflow/releases/latest")!
+    private let releasesURL = URL(string: "https://api.github.com/repos/zachlatta/freeflow/releases?per_page=100")!
     private let stabilityBufferDays: TimeInterval = 3
     private let checkIntervalSeconds: TimeInterval = 7 * 24 * 60 * 60 // 7 days
     private let postTranscriptionReminderInterval: TimeInterval = 24 * 60 * 60 // 1 day
@@ -244,78 +252,60 @@ final class UpdateManager: ObservableObject {
             }
 
             let decoder = JSONDecoder()
-            let release = try decoder.decode(GitHubRelease.self, from: data)
+            let releases = try decoder.decode([GitHubRelease].self, from: data)
             lastCheckDate = Date()
-            let releaseVersionString = release.tagName.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(
-                of: "^v",
-                with: "",
-                options: [.regularExpression, .caseInsensitive]
-            )
 
-            guard let latestVersion = SemanticVersion(release.tagName),
-                  let currentVersion = SemanticVersion(currentVersionString) else {
+            guard let currentVersion = SemanticVersion(currentVersionString) else {
+                updateAvailable = false
+                if userInitiated {
+                    showErrorAlert("The current app version does not use semantic versioning.")
+                }
+                return
+            }
+
+            let semanticReleases = releaseCandidates(from: releases)
+            guard let latestSemanticRelease = semanticReleases.last else {
                 updateAvailable = false
                 latestRelease = nil
                 latestReleaseVersion = ""
                 latestReleaseDate = ""
                 if userInitiated {
-                    showErrorAlert("The latest release does not use a semantic version tag.")
+                    showErrorAlert("No semantic version release was found.")
                 }
                 return
             }
 
-            // Parse the published date
-            let iso8601 = ISO8601DateFormatter()
-            iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            let iso8601Basic = ISO8601DateFormatter()
-            iso8601Basic.formatOptions = [.withInternetDateTime]
-
-            guard let publishedDate = iso8601.date(from: release.publishedAt)
-                    ?? iso8601Basic.date(from: release.publishedAt) else {
-                if userInitiated { showErrorAlert("Could not parse release date.") }
-                return
-            }
-
-            // Format the release date for display
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateStyle = .medium
-            dateFormatter.timeStyle = .none
-            let releaseDateString = dateFormatter.string(from: publishedDate)
+            let latestVersion = latestSemanticRelease.version
+            let release = latestSemanticRelease.release
+            let includedReleases = semanticReleases
+                .filter { currentVersion < $0.version && $0.version <= latestVersion }
+                .map(\.release)
+            latestRelease = releaseWithAggregatedNotes(latest: release, includedReleases: includedReleases)
+            latestReleaseVersion = latestSemanticRelease.versionString
+            latestReleaseDate = latestSemanticRelease.releaseDateString
 
             // If this is the same or an older semantic version, no update is available.
             if let currentTag = currentBuildTag, release.tagName == currentTag {
                 updateAvailable = false
-                latestRelease = nil
-                latestReleaseVersion = ""
-                latestReleaseDate = ""
                 if userInitiated { showUpToDateAlert() }
                 return
             }
 
             if latestVersion <= currentVersion {
                 updateAvailable = false
-                latestRelease = nil
-                latestReleaseVersion = ""
-                latestReleaseDate = ""
                 if userInitiated { showUpToDateAlert() }
                 return
             }
 
             // Check stability buffer (3 days since published)
-            let daysSincePublished = Date().timeIntervalSince(publishedDate) / (24 * 60 * 60)
+            let daysSincePublished = Date().timeIntervalSince(latestSemanticRelease.publishedDate) / (24 * 60 * 60)
             if daysSincePublished < stabilityBufferDays {
                 if !userInitiated {
                     // Auto-check: silently skip, too new
                     updateAvailable = false
-                    latestRelease = nil
-                    latestReleaseVersion = ""
-                    latestReleaseDate = ""
                     return
                 }
                 // Manual check: let user know and offer the update anyway
-                latestRelease = release
-                latestReleaseVersion = releaseVersionString
-                latestReleaseDate = releaseDateString
                 updateAvailable = true
                 showRecentReleaseAlert(daysSincePublished: daysSincePublished)
                 return
@@ -324,15 +314,9 @@ final class UpdateManager: ObservableObject {
             // Check if user skipped this version (only for auto checks)
             if !userInitiated && skippedVersion == release.tagName {
                 updateAvailable = false
-                latestRelease = nil
-                latestReleaseVersion = ""
-                latestReleaseDate = ""
                 return
             }
 
-            latestRelease = release
-            latestReleaseVersion = releaseVersionString
-            latestReleaseDate = releaseDateString
             updateAvailable = true
 
             if userInitiated {
@@ -343,6 +327,71 @@ final class UpdateManager: ObservableObject {
                 showErrorAlert("Failed to check for updates: \(error.localizedDescription)")
             }
         }
+    }
+
+    private func releaseCandidates(from releases: [GitHubRelease]) -> [SemanticRelease] {
+        releases.compactMap { release in
+            guard let version = SemanticVersion(release.tagName),
+                  let publishedDate = releasePublishedDate(from: release.publishedAt) else {
+                return nil
+            }
+
+            return SemanticRelease(
+                release: release,
+                version: version,
+                versionString: normalizedVersionString(from: release.tagName),
+                publishedDate: publishedDate,
+                releaseDateString: displayDateString(from: publishedDate)
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.version == rhs.version {
+                return lhs.publishedDate < rhs.publishedDate
+            }
+            return lhs.version < rhs.version
+        }
+    }
+
+    private func releaseWithAggregatedNotes(latest: GitHubRelease, includedReleases: [GitHubRelease]) -> GitHubRelease {
+        GitHubRelease(
+            tagName: latest.tagName,
+            name: latest.name,
+            body: aggregatedReleaseNotes(from: includedReleases) ?? latest.body,
+            htmlUrl: latest.htmlUrl,
+            publishedAt: latest.publishedAt,
+            assets: latest.assets
+        )
+    }
+
+    private func aggregatedReleaseNotes(from releases: [GitHubRelease]) -> String? {
+        let notes = releases.compactMap { releaseNotesBody(from: $0.body) }
+        guard !notes.isEmpty else { return nil }
+        return notes.joined(separator: "\n\n")
+    }
+
+    private func releasePublishedDate(from value: String) -> Date? {
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let iso8601Basic = ISO8601DateFormatter()
+        iso8601Basic.formatOptions = [.withInternetDateTime]
+
+        return iso8601.date(from: value) ?? iso8601Basic.date(from: value)
+    }
+
+    private func displayDateString(from date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .none
+        return dateFormatter.string(from: date)
+    }
+
+    private func normalizedVersionString(from tagName: String) -> String {
+        tagName.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(
+            of: "^v",
+            with: "",
+            options: [.regularExpression, .caseInsensitive]
+        )
     }
 
     func shouldShowPostTranscriptionReminder() -> Bool {
@@ -436,7 +485,8 @@ final class UpdateManager: ObservableObject {
             showReleaseNotes(for: release)
             showRecentReleaseAlert(daysSincePublished: daysSincePublished)
         default:
-            break
+            suppressPostTranscriptionReminder(for: release.tagName)
+            updateAvailable = false
         }
     }
 
@@ -477,13 +527,22 @@ final class UpdateManager: ObservableObject {
     }
 
     private func releaseNotesText(for release: GitHubRelease) -> String {
-        guard let body = release.body?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !body.isEmpty else {
+        guard let body = releaseNotesBody(from: release.body) else {
             return "No release notes were published for this version."
         }
 
+        return body
+    }
+
+    private func releaseNotesBody(from body: String?) -> String? {
+        guard let body = body?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !body.isEmpty else {
+            return nil
+        }
+
         if let downloadRange = body.range(of: "\n## Download") {
-            return String(body[..<downloadRange.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let notes = String(body[..<downloadRange.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+            return notes.isEmpty ? nil : notes
         }
 
         return body

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -137,9 +137,20 @@ final class UpdateManager: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: "updateSkippedVersion") }
     }
 
+    private var lastPostTranscriptionReminderVersion: String? {
+        get { UserDefaults.standard.string(forKey: "updateLastPostTranscriptionReminderVersion") }
+        set { UserDefaults.standard.set(newValue, forKey: "updateLastPostTranscriptionReminderVersion") }
+    }
+
+    private var lastPostTranscriptionReminderDate: Date? {
+        get { UserDefaults.standard.object(forKey: "updateLastPostTranscriptionReminderDate") as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: "updateLastPostTranscriptionReminderDate") }
+    }
+
     private let releasesURL = URL(string: "https://api.github.com/repos/zachlatta/freeflow/releases/latest")!
     private let stabilityBufferDays: TimeInterval = 3
     private let checkIntervalSeconds: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+    private let postTranscriptionReminderInterval: TimeInterval = 24 * 60 * 60 // 1 day
     private var periodicTimer: Timer?
     private var activeDownloadTask: Task<Void, Never>?
 
@@ -322,6 +333,40 @@ final class UpdateManager: ObservableObject {
         }
     }
 
+    func shouldShowPostTranscriptionReminder() -> Bool {
+        guard updateAvailable,
+              let release = latestRelease,
+              updateStatus == .idle,
+              skippedVersion != release.tagName else {
+            return false
+        }
+
+        guard lastPostTranscriptionReminderVersion == release.tagName,
+              let lastReminder = lastPostTranscriptionReminderDate else {
+            return true
+        }
+
+        return Date().timeIntervalSince(lastReminder) > postTranscriptionReminderInterval
+    }
+
+    func markPostTranscriptionReminderShown() {
+        guard let release = latestRelease else { return }
+        lastPostTranscriptionReminderVersion = release.tagName
+        lastPostTranscriptionReminderDate = Date()
+    }
+
+    private func suppressPostTranscriptionReminder(for tagName: String) {
+        lastPostTranscriptionReminderVersion = tagName
+        lastPostTranscriptionReminderDate = Date()
+    }
+
+    private func clearAvailableUpdate() {
+        updateAvailable = false
+        latestRelease = nil
+        latestReleaseVersion = ""
+        latestReleaseDate = ""
+    }
+
     // MARK: - Alerts
 
     func showUpdateAlert() {
@@ -346,13 +391,10 @@ final class UpdateManager: ObservableObject {
             showReleaseNotes(for: release)
             showUpdateAlert()
         case .alertThirdButtonReturn:
-            break // Remind me later — do nothing
+            suppressPostTranscriptionReminder(for: release.tagName)
         case NSApplication.ModalResponse(rawValue: NSApplication.ModalResponse.alertThirdButtonReturn.rawValue + 1):
             skippedVersion = release.tagName
-            updateAvailable = false
-            latestRelease = nil
-            latestReleaseVersion = ""
-            latestReleaseDate = ""
+            clearAvailableUpdate()
         default:
             break
         }


### PR DESCRIPTION
## Summary
- Switched release publishing from branch-based builds to semver tag triggers and stamped app versions from the release tag.
- Added changelog extraction tooling so GitHub Releases use the matching `CHANGELOG.md` section plus download links.
- Improved update handling to compare semantic versions, expose release notes in the app, and surface a newer `Whats New` flow in Settings and update alerts.
- Added a release-preflight check script and documented the release process for FreeFlow releases.

## Testing
- Not run (release workflow and app update-path changes were not exercised locally).
- Verified the changelog section extraction logic is wired into `.github/workflows/release.yml`.
- Verified the update manager now parses semantic versions and falls back cleanly when a release tag is not semver-shaped.
- Verified Settings now show the detected latest release version and provide a `Whats New` action.

Closes #124 #123 #122 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “What’s New” buttons in Settings and update alerts to view release notes in-app.
  * New in-app “Update Available” overlay in the recording UI with a tappable action that opens updates/settings.
  * Post‑transcription reminder that surfaces available updates after recordings.
  * Update alerts can show trimmed release notes and link to the release on GitHub.

* **Bug Fixes / UX**
  * Update banner and alerts now display the latest release version.

* **Documentation**
  * Added a public CHANGELOG documenting the 0.3.1 release and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->