### PR TITLE
Map transcription submission HTTP errors to one-line user messages

### DIFF
--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -112,12 +112,16 @@ class TranscriptionService {
             os_log(
                 .error,
                 log: transcriptionLog,
-                "URLSession upload returned HTTP %ld for %{public}@ (bytes=%{public}lld)",
+                "URLSession upload returned HTTP %ld for %{public}@ (bytes=%{public}lld) body=%{public}@",
                 httpResponse.statusCode,
                 fileURL.lastPathComponent,
-                fileSizeBytes(for: fileURL)
+                fileSizeBytes(for: fileURL),
+                responseBody
             )
-            throw TranscriptionError.submissionFailed("Status \(httpResponse.statusCode): \(responseBody)")
+            throw TranscriptionError.submissionFailed(Self.friendlyHTTPMessage(
+                status: httpResponse.statusCode,
+                host: baseURL.host
+            ))
         }
 
         return try parseTranscript(from: data)
@@ -177,6 +181,30 @@ class TranscriptionService {
 
         return body
     }
+
+    /// Map a non-200 HTTP status into a one-line user-readable message.
+    /// Used for transcription submission failures so the menu bar shows
+    /// "Invalid API key for api.openai.com" instead of raw JSON.
+    static func friendlyHTTPMessage(status: Int, host: String?) -> String {
+        let provider = host ?? "the provider"
+        switch status {
+        case 401:
+            return "Invalid API key for \(provider). Open Settings to fix it."
+        case 403:
+            return "Key lacks permission for this endpoint at \(provider) (HTTP 403). Check the key's scopes."
+        case 404:
+            return "Endpoint not found at \(provider) (HTTP 404). Base URL is likely wrong for this provider."
+        case 413:
+            return "Audio file too large for \(provider) (HTTP 413). Try a shorter recording."
+        case 429:
+            return "Rate limit reached at \(provider) (HTTP 429). Wait a moment and try again."
+        case 500..<600:
+            return "Provider error at \(provider) (HTTP \(status)). Try again in a moment."
+        default:
+            return "Request failed at \(provider) (HTTP \(status))."
+        }
+    }
+
     private static func normalizedBaseURL(from baseURL: String) throws -> URL {
         let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {


### PR DESCRIPTION
## What happened

I had Settings configured for one provider, then realized I needed to swap to a different provider with a different API key. I pasted the new key into the configured Base URL field (still pointing at the OLD provider), forgot to update the URL too, and recorded a clip. The transcription failed.

The menu bar dropdown then showed me this:

<img src="https://assets.themarketingshow.com/bugs/freeflow/transcription-401-raw-json-2026-04-27.png" width="600" alt="Menu bar dropdown showing the raw 401 JSON error mid-truncated as a single line">

Mid-truncated raw JSON in a dropdown that has ~280pt of horizontal room. Took a moment to figure out it was an auth problem and not a network problem, and longer to figure out the fix (Base URL was wrong for the key). The raw provider error is fine for a log file but wrong for a menu bar.

## The fix

Adds `TranscriptionService.friendlyHTTPMessage(status:host:)` mapping the most common non-200 codes to one-line messages that name the provider host and say what to do. The submission failure path uses it, the raw body still goes to `os_log` for debugging.

| Status | New message |
|---|---|
| 401 | `Invalid API key for <host>. Open Settings to fix it.` |
| 403 | `Key lacks permission for this endpoint at <host> (HTTP 403). Check the key's scopes.` |
| 404 | `Endpoint not found at <host> (HTTP 404). Base URL is likely wrong for this provider.` |
| 413 | `Audio file too large for <host> (HTTP 413). Try a shorter recording.` |
| 429 | `Rate limit reached at <host> (HTTP 429). Wait a moment and try again.` |
| 5xx | `Provider error at <host> (HTTP <code>). Try again in a moment.` |
| other | `Request failed at <host> (HTTP <code>).` |

The 401 message names the most common cause (wrong key) and points the user at Settings, which is where they fix it. The 404 message specifically calls out the Base-URL-for-wrong-provider case because that is the easy mistake to make when juggling providers.

## Files

`Sources/TranscriptionService.swift`, +31 / -3.

## Behavior

- **Submission success path** — unchanged.
- **Submission failure path** — the throw now carries a one-line readable message; the raw response body is no longer in the user-facing string. It IS still in `os_log` (one extra `body=...` field) so debugging is unaffected.
- **All other call sites** — unchanged.

## Verified

- 401 — pasted a wrong key, confirmed the menu bar shows the new one-liner instead of raw JSON. ✓
- The raw response body is still visible via `log show --predicate 'subsystem == "com.zachlatta.freeflow.dev"'`. ✓
- 200 path (normal transcription) — unchanged. ✓

By inspection (not exercised at the keyboard): 403, 404, 413, 429, 5xx, default cases all return through the same throw. Switch is exhaustive over the documented status families.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transcription submission error messages are now user-friendly and context-aware, providing specific guidance for common issues while improving error logging accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->