### PR TITLE
Show transcribing spinner immediately with delayed fallback

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2319,7 +2319,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         statusText = "Preparing audio..."
         errorMessage = nil
         playAlertSound(named: "Pop")
-        overlayManager.prepareForTranscribing()
+        overlayManager.showTranscribing()
         audioRecorder.stopRecording { [weak self] fileURL in
             guard let self else { return }
             guard let fileURL else {
@@ -2344,8 +2344,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.transcribingAudioFileName = savedAudioFile?.fileName
             self.statusText = "Transcribing..."
             self.debugStatusMessage = "Transcribing audio"
-
-            self.overlayManager.showTranscribing()
 
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -451,6 +451,45 @@ private struct ProcessingPill: View {
     }
 }
 
+struct ProcessingIndicatorView: View {
+    @State private var showsExtendedSpinner = false
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        ZStack {
+            if showsExtendedSpinner {
+                Circle()
+                    .trim(from: 0.1, to: 0.9)
+                    .stroke(Color.white, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                    .frame(width: 16, height: 16)
+                    .rotationEffect(.degrees(rotation))
+                    .frame(height: 20)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .transition(.opacity.combined(with: .scale(scale: 0.92)))
+                    .onAppear {
+                        rotation = 0
+                        withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
+                            rotation = 360
+                        }
+                    }
+            } else {
+                ProcessingWaveformView()
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            }
+        }
+        .task {
+            showsExtendedSpinner = false
+            do {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    showsExtendedSpinner = true
+                }
+            } catch {}
+        }
+    }
+}
+
 struct InitializingDotsView: View {
     @State private var activeDot = 0
     @State private var timer: Timer?
@@ -514,7 +553,7 @@ struct RecordingOverlayView: View {
                             )
                                 .transition(.opacity)
                         } else {
-                            ProcessingWaveformView()
+                            ProcessingIndicatorView()
                                 .transition(.opacity.combined(with: .scale(scale: 0.96)))
                         }
                     }

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -139,7 +139,7 @@ final class RecordingOverlayManager {
 
     func prepareForTranscribing() {
         DispatchQueue.main.async {
-            self.setTranscribingPhase(showsTranscribingSpinner: false)
+            self.setTranscribingPhase(showsTranscribingSpinner: true)
         }
     }
 
@@ -393,29 +393,61 @@ struct WaveformView: View {
 }
 
 struct ProcessingWaveformView: View {
-    private static let barCount = 9
-    private static let multipliers: [CGFloat] = [0.42, 0.58, 0.76, 0.9, 1.0, 0.9, 0.76, 0.58, 0.42]
+    private static let barCount = 5
+    private static let centerIndex = CGFloat((barCount - 1) / 2)
 
     var body: some View {
         TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
             let time = context.date.timeIntervalSinceReferenceDate
 
-            HStack(spacing: 2.5) {
+            HStack(spacing: 4) {
                 ForEach(0..<Self.barCount, id: \.self) { index in
-                    let wave = 0.5 + 0.5 * sin((time * 5.6) - Double(index) * 0.5)
-                    let shimmer = 0.5 + 0.5 * sin((time * 2.8) + Double(index) * 0.75)
-                    let amplitude = min(
-                        0.16 + CGFloat(wave) * Self.multipliers[index] * 0.52 + CGFloat(shimmer) * 0.08,
-                        1.0
+                    ProcessingPill(
+                        amplitude: amplitude(for: index, time: time),
+                        opacity: opacity(for: index, time: time)
                     )
-
-                    WaveformBar(amplitude: amplitude)
-                        .opacity(0.45 + CGFloat(wave) * 0.5)
                 }
             }
             .frame(height: 20)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func phase(for index: Int, time: TimeInterval) -> Double {
+        let cycle = 1.05
+        let stagger = 0.11
+        return ((time - Double(index) * stagger).truncatingRemainder(dividingBy: cycle)) / cycle
+    }
+
+    private func pulse(for index: Int, time: TimeInterval) -> CGFloat {
+        let phase = phase(for: index, time: time)
+        let wave = 0.5 + 0.5 * sin((phase * 2.0 * .pi) - (.pi / 2.0))
+        return CGFloat(pow(wave, 1.9))
+    }
+
+    private func amplitude(for index: Int, time: TimeInterval) -> CGFloat {
+        let centerDistance = abs(CGFloat(index) - Self.centerIndex) / Self.centerIndex
+        let baseline = 0.18 + (1.0 - centerDistance) * 0.1
+        return min(baseline + pulse(for: index, time: time) * 0.68, 1.0)
+    }
+
+    private func opacity(for index: Int, time: TimeInterval) -> CGFloat {
+        0.42 + pulse(for: index, time: time) * 0.52
+    }
+}
+
+private struct ProcessingPill: View {
+    let amplitude: CGFloat
+    let opacity: CGFloat
+
+    private let minHeight: CGFloat = 4
+    private let maxHeight: CGFloat = 18
+
+    var body: some View {
+        Capsule()
+            .fill(.white)
+            .frame(width: 4, height: minHeight + (maxHeight - minHeight) * amplitude)
+            .opacity(opacity)
     }
 }
 
@@ -456,7 +488,7 @@ struct RecordingOverlayView: View {
     private let trailingAccessoryWidth: CGFloat = 32
 
     private var showsLiveRecordingContent: Bool {
-        state.phase == .recording || (state.phase == .transcribing && !state.showsTranscribingSpinner)
+        state.phase == .recording
     }
 
     private var showsStopButton: Bool {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -8,7 +8,6 @@ final class RecordingOverlayState: ObservableObject {
     @Published var audioLevel: Float = 0.0
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
     @Published var isCommandMode = false
-    @Published var showsTranscribingSpinner = false
     @Published var updateVersion: String = ""
 }
 
@@ -95,7 +94,6 @@ final class RecordingOverlayManager {
             self.overlayState.recordingTriggerMode = mode
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .initializing
-            self.overlayState.showsTranscribingSpinner = false
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: false)
         }
@@ -107,7 +105,6 @@ final class RecordingOverlayManager {
             self.overlayState.recordingTriggerMode = mode
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
-            self.overlayState.showsTranscribingSpinner = false
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: true)
         }
@@ -119,7 +116,6 @@ final class RecordingOverlayManager {
             self.overlayState.recordingTriggerMode = mode
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
-            self.overlayState.showsTranscribingSpinner = false
             self.updateOverlayLayout(animated: true)
         }
     }
@@ -139,7 +135,7 @@ final class RecordingOverlayManager {
 
     func showTranscribing() {
         DispatchQueue.main.async {
-            self.setTranscribingPhase(showsTranscribingSpinner: true)
+            self.setTranscribingPhase()
         }
     }
 
@@ -153,7 +149,6 @@ final class RecordingOverlayManager {
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
             self.overlayState.isCommandMode = false
-            self.overlayState.showsTranscribingSpinner = false
             self.overlayState.updateVersion = version
             self.overlayState.phase = .updateAvailable
             self.showOverlayPanel(animatedResize: true)
@@ -207,10 +202,9 @@ final class RecordingOverlayManager {
         resize(panel: panel, to: frame, animated: animated)
     }
 
-    private func setTranscribingPhase(showsTranscribingSpinner: Bool) {
+    private func setTranscribingPhase() {
         lockedOverlayWidth = overlayWindow?.frame.width ?? overlayWidth
         overlayState.phase = .transcribing
-        overlayState.showsTranscribingSpinner = showsTranscribingSpinner
         showOverlayPanel(animatedResize: true)
     }
 
@@ -298,7 +292,6 @@ final class RecordingOverlayManager {
     private func dismissAll() {
         lockedOverlayWidth = nil
         overlayState.isCommandMode = false
-        overlayState.showsTranscribingSpinner = false
         overlayState.updateVersion = ""
         if let panel = overlayWindow {
             panel.orderOut(nil)

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -137,12 +137,6 @@ final class RecordingOverlayManager {
         }
     }
 
-    func prepareForTranscribing() {
-        DispatchQueue.main.async {
-            self.setTranscribingPhase(showsTranscribingSpinner: true)
-        }
-    }
-
     func showTranscribing() {
         DispatchQueue.main.async {
             self.setTranscribingPhase(showsTranscribingSpinner: true)


### PR DESCRIPTION
## Summary
- Show the transcribing indicator immediately instead of waiting for a short delay.
- Replace the old waveform-only processing state with a combined indicator that starts as an animated waveform and falls back to a spinner after 1 second.
- Simplify `AppState` by removing the separate transcribing indicator task and related delay bookkeeping.

## Testing
- Not run
- Reviewed the overlay state flow to confirm transcribing now enters the indicator immediately.
- Reviewed the new `ProcessingIndicatorView` transition from waveform to spinner after the timeout.

<img width="306" height="84" alt="Screen Recording 2026-04-29 at 17 00 49" src="https://github.com/user-attachments/assets/659719fc-99b7-4d53-b948-2c9ea35284bc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processing indicator now starts as a compact 5-bar capsule waveform and, after ~1s, transitions into an animated rotating spinner.
  * Transcribing UI now appears immediately when transcription begins; recording visuals are shown only during active recording.

* **Style**
  * Refreshed waveform visuals and smoother animation/transitions for recording and transcribing states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->