### PR TITLE
Render release notes with Markdown formatting

### DIFF
--- a/.agents/skills/freeflow-release/SKILL.md
+++ b/.agents/skills/freeflow-release/SKILL.md
@@ -9,9 +9,11 @@ description: Prepare and publish FreeFlow app releases. Use when the user asks t
 
 Use this skill to prepare a FreeFlow release from the local repository. FreeFlow releases are semver-tag driven: pushing a tag like `v0.3.1` triggers `.github/workflows/release.yml`, which stamps the app bundle, extracts the matching `CHANGELOG.md` section, builds/signs/notarizes the DMG, and creates the GitHub Release.
 
+Every release prep must update `CHANGELOG.md` by comparing the previous public semver release with the current release target. The changelog section should describe the user-visible changes that shipped since the previous release, not just summarize the final release-prep commit.
+
 ## Ground Rules
 
-- Treat `CHANGELOG.md` as the release notes source of truth.
+- Treat `CHANGELOG.md` as the release notes source of truth, and update it before any release commit or tag.
 - Keep changelog language user-facing. Avoid implementation details unless they affect maintainers or troubleshooting.
 - Do not edit `README.md` or unrelated docs unless the user explicitly asks.
 - Do not push tags or branches until the user has approved the exact release version and changelog.
@@ -26,12 +28,14 @@ Use this skill to prepare a FreeFlow release from the local repository. FreeFlow
    git log --oneline --decorate -n 20
    ```
 
-2. Find the last version bump:
+2. Find the previous public release:
    ```bash
+   git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname
+   git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0
    git log --oneline --decorate -- Info.plist CHANGELOG.md .github/workflows/release.yml
    git blame -L 11,14 Info.plist
    ```
-   Use the last commit that changed `CFBundleShortVersionString`, `CFBundleVersion`, or the prior release section as the start of the changelog range.
+   Use the latest reachable public semver tag, such as `v0.3.2`, as the previous-release boundary. If tags are missing or inconsistent, fall back to the commit that introduced the prior `CHANGELOG.md` section or changed `CFBundleShortVersionString`/`CFBundleVersion`, and state that fallback explicitly.
 
 3. Determine the next version:
    - `PATCH` for fixes, polish, release-system updates, and small user-visible improvements.
@@ -39,13 +43,14 @@ Use this skill to prepare a FreeFlow release from the local repository. FreeFlow
    - `MAJOR` only for breaking behavior or major compatibility changes.
    Confirm the version with the user if it was not specified.
 
-4. Build the changelog from the commit range:
+4. Build and write the `CHANGELOG.md` entry from the previous release to the current release target:
    ```bash
-   git log --first-parent --reverse --oneline <last-version-commit>..HEAD
-   git log --reverse --oneline <last-version-commit>..HEAD
-   git diff --stat <last-version-commit>..HEAD
+   git log --first-parent --reverse --oneline <previous-release-tag>..HEAD
+   git log --reverse --oneline <previous-release-tag>..HEAD
+   git diff --stat <previous-release-tag>..HEAD
+   git diff --name-status <previous-release-tag>..HEAD
    ```
-   Prefer first-parent merge commits for feature grouping, then inspect individual commits for details. Write a concise section:
+   Prefer first-parent merge commits for feature grouping, then inspect individual commits and relevant diffs for details. Write a concise section near the top of `CHANGELOG.md`, above the previous release:
    ```md
    ## [0.3.1] - YYYY-MM-DD
 
@@ -58,6 +63,7 @@ Use this skill to prepare a FreeFlow release from the local repository. FreeFlow
    ### Fixed
    - User-visible bugs and update/release fixes.
    ```
+   Include only categories that have entries. If the release contains mostly internal work, describe the user-facing effect, such as reliability, update behavior, packaging, or troubleshooting improvements. Do not include raw commit hashes in the changelog.
 
 5. Validate locally before commit/tag:
    ```bash

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -364,7 +364,7 @@ final class UpdateManager: ObservableObject {
     }
 
     private func aggregatedReleaseNotes(from releases: [GitHubRelease]) -> String? {
-        let notes = releases.compactMap { releaseNotesBody(from: $0.body) }
+        let notes = releases.reversed().compactMap { releaseNotesBody(from: $0.body) }
         guard !notes.isEmpty else { return nil }
         return notes.joined(separator: "\n\n")
     }
@@ -561,10 +561,119 @@ final class UpdateManager: ObservableObject {
         textView.textColor = .textColor
         textView.font = .systemFont(ofSize: NSFont.systemFontSize)
         textView.textContainerInset = NSSize(width: 10, height: 10)
-        textView.string = text
+        textView.textStorage?.setAttributedString(releaseNotesAttributedString(from: text))
 
         scrollView.documentView = textView
         return scrollView
+    }
+
+    private func releaseNotesAttributedString(from text: String) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        let bodyFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        let bulletFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        let headingFont = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize + 3)
+        let subheadingFont = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize + 1)
+        let baseParagraph = NSMutableParagraphStyle()
+        baseParagraph.lineSpacing = 2
+        baseParagraph.paragraphSpacing = 6
+
+        let bulletParagraph = NSMutableParagraphStyle()
+        bulletParagraph.lineSpacing = 2
+        bulletParagraph.paragraphSpacing = 4
+        bulletParagraph.firstLineHeadIndent = 0
+        bulletParagraph.headIndent = 16
+
+        for rawLine in text.components(separatedBy: .newlines) {
+            let trimmedLine = rawLine.trimmingCharacters(in: .whitespaces)
+            let font: NSFont
+            let paragraphStyle: NSParagraphStyle
+            let renderedLine: String
+
+            if trimmedLine.hasPrefix("### ") {
+                font = subheadingFont
+                paragraphStyle = baseParagraph
+                renderedLine = String(trimmedLine.dropFirst(4))
+            } else if trimmedLine.hasPrefix("## ") {
+                font = headingFont
+                paragraphStyle = baseParagraph
+                renderedLine = String(trimmedLine.dropFirst(3))
+            } else if trimmedLine.hasPrefix("- ") {
+                font = bulletFont
+                paragraphStyle = bulletParagraph
+                renderedLine = "• \(trimmedLine.dropFirst(2))"
+            } else {
+                font = bodyFont
+                paragraphStyle = baseParagraph
+                renderedLine = rawLine
+            }
+
+            result.append(inlineMarkdownAttributedString(
+                from: renderedLine,
+                font: font,
+                paragraphStyle: paragraphStyle
+            ))
+            result.append(NSAttributedString(string: "\n"))
+        }
+
+        return result
+    }
+
+    private func inlineMarkdownAttributedString(
+        from text: String,
+        font: NSFont,
+        paragraphStyle: NSParagraphStyle
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        var remaining = text[...]
+
+        while let markerRange = remaining.range(of: "**") {
+            appendPlainMarkdownText(
+                String(remaining[..<markerRange.lowerBound]),
+                to: result,
+                font: font,
+                paragraphStyle: paragraphStyle
+            )
+
+            let boldStart = markerRange.upperBound
+            guard let boldEndRange = remaining[boldStart...].range(of: "**") else {
+                appendPlainMarkdownText(
+                    String(remaining[markerRange.lowerBound...]),
+                    to: result,
+                    font: font,
+                    paragraphStyle: paragraphStyle
+                )
+                return result
+            }
+
+            let boldText = String(remaining[boldStart..<boldEndRange.lowerBound])
+            let boldFont = NSFontManager.shared.convert(font, toHaveTrait: .boldFontMask)
+            appendPlainMarkdownText(
+                boldText,
+                to: result,
+                font: boldFont,
+                paragraphStyle: paragraphStyle
+            )
+            remaining = remaining[boldEndRange.upperBound...]
+        }
+
+        appendPlainMarkdownText(String(remaining), to: result, font: font, paragraphStyle: paragraphStyle)
+        return result
+    }
+
+    private func appendPlainMarkdownText(
+        _ text: String,
+        to result: NSMutableAttributedString,
+        font: NSFont,
+        paragraphStyle: NSParagraphStyle
+    ) {
+        result.append(NSAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor.textColor,
+                .paragraphStyle: paragraphStyle
+            ]
+        ))
     }
 
     private func showErrorAlert(_ message: String) {


### PR DESCRIPTION
## Summary
- Updated release-note rendering in the update viewer to preserve Markdown structure, including headings, bullets, and inline bold text.
- Reversed the aggregated release notes order so the newest release notes are presented consistently.
- Tightened FreeFlow release prep guidance so changelog updates are based on the previous public semver release, not just the final prep commit.

## Testing
- Not run (not requested).
- Code review of `Sources/UpdateManager.swift` for attributed-string rendering logic.
- Documentation check of `.agents/skills/freeflow-release/SKILL.md` for changelog workflow updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release notes now display with enhanced formatting, including styled headings, formatted bullet points, and bold text support for improved readability and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->