### PR TITLE
Remove pause-based dictation audio interruption

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -120,20 +120,6 @@ private enum CommandInvocation: String {
     case manual
 }
 
-enum DictationAudioInterruptionMode: String, CaseIterable, Identifiable {
-    case mute
-    case pause
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .mute: return "Mute"
-        case .pause: return "Pause"
-        }
-    }
-}
-
 private enum SessionIntent {
     case dictation
     case command(invocation: CommandInvocation, selectedText: String)
@@ -193,7 +179,6 @@ private enum SessionIntent {
 final class AppState: ObservableObject, @unchecked Sendable {
     private enum ActiveAudioInterruption {
         case muted(previouslyMuted: Bool)
-        case paused
     }
 
     private let apiKeyStorageKey = "groq_api_key"
@@ -227,7 +212,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
-    private let dictationAudioInterruptionModeStorageKey = "dictation_audio_interruption_mode"
     private let transcribingIndicatorDelay: TimeInterval = 0.25
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -422,15 +406,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    @Published var dictationAudioInterruptionMode: DictationAudioInterruptionMode {
-        didSet {
-            UserDefaults.standard.set(
-                dictationAudioInterruptionMode.rawValue,
-                forKey: dictationAudioInterruptionModeStorageKey
-            )
-        }
-    }
-
     @Published var preserveClipboard: Bool {
         didSet {
             UserDefaults.standard.set(preserveClipboard, forKey: preserveClipboardStorageKey)
@@ -587,9 +562,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
-        let dictationAudioInterruptionMode = DictationAudioInterruptionMode(
-            rawValue: UserDefaults.standard.string(forKey: dictationAudioInterruptionModeStorageKey) ?? ""
-        ) ?? .mute
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -656,7 +628,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
-        self.dictationAudioInterruptionMode = dictationAudioInterruptionMode
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
@@ -1828,18 +1799,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func applyAudioInterruptionIfNeeded() {
         guard dictationAudioInterruptionEnabled, activeAudioInterruption == nil else { return }
 
-        switch dictationAudioInterruptionMode {
-        case .mute:
-            let wasMuted = SystemAudioStatus.isDefaultOutputMuted()
-            if wasMuted {
-                activeAudioInterruption = .muted(previouslyMuted: true)
-            } else if SystemAudioStatus.setDefaultOutputMuted(true) {
-                activeAudioInterruption = .muted(previouslyMuted: false)
-            }
-        case .pause:
-            guard SystemAudioStatus.isDefaultOutputRunningSomewhere() else { return }
-            SystemAudioStatus.sendMediaPlayPauseKey()
-            activeAudioInterruption = .paused
+        let wasMuted = SystemAudioStatus.isDefaultOutputMuted()
+        if wasMuted {
+            activeAudioInterruption = .muted(previouslyMuted: true)
+        } else if SystemAudioStatus.setDefaultOutputMuted(true) {
+            activeAudioInterruption = .muted(previouslyMuted: false)
         }
     }
 
@@ -1852,8 +1816,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             if !previouslyMuted {
                 _ = SystemAudioStatus.setDefaultOutputMuted(false)
             }
-        case .paused:
-            SystemAudioStatus.sendMediaPlayPauseKey()
         }
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -983,18 +983,9 @@ struct GeneralSettingsView: View {
     private var dictationAudioSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             Toggle(
-                "Mute or pause audio when dictation starts",
+                "Mute audio when dictation starts",
                 isOn: $appState.dictationAudioInterruptionEnabled
             )
-
-            Picker("Audio Action", selection: $appState.dictationAudioInterruptionMode) {
-                ForEach(DictationAudioInterruptionMode.allCases) { mode in
-                    Text(mode.title).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .disabled(!appState.dictationAudioInterruptionEnabled)
-            .opacity(appState.dictationAudioInterruptionEnabled ? 1 : 0.5)
 
             Text("FreeFlow restores the audio state it changed when dictation ends.")
                 .font(.caption)

--- a/Sources/SystemAudioStatus.swift
+++ b/Sources/SystemAudioStatus.swift
@@ -1,11 +1,6 @@
-import AppKit
 import CoreAudio
 
 enum SystemAudioStatus {
-    private static let nxKeyTypePlay = 16
-    private static let mediaKeyDown = 0xA
-    private static let mediaKeyUp = 0xB
-
     static func isDefaultOutputMuted() -> Bool {
         guard let deviceID = defaultOutputDeviceID() else { return false }
 
@@ -70,54 +65,6 @@ enum SystemAudioStatus {
             }
         }
         return maxChannelVolume
-    }
-
-    static func isDefaultOutputRunningSomewhere() -> Bool {
-        guard let deviceID = defaultOutputDeviceID() else { return false }
-
-        var isRunning: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        guard AudioObjectHasProperty(deviceID, &address) else { return false }
-
-        let status = AudioObjectGetPropertyData(
-            deviceID,
-            &address,
-            0,
-            nil,
-            &size,
-            &isRunning
-        )
-
-        guard status == noErr else { return false }
-        return isRunning != 0
-    }
-
-    static func sendMediaPlayPauseKey() {
-        postMediaPlayPauseKey(state: mediaKeyDown)
-        postMediaPlayPauseKey(state: mediaKeyUp)
-    }
-
-    private static func postMediaPlayPauseKey(state: Int) {
-        let data1 = (nxKeyTypePlay << 16) | (state << 8)
-        guard let event = NSEvent.otherEvent(
-            with: .systemDefined,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            subtype: 8,
-            data1: data1,
-            data2: -1
-        ) else { return }
-
-        event.cgEvent?.post(tap: .cghidEventTap)
     }
 
     private static func readVolume(deviceID: AudioDeviceID, element: AudioObjectPropertyElement) -> Float? {


### PR DESCRIPTION
## Summary
- Removed the dictation audio interruption mode UI and logic, leaving mute as the only behavior.
- Simplified `AppState` to persist and restore only the mute-based interruption state.
- Deleted the unused system media play/pause audio interruption helpers from `SystemAudioStatus`.

## Why
- Detecting whether the user is currently playing audio is non-trivial
- There are often misfires when the media has been paused recently, and dictation "flips" the state, so it starts playing during dictation and pauses again at the end.

## Testing
- Not run.
- Reviewed the diff to confirm all pause-mode references were removed from state, settings UI, and audio helpers.
- Confirmed the remaining interruption flow still mutes and restores default output audio state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified audio handling during dictation: removed pause mode option, audio now only mutes when dictation begins.
  * Streamlined settings interface with a single toggle for muting audio during dictation, replacing the previous mode selection picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->