### PR TITLE
Use CFBundleName in window titles and welcome screen

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -82,7 +82,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             backing: .buffered,
             defer: false
         )
-        window.title = "FreeFlow"
+        window.title = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
         window.contentView = hostingView
         window.isReleasedWhenClosed = false
         window.center()
@@ -118,7 +118,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             backing: .buffered,
             defer: false
         )
-        window.title = "FreeFlow"
+        window.title = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.contentView = NSHostingView(rootView: setupView)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -498,7 +498,7 @@ struct GeneralSettingsView: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 64, height: 64)
 
-                    Text("FreeFlow")
+                    Text(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow")
                         .font(.system(size: 20, weight: .bold, design: .rounded))
 
                     Text("v\(appVersion)")

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -263,7 +263,7 @@ struct SetupView: View {
                 .frame(width: 128, height: 128)
 
             VStack(spacing: 6) {
-                Text("Welcome to FreeFlow")
+                Text("Welcome to \(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow")")
                     .font(.system(size: 30, weight: .bold, design: .rounded))
 
                 Text("Dictate text anywhere on your Mac.\nHold to talk or tap to toggle dictation.")


### PR DESCRIPTION
Three spots in the UI hardcode the string `"FreeFlow"`. The Makefile already sets `CFBundleName` to `"FreeFlow Dev"` when `make` is run without overrides, but the hardcoded strings do not reflect that — which makes dev builds indistinguishable from prod in the window title and setup wizard.

## The fix

Replace each hardcoded `"FreeFlow"` with the bundle's `CFBundleName`, falling back to `"FreeFlow"`. Prod builds are unchanged (`CFBundleName` resolves to `"FreeFlow"` there); dev builds now correctly show `"FreeFlow Dev"` throughout the UI.

## Scope

Three one-line changes across three files. No behavior change for production users — this only affects what dev-built bundles render in their own UI.

- `Sources/AppDelegate.swift` line 85 and 121 — settings and setup window titles
- `Sources/SettingsView.swift` line 501 — about/version card in General settings
- `Sources/SetupView.swift` line 266 — welcome screen heading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app display name references in window titles and headers to use the app's configured name dynamically instead of hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->