### PR TITLE
Expose recording state via flag file for external integrations

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -899,18 +899,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return appSupport.appendingPathComponent("\(appName)/is-recording")
     }
 
+    /// Serial queue that owns every flag-file I/O so the recording
+    /// start/stop hot path never blocks on disk.
+    private static let recordingStateFlagQueue = DispatchQueue(
+        label: "com.zachlatta.freeflow.recording-state-flag"
+    )
+
     /// Write or clear the `is-recording` flag file. Called from the
-    /// `isRecording` didSet. Failures are swallowed — this is advisory IPC
-    /// and must never interrupt the recording pipeline.
+    /// `isRecording` didSet. Dispatches to a background queue so disk
+    /// I/O never adds latency to recording start/stop. Failures are
+    /// swallowed — this is advisory IPC and must never interrupt the
+    /// recording pipeline.
     static func writeRecordingStateFlag(_ recording: Bool) {
-        let url = recordingStateFlagURL()
-        if recording {
-            let dir = url.deletingLastPathComponent()
-            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            let timestamp = String(Date().timeIntervalSince1970)
-            try? timestamp.write(to: url, atomically: true, encoding: .utf8)
-        } else {
-            try? FileManager.default.removeItem(at: url)
+        let timestamp = recording ? String(Date().timeIntervalSince1970) : nil
+        recordingStateFlagQueue.async {
+            let url = recordingStateFlagURL()
+            if let timestamp {
+                let dir = url.deletingLastPathComponent()
+                try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+                try? timestamp.write(to: url, atomically: true, encoding: .utf8)
+            } else {
+                try? FileManager.default.removeItem(at: url)
+            }
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -441,7 +441,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    @Published var isRecording = false
+    @Published var isRecording = false {
+        didSet {
+            guard oldValue != isRecording else { return }
+            AppState.writeRecordingStateFlag(isRecording)
+        }
+    }
     @Published var isTranscribing = false
     @Published var retryingItemIDs: Set<UUID> = []
     @Published var lastTranscript: String = ""
@@ -665,10 +670,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self?.handleUpdateOverlayPressed()
             }
         }
+
+        // Clear any stale recording flag left over from an unclean exit.
+        AppState.writeRecordingStateFlag(false)
     }
 
     deinit {
         removeAudioDeviceObservers()
+        AppState.writeRecordingStateFlag(false)
     }
 
     private func removeAudioDeviceObservers() {
@@ -872,6 +881,37 @@ final class AppState: ObservableObject, @unchecked Sendable {
             try? FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
         }
         return audioDir
+    }
+
+    /// URL of the flag file written while FreeFlow is actively recording.
+    ///
+    /// External tools (voice assistants, TTS barge-in pipelines, conversation
+    /// apps) can poll this file to know when the user is dictating. The file
+    /// exists while `isRecording` is true and is removed when it flips false.
+    /// Contents are the UNIX timestamp (seconds, float) of when recording
+    /// started — useful for stale-flag detection after an unclean exit.
+    ///
+    /// Path: `~/Library/Application Support/FreeFlow/is-recording`
+    /// (or `FreeFlow Dev/is-recording` when running the dev bundle).
+    static func recordingStateFlagURL() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+        return appSupport.appendingPathComponent("\(appName)/is-recording")
+    }
+
+    /// Write or clear the `is-recording` flag file. Called from the
+    /// `isRecording` didSet. Failures are swallowed — this is advisory IPC
+    /// and must never interrupt the recording pipeline.
+    static func writeRecordingStateFlag(_ recording: Bool) {
+        let url = recordingStateFlagURL()
+        if recording {
+            let dir = url.deletingLastPathComponent()
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let timestamp = String(Date().timeIntervalSince1970)
+            try? timestamp.write(to: url, atomically: true, encoding: .utf8)
+        } else {
+            try? FileManager.default.removeItem(at: url)
+        }
     }
 
     static func saveAudioFile(from tempURL: URL) -> SavedAudioFile? {


### PR DESCRIPTION
Adds an advisory IPC flag file that external tools can poll to know when FreeFlow is recording. Solves a common integration pain point for voice assistants and TTS pipelines that need to stop speaking the moment the user starts dictating.

## The problem

Dictation hotkeys are captured at the `CGEventTap` layer, below what external processes can see via `CGEventSourceFlagsState`. Workarounds — mic-active polling, system-mute detection, keyboard event polling — all have false-positive problems (Zoom, speaker-to-mic echo, background listening, etc.).

## The fix

Write `~/Library/Application Support/FreeFlow/is-recording` when `isRecording` becomes true, remove it when false. Dev builds route naturally to `FreeFlow Dev/is-recording` via `CFBundleName`. Contents are the UNIX timestamp of recording start (for stale-flag detection after unclean exit). Startup init + deinit both clear any stale flag. All I/O is `try?` — never interrupts the recording pipeline.

## Example consumer (Python)

```
import os, time
FLAG = os.path.expanduser("~/Library/Application Support/FreeFlow/is-recording")
while True:
    if os.path.exists(FLAG):
        # user is dictating — cut off any active TTS
        kill_my_audio()
    time.sleep(0.05)
```

## Testing

Built locally, dictated multiple sessions, confirmed flag transitions fire on exact boundaries with sub-50ms latency. Wired into a downstream speech-server daemon — replaced a 1.5-second debounced mic-polling path with instant barge-in. TTS audio cuts mid-word the instant dictation starts.

Happy to iterate on the interface. Started with the simplest thing that works — if you prefer `NSDistributedNotification`, a JSON state file, or something else, let me know.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable persistence of the recording state so the app better reflects active recording after restarts or crashes.
  * Added startup and shutdown cleanup to prevent stale “recording” status from remaining after unclean exits.
  * Recording-state writes are now performed safely and tolerate filesystem errors to avoid impacting app stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->