### PR TITLE
Visually group Settings rows in titled sub-cards

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -32,6 +32,36 @@ private struct SettingsCard<Content: View>: View {
     }
 }
 
+private struct SettingsSubcard<Content: View>: View {
+    let title: String?
+    let content: Content
+
+    init(_ title: String? = nil, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let title {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+            }
+            content
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.3))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+}
+
 private let iso8601DayFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd"
@@ -1055,52 +1085,57 @@ struct GeneralSettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            Picker("Invocation Style", selection: Binding(
-                get: { appState.commandModeStyle },
-                set: { newValue in
-                    _ = appState.setCommandModeStyle(newValue)
-                }
-            )) {
-                ForEach(CommandModeStyle.allCases) { style in
-                    Text(style.title).tag(style)
-                }
-            }
-            .pickerStyle(.segmented)
-            .disabled(!appState.isCommandModeEnabled)
+            SettingsSubcard("Invocation Style") {
+                VStack(alignment: .leading, spacing: 12) {
+                    Picker("Invocation Style", selection: Binding(
+                        get: { appState.commandModeStyle },
+                        set: { newValue in
+                            _ = appState.setCommandModeStyle(newValue)
+                        }
+                    )) {
+                        ForEach(CommandModeStyle.allCases) { style in
+                            Text(style.title).tag(style)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .disabled(!appState.isCommandModeEnabled)
 
-            Group {
-                switch appState.commandModeStyle {
-                case .automatic:
-                    Text("If text is selected, your normal dictation shortcut transforms the selection instead of dictating over it.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                case .manual:
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Hold the extra modifier together with your normal dictation shortcut to transform selected text.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    Group {
+                        switch appState.commandModeStyle {
+                        case .automatic:
+                            Text("If text is selected, your normal dictation shortcut transforms the selection instead of dictating over it.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        case .manual:
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Hold the extra modifier together with your normal dictation shortcut to transform selected text.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
 
-                        Picker("Extra Modifier", selection: Binding(
-                            get: { appState.commandModeManualModifier },
-                            set: { newValue in
-                                _ = appState.setCommandModeManualModifier(newValue)
-                            }
-                        )) {
-                            ForEach(CommandModeManualModifier.allCases) { modifier in
-                                Text(modifier.title).tag(modifier)
+                                Picker("Extra Modifier", selection: Binding(
+                                    get: { appState.commandModeManualModifier },
+                                    set: { newValue in
+                                        _ = appState.setCommandModeManualModifier(newValue)
+                                    }
+                                )) {
+                                    ForEach(CommandModeManualModifier.allCases) { modifier in
+                                        Text(modifier.title).tag(modifier)
+                                    }
+                                }
+                                .disabled(!appState.isCommandModeEnabled || appState.commandModeStyle != .manual)
                             }
                         }
-                        .disabled(!appState.isCommandModeEnabled || appState.commandModeStyle != .manual)
+                    }
+
+                    if let validationMessage = appState.commandModeManualModifierValidationMessage {
+                        Label(validationMessage, systemImage: "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
                     }
                 }
             }
             .opacity(appState.isCommandModeEnabled ? 1 : 0.5)
-
-            if let validationMessage = appState.commandModeManualModifierValidationMessage {
-                Label(validationMessage, systemImage: "xmark.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
         }
     }
 
@@ -1108,20 +1143,25 @@ struct GeneralSettingsView: View {
 
     private var clipboardSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Toggle("Preserve clipboard after paste", isOn: $appState.preserveClipboard)
+            SettingsSubcard {
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Preserve clipboard after paste", isOn: $appState.preserveClipboard)
 
-            Text("\(AppName.displayName) will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, \(AppName.displayName) leaves it alone.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                    Text("\(AppName.displayName) will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, \(AppName.displayName) leaves it alone.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
 
-            Divider()
-                .padding(.vertical, 2)
+            SettingsSubcard {
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Say \"press enter\" to submit after paste", isOn: $appState.isPressEnterVoiceCommandEnabled)
 
-            Toggle("Say \"press enter\" to submit after paste", isOn: $appState.isPressEnterVoiceCommandEnabled)
-
-            Text("When the transcription ends with \"press enter\", \(AppName.displayName) removes those words before cleanup, pastes the remaining transcript, then presses Return.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                    Text("When the transcription ends with \"press enter\", \(AppName.displayName) removes those words before cleanup, pastes the remaining transcript, then presses Return.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -112,6 +112,20 @@ struct ShortcutRoleSection: View {
                     .foregroundStyle(.red)
             }
         }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.3))
+        )
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isFocused ? Color.blue.opacity(0.08) : Color.clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(isFocused ? Color.blue : Color.primary.opacity(0.08), lineWidth: isFocused ? 2 : 1)
+        )
+        .id(role)
     }
 }
 


### PR DESCRIPTION
## Summary
The Settings window has several sections (Dictation Shortcuts, Edit Mode, Clipboard) where multiple related controls sit in a single big card with no visual boundary between them. Hard to parse where one group ends and the next begins. This PR wraps each group in a subtle bordered "sub-card" so the eye can pick them out at a glance.

![Clipboard section showing two un-titled sub-cards](https://assets.themarketingshow.com/bugs/freeflow/sub-fieldset-clipboard-demo-2026-04-29.png)

## What changes

**Dictation Shortcuts** — each `ShortcutRoleSection` (Hold to Talk, Tap to Toggle, Paste Again) gets sub-card chrome: subtle `controlBackgroundColor` fill, 1pt primary stroke, 12pt padding. The existing focus state (blue tint + 2pt blue stroke) overlays cleanly on top.

**Edit Mode** — the Invocation Style picker plus the conditional Manual modifier picker now sit inside one titled sub-card. The whole sub-card dims as a unit when Edit Mode is off (replaces the inline opacity that only dimmed the inner Group).

**Clipboard** — the two features (preserve clipboard, press-enter voice command) each get their own un-titled sub-card. Replaces the horizontal Divider between them. Pictured above.

Introduces one reusable `SettingsSubcard` component for future re-use elsewhere.

## Files
- `Sources/ShortcutComponents.swift` — sub-card chrome on `ShortcutRoleSection`
- `Sources/SettingsView.swift` — `SettingsSubcard` component + Edit Mode + Clipboard sub-cards

## Test plan
- Open Settings → Dictation Shortcuts. Each role group renders inside its own card with subtle background fill and thin border.
- Click any shortcut row to focus it. Blue focus ring overlays cleanly on the sub-card chrome.
- Open Settings → Edit Mode. Invocation Style picker + Manual modifier picker (when Manual selected) both inside one titled sub-card. Toggle Edit Mode off — whole sub-card dims as a unit.
- Open Settings → Clipboard. Two un-titled sub-cards (preserve clipboard / press-enter voice command), no Divider between them.
- Cmd-Q the app, reopen. Sub-card layout stable on relaunch.

## Notes
No behavior change. Pure visual grouping. Dark mode handled automatically since all colors derive from system semantic tokens (`controlBackgroundColor`, `.primary` stroke).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced settings and shortcut sections with card-like styling and rounded appearance.
  * Improved visual feedback with focus-dependent background and stroke styling.

* **Refactor**
  * Standardized layout and appearance of smaller setting groups across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->