### PR TITLE
Fix paste failing on Colemak-DH and other non-QWERTY layouts

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5,6 +5,7 @@ import AVFoundation
 import ServiceManagement
 import ApplicationServices
 import ScreenCaptureKit
+import Carbon
 import os.log
 private let recordingLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Recording")
 
@@ -2820,14 +2821,43 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func pasteAtCursor() {
         let source = CGEventSource(stateID: .hidSystemState)
+        let vKeyCode = keyCodeForCharacter("v") ?? 9
 
-        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: true)
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
         keyDown?.flags = .maskCommand
         keyDown?.post(tap: .cgSessionEventTap)
 
-        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: false)
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
         keyUp?.flags = .maskCommand
         keyUp?.post(tap: .cgSessionEventTap)
+    }
+
+    private func keyCodeForCharacter(_ character: String) -> CGKeyCode? {
+        guard let char = character.lowercased().utf16.first else { return nil }
+        let source = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
+        guard let layoutDataRef = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+        let layoutData = unsafeBitCast(layoutDataRef, to: CFData.self) as Data
+        return layoutData.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> CGKeyCode? in
+            guard let layout = ptr.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else {
+                return nil
+            }
+            for keyCode in UInt16(0)..<UInt16(128) {
+                var chars = [UniChar](repeating: 0, count: 4)
+                var charCount = 0
+                var deadKeyState: UInt32 = 0
+                let status = UCKeyTranslate(
+                    layout, keyCode, UInt16(kUCKeyActionDisplay), 0,
+                    UInt32(LMGetKbdType()), OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                    &deadKeyState, 4, &charCount, &chars
+                )
+                if status == noErr, charCount > 0, chars[0] == char {
+                    return CGKeyCode(keyCode)
+                }
+            }
+            return nil
+        }
     }
 
     private func pressEnter() {


### PR DESCRIPTION
## Summary

- `pasteAtCursor()` hardcoded `virtualKey: 9` (the physical 'V' key on QWERTY). On layouts that relocate V — notably Colemak-DH — that physical key produces a different character, so `Cmd+keycode-9` is not interpreted as `Cmd+V` by the OS and the transcribed text never pastes.
- Fix by dynamically looking up the physical key that produces `'v'` in the current keyboard input source via `TISCopyCurrentKeyboardInputSource` + `UCKeyTranslate`, with a fallback to keycode 9 if the lookup fails.
- Standard Colemak keeps V at the QWERTY position so it was unaffected; this primarily fixes Colemak-DH users (and any other layout that moves V).

## Test plan

- [x] Builds cleanly (`make CODESIGN_IDENTITY=- run`)
- [x] Verified transcribed text pastes correctly on Colemak in multiple apps (Terminal, browser text fields, Notes)
- [ ] (Recommended) Verify on standard QWERTY — should be unchanged since the lookup returns keycode 9 there as well
- [ ] (Recommended) Verify on another non-QWERTY layout (Dvorak, Colemak-DH) if a reviewer has one available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved paste functionality to dynamically detect and use the correct keyboard key codes based on your current keyboard layout, ensuring paste operations work reliably with non-QWERTY and other custom keyboard configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->