### PR TITLE
Show a circular spinner while transcription is processing

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -214,7 +214,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
-    private let transcribingIndicatorDelay: TimeInterval = 0.25
+    private let transcribingIndicatorDelay: TimeInterval = 1.0
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
     private let clipboardRestoreDelay: TimeInterval = 1.0

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -393,29 +393,21 @@ struct WaveformView: View {
 }
 
 struct ProcessingWaveformView: View {
-    private static let barCount = 9
-    private static let multipliers: [CGFloat] = [0.42, 0.58, 0.76, 0.9, 1.0, 0.9, 0.76, 0.58, 0.42]
+    @State private var rotation: Double = 0
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
-            let time = context.date.timeIntervalSinceReferenceDate
-
-            HStack(spacing: 2.5) {
-                ForEach(0..<Self.barCount, id: \.self) { index in
-                    let wave = 0.5 + 0.5 * sin((time * 5.6) - Double(index) * 0.5)
-                    let shimmer = 0.5 + 0.5 * sin((time * 2.8) + Double(index) * 0.75)
-                    let amplitude = min(
-                        0.16 + CGFloat(wave) * Self.multipliers[index] * 0.52 + CGFloat(shimmer) * 0.08,
-                        1.0
-                    )
-
-                    WaveformBar(amplitude: amplitude)
-                        .opacity(0.45 + CGFloat(wave) * 0.5)
+        Circle()
+            .trim(from: 0.1, to: 0.9)
+            .stroke(Color.white, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+            .frame(width: 16, height: 16)
+            .rotationEffect(.degrees(rotation))
+            .frame(height: 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onAppear {
+                withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
+                    rotation = 360
                 }
             }
-            .frame(height: 20)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 


### PR DESCRIPTION
## Summary

The post-release "transcribing" state currently uses a synthetic `ProcessingWaveformView` that animates bars almost identically to the live listening `WaveformView`, so visually there is no signal that FreeFlow has stopped capturing audio and is now waiting on the model. This PR replaces it with a small white circular rotating arc — a clear "processing" affordance — so the transition from listening to waiting reads at a glance.

<img width="480" alt="Circular spinner rendering in the menu bar overlay during transcription processing" src="https://assets.themarketingshow.com/bugs/freeflow/spinner-in-action-2026-04-24.png">

*The new spinner during the post-release transcription wait — visible against the dark notch overlay, clearly distinct from the listening waveform.*

## The problem

When the user releases the shortcut after a long recording, the existing `ProcessingWaveformView` keeps animated bars moving in roughly the same shape as the audio-driven `WaveformView`. On screen, the user can't tell whether the mic is still open or whether transcription is underway. On long transcriptions where the wait is meaningful (multi-second), this is the moment a clear "we're working on it" affordance matters most.

## The fix

The state machine for this is already in place — `OverlayPhase.transcribing` plus the `showsTranscribingSpinner` flag plus the `transcribingIndicatorDelay`-gated swap from `WaveformView` to `ProcessingWaveformView` already do the right routing. The only thing missing is that the destination view doesn't visually read as "processing." So this PR keeps the routing and only changes what `ProcessingWaveformView` renders:

```swift
struct ProcessingWaveformView: View {
    @State private var rotation: Double = 0

    var body: some View {
        Circle()
            .trim(from: 0.1, to: 0.9)
            .stroke(Color.white, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
            .frame(width: 16, height: 16)
            .rotationEffect(.degrees(rotation))
            .frame(height: 20)
            .frame(maxWidth: .infinity, maxHeight: .infinity)
            .onAppear {
                withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
                    rotation = 360
                }
            }
    }
}
```

A trimmed circle stroke with a continuous linear rotation. White on the existing dark notch background. Same parent `.frame(height: 20)` and `.frame(maxWidth: .infinity, maxHeight: .infinity)` so layout stays identical to the previous view.

## Why not `ProgressView(.circular)`?

That was the first thing I tried. On the overlay's translucent material in this context, SwiftUI's native `ProgressView()` with `.circular` style and `.tint(.white)` does not render visibly — the view layout fires (verified by swapping in a solid-color background, the area paints), but the spinner itself isn't drawn. Falling back to a hand-built trimmed-`Circle` stroke renders consistently. Happy to revisit if there's a known way to get the native control to draw on the notch panel.

## Bump `transcribingIndicatorDelay` from 0.25s to 1.0s

The existing 0.25s delay before swapping from frozen waveform to processing indicator is short enough that fast transcriptions briefly flash the indicator before completing, which feels like a glitch. Raising it to 1.0s keeps the indicator out of the way for the genuinely fast transcriptions (where it adds noise) and only surfaces it for the slow ones (where it adds clarity). Open to a different value if maintainers prefer.

## Test plan

- [x] Build cleanly with `make` on macOS 13+ arm64
- [x] Short dictation (~1s of speech): waveform freezes briefly at last level, no spinner appears, text inserts. Same as before.
- [x] Long dictation (multi-sentence paragraph): after release, waveform freezes for ~1s, then swaps to the rotating arc spinner, then text inserts when transcription completes.
- [x] Spinner renders visibly on the dark notch background and the rotation animation runs smoothly.
- [ ] If maintainers have a stronger preference on spinner style (native control, alternate animation), happy to iterate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Adjusted timing: Transcribing indicator now displays after 1.0 second instead of 0.25 seconds.
* Updated visual indicator: Transcription progress now displays as a rotating circle instead of animated waveform bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->