### PR TITLE
Improve disable-shortcut error: name which shortcut to enable instead

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1420,7 +1420,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let nextToggleShortcut = role == .toggle ? binding : toggleShortcut
         let otherBinding = role == .hold ? toggleShortcut : holdShortcut
         if binding.isDisabled && otherBinding.isDisabled {
-            return "At least one shortcut must remain enabled."
+            if role == .hold {
+                return "At least one shortcut must remain enabled. Turn on Tap to Toggle before disabling Hold to Talk."
+            } else {
+                return "At least one shortcut must remain enabled. Turn on Hold to Talk before disabling Tap to Toggle."
+            }
         }
         guard !binding.conflicts(with: otherBinding) else {
             return "Hold and tap shortcuts must be distinct."


### PR DESCRIPTION
## What happened

I was cleaning up my dictation shortcuts in Settings — disabled Hold to Talk because I only ever use Tap to Toggle. Later went back to swap Tap to Toggle to a different binding, and on the way through I tried to set Tap to Toggle to "Disabled" first. Got a red error label:

> At least one shortcut must remain enabled.

True statement, but no guidance. I had to think through what was happening: oh right, Hold to Talk is already off, so disabling Tap to Toggle would leave me with no dictation shortcut at all, and the app refuses. Took a moment to reconstruct, especially because the Hold to Talk row was scrolled off-screen at the time.

## The bug

The error states the constraint without naming the fix. The user has to mentally reconstruct which shortcut is currently the "one" that must remain enabled, and that they would need to re-enable the other one before this one can be disabled.

## Repro

1. Settings → Hold to Talk → Disabled
2. Settings → Tap to Toggle → Disabled
3. Red error: "At least one shortcut must remain enabled."

## The fix

Branch on `role` inside `setShortcut` and name both shortcuts and the action:

- Disabling Hold to Talk while Tap to Toggle is off → "At least one shortcut must remain enabled. Turn on Tap to Toggle before disabling Hold to Talk."
- Disabling Tap to Toggle while Hold to Talk is off → "At least one shortcut must remain enabled. Turn on Hold to Talk before disabling Tap to Toggle."

Same constraint, but now the user knows what to actually do.

<img src="https://assets.themarketingshow.com/bugs/freeflow/disable-error-message-2026-04-29.png" width="500" alt="Tap to Toggle picker showing Right Option selected with the new red error label naming both shortcuts">

## Files

`Sources/AppState.swift`, +5 / -1.

## Behavior

Zero change for any flow that does not hit the both-disabled branch. The new strings only appear in the case the original string already appeared in.

## Verified

Built locally on a daily-driver fork, exercised both directions of the disable flow at the keyboard, confirmed the picker shows the correct role-specific message in each direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when attempting to disable shortcuts, providing clearer guidance on which shortcut must remain enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->