### PR TITLE
Fix dev bundle icon: copy ICNS as AppIcon.icns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 	@plutil -replace CFBundleDisplayName -string "$(APP_NAME)" "$(CONTENTS)/Info.plist"
 	@plutil -replace CFBundleExecutable -string "$(APP_NAME)" "$(CONTENTS)/Info.plist"
 	@plutil -replace CFBundleIdentifier -string "$(BUNDLE_ID)" "$(CONTENTS)/Info.plist"
-	@cp $(ICON_ICNS) "$(RESOURCES)/"
+	@cp $(ICON_ICNS) "$(RESOURCES)/AppIcon.icns"
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 


### PR DESCRIPTION
## Summary

The Dev bundle's hammer-on-waveform icon (added in #137) does not actually appear in Finder, the Dock, or System Settings — macOS falls back to the prod waveform icon instead. The Makefile's icon copy step was preserving the source filename (`AppIcon-Dev.icns`), but `Info.plist`'s `CFBundleIconFile` is `"AppIcon"`, so macOS looks for `AppIcon.icns` in the bundle, doesn't find it, and falls back. One-line fix.

## Reproduction

1. Build the Dev bundle: `make` (defaults to `APP_NAME=FreeFlow Dev`).
2. Open `build/FreeFlow Dev.app` in Finder, or look at it in the Dock when running, or look at the entry in System Settings → Privacy & Security → Accessibility.
3. The icon shown is the prod waveform — the hammer overlay added in #137 is missing.

Inside the bundle:

```
build/FreeFlow Dev.app/Contents/Resources/AppIcon-Dev.icns   ← what the Makefile copied
build/FreeFlow Dev.app/Contents/Info.plist:
    <key>CFBundleIconFile</key>
    <string>AppIcon</string>                                  ← what macOS looks for
```

`AppIcon.icns` does not exist, so macOS uses its fallback chain and lands on the generic icon (or the prod icon if there's a stale cache).

## The fix

Rename the copied file to `AppIcon.icns` regardless of source. The `CFBundleIconFile` entry stays single-source, the dev `.icns` arrives at the path macOS expects, and the hammer overlay actually shows up everywhere.

```diff
-	@cp $(ICON_ICNS) "$(RESOURCES)/"
+	@cp $(ICON_ICNS) "$(RESOURCES)/AppIcon.icns"
```

## Test plan

- [x] `make clean && make` produces a Dev bundle whose `Contents/Resources/AppIcon.icns` matches `Resources/AppIcon-Dev.icns`
- [x] Dock icon, Finder thumbnail, and System Settings entry all show the hammer overlay
- [x] No change to prod builds (`APP_NAME=FreeFlow` still copies `AppIcon.icns` from `AppIcon.icns` — same file, no-op rename)
- [x] No change to `Info.plist`, no change to source files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * macOS app build updated to ensure the application icon is reliably included in the packaged .app using a standardized resource name, improving consistency of the installed app's icon.
  * Build packaging and signing steps continue to produce the same signed bundle while normalizing on-disk icon naming for predictable distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->