### PR TITLE
Promote menu bar dropdown labels to Button rows for full contrast

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -10,11 +10,12 @@ struct MenuBarView: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            Text("\(AppName.displayName) v\(appVersion)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 4)
+            Button {
+                // Empty action: renders as a real menu item with full system contrast.
+            } label: {
+                Text("\(AppName.displayName) v\(appVersion)")
+                    .fontWeight(.bold)
+            }
 
             Divider()
 
@@ -65,11 +66,11 @@ struct MenuBarView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 6)
             } else {
-                Text(appState.shortcutStatusText)
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 6)
+                Button {
+                    // Same pattern as the version label.
+                } label: {
+                    Text(appState.shortcutStatusText)
+                }
             }
 
             Divider()
@@ -100,18 +101,21 @@ struct MenuBarView: View {
 
             if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
                 Divider()
-                Text(appState.lastTranscript.count > 35
-                    ? String(appState.lastTranscript.prefix(35)) + "…"
-                    : appState.lastTranscript)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 16)
-                    .lineLimit(4)
-                    .frame(maxWidth: 280, alignment: .leading)
 
                 Button("Copy Again") {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(appState.lastTranscript, forType: .string)
+                }
+
+                let truncatedTranscript = appState.lastTranscript.count > 35
+                    ? String(appState.lastTranscript.prefix(35)) + "…"
+                    : appState.lastTranscript
+                Button {
+                    // Same pattern as the version label.
+                } label: {
+                    Text("\u{201C}\(truncatedTranscript)\u{201D}")
+                        .lineLimit(4)
+                        .frame(maxWidth: 280, alignment: .leading)
                 }
             }
 


### PR DESCRIPTION
## What happened

I noticed the version line at the top of the menu bar dropdown rendered in muted grey, hard to read on a translucent background. Tried bumping it to bold black with `.foregroundStyle(.black)` — that worked in light mode and immediately broke dark mode (black-on-dark, worse than the muted grey it replaced). The literal `.black` was the wrong tool. The right tool is to let `NSMenu` render the row using its own system styling.

## The diagnosis

`MenuBarExtra` builds an `NSMenu`. When you put a bare `Text(...)` in the body, the `NSMenu` pipeline overrides `.foregroundStyle` and applies system "secondary header" grey — which is correct for annotations but wrong for primary information like the version label and the shortcut status row.

When the same row is wrapped in `Button { /* empty */ } label: { Text(...) }`, `NSMenu` styles it as a real `NSMenuItem` with full system text styling: true black on light, true white on dark. No color literals, no `if colorScheme == .dark` conditional, no manual color management. The OS appearance pipeline does the work.

## The fix

The same wrap pattern applied to three rows that currently render muted:

1. **Version label** at the top of the dropdown.
2. **Shortcut status row** ("Tap ⌥ → to dictate") below the permission warnings.
3. **Last-transcript preview row** above the Copy Again button.

Two adjacent UI tweaks in the same area:

4. **Curly quotes** wrap the truncated transcript text (`“like this”`) so it reads as the literal pasteboard content without needing a label.
5. **Copy Again** button moves above the quoted preview so the action sits above its target instead of below it.

## Visual proof

**Light mode** — version label renders bold black, status row clean black, Paste Again above the curly-quoted transcript:

<img src="https://assets.themarketingshow.com/bugs/freeflow/menu-bar-button-rows-light-2026-04-29.png" width="500" alt="Menu bar dropdown in light mode showing bold version label, status row, and Copy Again button above the curly-quoted transcript preview">

**Dark mode** (regression check) — same rows, all rendering in clean white-on-dark, NOT black-on-dark:

<img src="https://assets.themarketingshow.com/bugs/freeflow/menu-bar-button-rows-dark-2026-04-29.png" width="500" alt="Menu bar dropdown in dark mode showing the same rows in white text">

Note: the screenshots are from a personal fork that displays "FreeFlow James" as the bundle name. The styling code path is identical to upstream — the fork name does not affect Button-wrap behavior.

## Files

`Sources/MenuBarView.swift`, +22 / -18.

## Behavior

- Click on any of the three new no-action rows → menu closes (default `NSMenu` click-to-dismiss). No crash, no toggle, no side effect. Acceptable behavior for display-only rows.
- Modifier-key chord rendering, all other rows (Hold Shortcut menu, Tap Shortcut menu, audio device menu, Settings, Quit) — unchanged.

## Verified

- TC1 — Light mode contrast: version line bold black, status line clean black, transcript readable. ✓
- TC2 — Dark mode regression check: all three rows render white-on-dark, not black-on-dark. ✓
- TC3 — Curly quotes: truncated transcript renders as `“…”`. ✓
- TC4 — Click on no-action rows: menu closes, no side effect. ✓
- TC5 — Copy Again sits above the quoted transcript. ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Version label now displays with bold text weight
  * Transcript text now displays with quotation marks
  * Refined visual styling for status and transcript labels in the menu bar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->