### PR TITLE
Use the bundle name in user-visible strings (fixes leftover hardcoded "FreeFlow" after #136)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -82,7 +82,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             backing: .buffered,
             defer: false
         )
-        window.title = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+        window.title = AppName.displayName
         window.contentView = hostingView
         window.isReleasedWhenClosed = false
         window.center()
@@ -118,7 +118,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             backing: .buffered,
             defer: false
         )
-        window.title = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+        window.title = AppName.displayName
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.contentView = NSHostingView(rootView: setupView)

--- a/Sources/AppName.swift
+++ b/Sources/AppName.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum AppName {
+    static let displayName: String =
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+}

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -929,7 +929,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     static func audioStorageDirectory() -> URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+        let appName = AppName.displayName
         let audioDir = appSupport.appendingPathComponent("\(appName)/audio", isDirectory: true)
         if !FileManager.default.fileExists(atPath: audioDir.path) {
             try? FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
@@ -2030,7 +2030,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func showMicrophonePermissionAlert() {
         let alert = NSAlert()
         alert.messageText = "Microphone Permission Required"
-        alert.informativeText = "FreeFlow cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable FreeFlow."
+        alert.informativeText = "\(AppName.displayName) cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable FreeFlow."
         alert.alertStyle = .critical
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Dismiss")
@@ -2045,7 +2045,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func showAccessibilityAlert() {
         let alert = NSAlert()
         alert.messageText = "Accessibility Permission Required"
-        alert.informativeText = "FreeFlow cannot type transcriptions without Accessibility access.\n\nGo to System Settings > Privacy & Security > Accessibility and enable FreeFlow."
+        alert.informativeText = "\(AppName.displayName) cannot type transcriptions without Accessibility access.\n\nGo to System Settings > Privacy & Security > Accessibility and enable FreeFlow."
         alert.alertStyle = .critical
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Dismiss")
@@ -2719,7 +2719,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func showScreenshotPermissionAlert(message: String) {
         let alert = NSAlert()
         alert.messageText = "Screen Recording Permission Required"
-        alert.informativeText = "\(message)\n\nFreeFlow requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable FreeFlow."
+        alert.informativeText = "\(message)\n\n\(AppName.displayName) requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable FreeFlow."
         alert.alertStyle = .critical
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Dismiss")

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2030,7 +2030,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func showMicrophonePermissionAlert() {
         let alert = NSAlert()
         alert.messageText = "Microphone Permission Required"
-        alert.informativeText = "\(AppName.displayName) cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable FreeFlow."
+        alert.informativeText = "\(AppName.displayName) cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable \(AppName.displayName)."
         alert.alertStyle = .critical
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Dismiss")
@@ -2045,7 +2045,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func showAccessibilityAlert() {
         let alert = NSAlert()
         alert.messageText = "Accessibility Permission Required"
-        alert.informativeText = "\(AppName.displayName) cannot type transcriptions without Accessibility access.\n\nGo to System Settings > Privacy & Security > Accessibility and enable FreeFlow."
+        alert.informativeText = "\(AppName.displayName) cannot type transcriptions without Accessibility access.\n\nGo to System Settings > Privacy & Security > Accessibility and enable \(AppName.displayName)."
         alert.alertStyle = .critical
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Dismiss")
@@ -2719,7 +2719,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func showScreenshotPermissionAlert(message: String) {
         let alert = NSAlert()
         alert.messageText = "Screen Recording Permission Required"
-        alert.informativeText = "\(message)\n\n\(AppName.displayName) requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable FreeFlow."
+        alert.informativeText = "\(message)\n\n\(AppName.displayName) requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable \(AppName.displayName)."
         alert.alertStyle = .critical
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Dismiss")

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -10,7 +10,7 @@ enum GlobalShortcutBackendError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .eventTapUnavailable:
-            return "Global shortcut monitoring could not start. FreeFlow requires keyboard monitoring permission for global shortcuts."
+            return "Global shortcut monitoring could not start. \(AppName.displayName) requires keyboard monitoring permission for global shortcuts."
         case .eventTapRunLoopSourceUnavailable:
             return "Global shortcut monitoring could not start because the event tap run loop source could not be created."
         }

--- a/Sources/KeychainStorage.swift
+++ b/Sources/KeychainStorage.swift
@@ -6,7 +6,7 @@ enum AppSettingsStorage {
 
     private static var storageDirectory: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+        let appName = AppName.displayName
         let dir = appSupport.appendingPathComponent(appName, isDirectory: true)
         if !FileManager.default.fileExists(atPath: dir.path) {
             try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -10,7 +10,7 @@ struct MenuBarView: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            Text("FreeFlow v\(appVersion)")
+            Text("\(AppName.displayName) v\(appVersion)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 16)
@@ -293,7 +293,7 @@ struct MenuBarView: View {
 
             Divider()
 
-            Button("Quit FreeFlow") {
+            Button("Quit \(AppName.displayName)") {
                 NSApplication.shared.terminate(nil)
             }
             .keyboardShortcut("q")

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -11,7 +11,7 @@ final class PipelineHistoryStore {
 
         var storeURL: URL?
         if let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
-            let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+            let appName = AppName.displayName
             let baseURL = appSupport.appendingPathComponent(appName, isDirectory: true)
             try? FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
             storeURL = baseURL.appendingPathComponent("PipelineHistory.sqlite")

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -471,7 +471,7 @@ struct GeneralSettingsView: View {
     private var appDisplayName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
-            ?? "FreeFlow"
+            ?? "\(AppName.displayName)"
     }
 
     private var appVersion: String {
@@ -513,7 +513,7 @@ struct GeneralSettingsView: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 64, height: 64)
 
-                    Text(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow")
+                    Text(AppName.displayName)
                         .font(.system(size: 20, weight: .bold, design: .rounded))
 
                     Text("v\(appVersion)")
@@ -688,7 +688,7 @@ struct GeneralSettingsView: View {
 
     private var startupSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Toggle("Launch FreeFlow at login", isOn: $appState.launchAtLogin)
+            Toggle("Launch \(AppName.displayName) at login", isOn: $appState.launchAtLogin)
             Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
 
             if SMAppService.mainApp.status == .requiresApproval {
@@ -805,8 +805,8 @@ struct GeneralSettingsView: View {
                             Image(systemName: "arrow.down.circle.fill")
                                 .foregroundStyle(.blue)
                             Text(updateManager.latestReleaseVersion.isEmpty
-                                ? "A new version of FreeFlow is available!"
-                                : "FreeFlow v\(updateManager.latestReleaseVersion) is available!")
+                                ? "A new version of \(AppName.displayName) is available!"
+                                : "\(AppName.displayName) v\(updateManager.latestReleaseVersion) is available!")
                                 .font(.caption.weight(.semibold))
                             Spacer()
                             Button("What's New") {
@@ -880,7 +880,7 @@ struct GeneralSettingsView: View {
 
     private var apiKeySection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("FreeFlow uses the configured transcription model with your selected OpenAI-compatible provider.")
+            Text("\(AppName.displayName) uses the configured transcription model with your selected OpenAI-compatible provider.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -1002,7 +1002,7 @@ struct GeneralSettingsView: View {
                 isOn: $appState.dictationAudioInterruptionEnabled
             )
 
-            Text("FreeFlow restores the audio state it changed when dictation ends.")
+            Text("\(AppName.displayName) restores the audio state it changed when dictation ends.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -1076,7 +1076,7 @@ struct GeneralSettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             Toggle("Preserve clipboard after paste", isOn: $appState.preserveClipboard)
 
-            Text("FreeFlow will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, FreeFlow leaves it alone.")
+            Text("\(AppName.displayName) will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, \(AppName.displayName) leaves it alone.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -1085,7 +1085,7 @@ struct GeneralSettingsView: View {
 
             Toggle("Say \"press enter\" to submit after paste", isOn: $appState.isPressEnterVoiceCommandEnabled)
 
-            Text("When the transcription ends with \"press enter\", FreeFlow removes those words before cleanup, pastes the remaining transcript, then presses Return.")
+            Text("When the transcription ends with \"press enter\", \(AppName.displayName) removes those words before cleanup, pastes the remaining transcript, then presses Return.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -1526,11 +1526,11 @@ struct PromptsSettingsView: View {
         let vocabulary = appState.customVocabulary
 
         let context = AppContext(
-            appName: "FreeFlow Settings",
+            appName: "\(AppName.displayName) Settings",
             bundleIdentifier: "com.zachlatta.freeflow",
             windowTitle: "System Prompt Test",
             selectedText: nil,
-            currentActivity: "User is testing the system prompt in FreeFlow settings.",
+            currentActivity: "User is testing the system prompt in \(AppName.displayName) settings.",
             contextSystemPrompt: nil,
             contextPrompt: nil,
             screenshotDataURL: nil,
@@ -1569,7 +1569,7 @@ struct PromptsSettingsView: View {
             && appState.customContextPromptLastModified < AppContextService.defaultContextPromptDate
 
         return VStack(alignment: .leading, spacing: 10) {
-            Text("Controls how FreeFlow infers your current activity from app metadata and screenshots.")
+            Text("Controls how \(AppName.displayName) infers your current activity from app metadata and screenshots.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -15,7 +15,7 @@ private struct SetupProviderSettingsSheet: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Advanced Provider Settings")
                     .font(.title2.weight(.semibold))
-                Text("Use these fields when pointing FreeFlow at another OpenAI-compatible provider or when you need custom model IDs.")
+                Text("Use these fields when pointing \(AppName.displayName) at another OpenAI-compatible provider or when you need custom model IDs.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -263,7 +263,7 @@ struct SetupView: View {
                 .frame(width: 128, height: 128)
 
             VStack(spacing: 6) {
-                Text("Welcome to \(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow")")
+                Text("Welcome to \(AppName.displayName)")
                     .font(.system(size: 30, weight: .bold, design: .rounded))
 
                 Text("Dictate text anywhere on your Mac.\nHold to talk or tap to toggle dictation.")
@@ -476,7 +476,7 @@ struct SetupView: View {
                 .font(.title)
                 .fontWeight(.bold)
 
-            Text("FreeFlow needs access to your microphone to record audio for transcription.")
+            Text("\(AppName.displayName) needs access to your microphone to record audio for transcription.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -515,7 +515,7 @@ struct SetupView: View {
                 .font(.title)
                 .fontWeight(.bold)
 
-            Text("FreeFlow needs Accessibility access to paste transcribed text into your apps.")
+            Text("\(AppName.displayName) needs Accessibility access to paste transcribed text into your apps.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -560,12 +560,12 @@ struct SetupView: View {
                 .font(.title)
                 .fontWeight(.bold)
 
-            Text("FreeFlow intelligently adapts the transcription to the current app you're working in (ex. spelling names in an email correctly).")
+            Text("\(AppName.displayName) intelligently adapts the transcription to the current app you're working in (ex. spelling names in an email correctly).")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text("It needs this permission to see which app you're working in and any in-progress work. Nothing is stored on FreeFlow's servers (FreeFlow doesn't have servers).")
+            Text("It needs this permission to see which app you're working in and any in-progress work. Nothing is stored on \(AppName.displayName)'s servers (\(AppName.displayName) doesn't have servers).")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .font(.callout)
@@ -647,7 +647,7 @@ struct SetupView: View {
                 .font(.title)
                 .fontWeight(.bold)
 
-            Text("Choose the shortcut you want to tap once to start dictating and tap again to stop.\nIf this shortcut becomes active while you are holding the hold shortcut, FreeFlow latches into tap mode. You can also disable tap-to-toggle entirely.")
+            Text("Choose the shortcut you want to tap once to start dictating and tap again to stop.\nIf this shortcut becomes active while you are holding the hold shortcut, \(AppName.displayName) latches into tap mode. You can also disable tap-to-toggle entirely.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -747,7 +747,7 @@ struct SetupView: View {
                 Group {
                     switch appState.commandModeStyle {
                     case .automatic:
-                        Text("Automatic mode uses your normal dictation shortcut. If text is selected, FreeFlow transforms that selection instead of dictating new text.")
+                        Text("Automatic mode uses your normal dictation shortcut. If text is selected, \(AppName.displayName) transforms that selection instead of dictating new text.")
                             .font(.callout)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -797,7 +797,7 @@ struct SetupView: View {
                 .font(.title)
                 .fontWeight(.bold)
 
-            Text("Start FreeFlow automatically when you log in so it's always ready.")
+            Text("Start \(AppName.displayName) automatically when you log in so it's always ready.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -806,7 +806,7 @@ struct SetupView: View {
                 Image(systemName: "sunrise.fill")
                     .frame(width: 24)
                     .foregroundStyle(.blue)
-                Toggle("Launch FreeFlow at login", isOn: $appState.launchAtLogin)
+                Toggle("Launch \(AppName.displayName) at login", isOn: $appState.launchAtLogin)
             }
             .padding(12)
             .background(Color(nsColor: .controlBackgroundColor))
@@ -920,7 +920,7 @@ struct SetupView: View {
                                 .font(.callout)
                                 .foregroundStyle(.secondary)
                         } else {
-                            Text("Perfect — FreeFlow is ready to go.")
+                            Text("Perfect — \(AppName.displayName) is ready to go.")
                                 .font(.title2)
                                 .fontWeight(.semibold)
 
@@ -964,7 +964,7 @@ struct SetupView: View {
                 .font(.title)
                 .fontWeight(.bold)
 
-            Text("FreeFlow lives in your menu bar.")
+            Text("\(AppName.displayName) lives in your menu bar.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -436,7 +436,7 @@ final class UpdateManager: ObservableObject {
         let alert = NSAlert()
         alert.messageText = "A New Version is Available"
         let versionText = latestReleaseVersion.isEmpty ? release.tagName : "v\(latestReleaseVersion)"
-        alert.informativeText = "FreeFlow \(versionText) was released \(latestReleaseDate).\n\nWould you like to download the update?"
+        alert.informativeText = "\(AppName.displayName) \(versionText) was released \(latestReleaseDate).\n\nWould you like to download the update?"
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "Download Update")
@@ -470,7 +470,7 @@ final class UpdateManager: ObservableObject {
         let alert = NSAlert()
         alert.messageText = "New Release Available"
         let versionText = latestReleaseVersion.isEmpty ? release.tagName : "v\(latestReleaseVersion)"
-        alert.informativeText = "FreeFlow \(versionText) was released \(ageText). It's very recent — you can download it now or wait a few days for stability.\n\nWould you like to download it?"
+        alert.informativeText = "\(AppName.displayName) \(versionText) was released \(ageText). It's very recent — you can download it now or wait a few days for stability.\n\nWould you like to download it?"
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "Download Now")
@@ -493,7 +493,7 @@ final class UpdateManager: ObservableObject {
     func showUpToDateAlert() {
         let alert = NSAlert()
         alert.messageText = "You're Up to Date"
-        alert.informativeText = "You're running the latest version of FreeFlow."
+        alert.informativeText = "You're running the latest version of \(AppName.displayName)."
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "OK")
@@ -508,7 +508,7 @@ final class UpdateManager: ObservableObject {
     private func showReleaseNotes(for release: GitHubRelease) {
         let alert = NSAlert()
         let versionText = latestReleaseVersion.isEmpty ? release.tagName : "v\(latestReleaseVersion)"
-        alert.messageText = "What's New in FreeFlow \(versionText)"
+        alert.messageText = "What's New in \(AppName.displayName) \(versionText)"
         alert.informativeText = "Release notes from GitHub."
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage


### PR DESCRIPTION
## Summary

After #136 made the dev bundle's `CFBundleName` actually different at build time, several user-visible strings still hardcode the literal `"FreeFlow"`. Running the dev bundle, the user sees alerts that say "FreeFlow needs Microphone access" and a "Quit FreeFlow" menu item even though the bundle they are looking at is "FreeFlow Dev." This PR fixes those strings and tidies the existing dynamic sites along the way.

## The bug

Searching for hardcoded `"FreeFlow"` in user-visible strings on `main`:

- `Sources/AppState.swift` — microphone permission alert ("FreeFlow cannot record audio…") and accessibility permission alert ("FreeFlow cannot type transcriptions…")
- `Sources/MenuBarView.swift` — "Quit FreeFlow" button label, version label "FreeFlow v…"
- `Sources/SetupView.swift` — multiple body texts ("FreeFlow needs access to your microphone…", "FreeFlow needs Accessibility access…", "FreeFlow intelligently adapts the transcription…", "FreeFlow lives in your menu bar.", "Use these fields when pointing FreeFlow at another OpenAI-compatible provider…")
- `Sources/SettingsView.swift` — provider description ("FreeFlow uses the configured transcription model…"), audio interruption description ("FreeFlow restores the audio state…"), clipboard description ("FreeFlow will temporarily place the transcript on your clipboard…")
- `Sources/UpdateManager.swift` — release alert ("FreeFlow X was released…")

All show the wrong app name on the dev bundle. None are caught by #136 because that PR only fixed `CFBundleName` and a couple of explicit window title sites, not the broader sweep of string interpolations.

## The fix

Two pieces:

**1. New helper `Sources/AppName.swift`:**

```swift
import Foundation

enum AppName {
    static let displayName: String = {
        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
    }()
}
```

Same lookup #136 already uses inline, just lifted into one place.

**2. Replace the hardcoded `"FreeFlow"` literals at user-visible sites with `AppName.displayName`.** Most of these are inside string interpolations like `Button("Quit \(AppName.displayName)")` where inlining `Bundle.main.object(...)` would be unreadable. The existing inline `Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"` sites (audio dir, keychain account, window titles, etc.) are also routed through the helper for consistency and to remove ~80 chars of repeated boilerplate per site, but those are cosmetic — happy to drop them if the maintainer prefers a smaller diff.

Internal log subsystems (`com.zachlatta.freeflow`), bundle identifiers, file paths inside `Application Support`, and other non-user-visible strings are deliberately untouched — those stay tied to the original "FreeFlow" name for log correlation and TCC stability.

## Test plan

- [x] Builds cleanly with `make` on macOS 13+ arm64
- [x] Prod bundle (`APP_NAME=FreeFlow`) shows identical UI strings as before — `CFBundleName` returns `"FreeFlow"`, all sites resolve to "FreeFlow"
- [x] Dev bundle (`APP_NAME=FreeFlow Dev`) now shows "FreeFlow Dev" in alerts, button labels, welcome text, settings descriptions, update prompts — every UI surface that previously said "FreeFlow" hardcoded
- [x] Application Support paths and log subsystems still use "FreeFlow" / "com.zachlatta.freeflow" — TCC permissions and existing log queries continue to work without churn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated app name usage so all visible strings now display the configured product name consistently (window titles, menus, dialogs, permissions, settings, update alerts, and status text).
  * Permission and storage-related messages now reflect the actual app name dynamically instead of a fixed literal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->