### PR TITLE
Default to a minimalist menu-bar recording overlay (drop-down via config)

### DIFF
--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -209,20 +209,42 @@ final class RecordingOverlayManager {
     }
 
     private func makeOverlayContent(frame: NSRect) -> NSView {
-        makeNotchContent(
+        if useWingedLayout {
+            // Winged layout: notch x-range stays solid black so the cutout masks it.
+            let rootView = WingedRecordingView(
+                state: overlayState,
+                leftWingWidth: Self.leftWingWidth,
+                notchWidth: notchWidth,
+                rightWingWidth: Self.rightWingWidth,
+                height: frame.height,
+                onStopButtonPressed: { [weak self] in
+                    self?.onStopButtonPressed?()
+                }
+            )
+            return makeNotchContent(
+                width: frame.width,
+                height: frame.height,
+                cornerRadius: 14,
+                rootView: AnyView(rootView)
+            )
+        }
+
+        return makeNotchContent(
             width: frame.width,
             height: frame.height,
             cornerRadius: screenHasNotch ? 18 : 12,
-            rootView: RecordingOverlayView(
-                state: overlayState,
-                onStopButtonPressed: { [weak self] in
-                    self?.onStopButtonPressed?()
-                },
-                onUpdateOverlayPressed: { [weak self] in
-                    self?.onUpdateOverlayPressed?()
-                }
+            rootView: AnyView(
+                RecordingOverlayView(
+                    state: overlayState,
+                    onStopButtonPressed: { [weak self] in
+                        self?.onStopButtonPressed?()
+                    },
+                    onUpdateOverlayPressed: { [weak self] in
+                        self?.onUpdateOverlayPressed?()
+                    }
+                )
+                .padding(.top, screenHasNotch ? notchOverlap : 0)
             )
-            .padding(.top, screenHasNotch ? notchOverlap : 0)
         )
     }
 
@@ -239,8 +261,44 @@ final class RecordingOverlayManager {
         }
     }
 
+    /// True iff the overlay renders as wings flanking the notch (notched display
+    /// + use_compact_overlay on). updateAvailable still uses the drop-down pill.
+    private var useWingedLayout: Bool {
+        guard screenHasNotch else { return false }
+        let useCompact = (UserDefaults.standard.object(forKey: "use_compact_overlay") as? Bool) ?? true
+        guard useCompact else { return false }
+        switch overlayState.phase {
+        case .recording, .initializing, .transcribing, .feedback:
+            return true
+        case .updateAvailable:
+            return false
+        }
+    }
+
+    /// Wing width — tight to the compact waveform / stop button so the
+    /// panel stays clear of right-side menu-bar items.
+    static let wingWidth: CGFloat = 36
+    static let leftWingWidth: CGFloat = wingWidth
+    static let rightWingWidth: CGFloat = wingWidth
+
     private var overlayFrame: NSRect {
         guard let screen = NSScreen.main else { return .zero }
+
+        if useWingedLayout {
+            // Anchor to the screen's auxiliary-area boundaries of the notch;
+            // panel height matches the menu-bar overlap so nothing protrudes below.
+            let nWidth = notchWidth
+            let nLeftX = screen.auxiliaryTopLeftArea?.maxX
+                ?? (screen.frame.midX - nWidth / 2)
+            let leftWing = Self.leftWingWidth
+            let rightWing = Self.rightWingWidth
+            let panelHeight = notchOverlap
+            let panelWidth = leftWing + nWidth + rightWing
+            let panelX = nLeftX - leftWing
+            let panelY = screen.frame.maxY - panelHeight
+            return NSRect(x: panelX, y: panelY, width: panelWidth, height: panelHeight)
+        }
+
         let width = overlayWidth
         let overlap = screenHasNotch ? notchOverlap : 0
         let height: CGFloat = 38 + overlap
@@ -300,13 +358,102 @@ final class RecordingOverlayManager {
     }
 }
 
+// MARK: - Winged Recording View
+
+/// Wing layout: waveform left, stop button right, solid-black notch in the middle
+/// (the camera cutout masks those pixels).
+struct WingedRecordingView: View {
+    @ObservedObject var state: RecordingOverlayState
+    let leftWingWidth: CGFloat
+    let notchWidth: CGFloat
+    let rightWingWidth: CGFloat
+    let height: CGFloat
+    let onStopButtonPressed: () -> Void
+
+    private var showsLiveRecordingContent: Bool {
+        state.phase == .recording
+    }
+
+    private var showsStopButton: Bool {
+        showsLiveRecordingContent && state.recordingTriggerMode == .toggle
+    }
+
+    var body: some View {
+        wingsHStack
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(.spring(response: 0.28, dampingFraction: 1.0), value: state.phase)
+    }
+
+    private var wingsHStack: some View {
+        HStack(spacing: 0) {
+            // Left wing — empty during feedback so the right-wing X reads as the sole signal.
+            HStack {
+                Spacer(minLength: 0)
+                Group {
+                    if state.phase == .feedback {
+                        Color.clear
+                    } else if state.phase == .initializing {
+                        InitializingDotsView()
+                            .transition(.opacity)
+                    } else if showsLiveRecordingContent {
+                        CompactWaveformView(
+                            audioLevel: state.audioLevel,
+                            showsActivityPulse: state.phase == .recording
+                        )
+                        .transition(.opacity)
+                    } else {
+                        CompactProcessingIndicatorView()
+                            .transition(.opacity)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .frame(width: leftWingWidth, height: height)
+
+            // Notch spacer — solid black; camera cutout hides it.
+            Color.black
+                .frame(width: notchWidth, height: height)
+
+            // Right wing — stop button (recording) OR failure X (feedback),
+            // horizontally centered.
+            HStack {
+                Spacer(minLength: 0)
+                Group {
+                    if state.phase == .feedback {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 7, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 14, height: 14)
+                            .background(Circle().fill(Color.red.opacity(0.92)))
+                            .transition(.opacity)
+                    } else if showsStopButton {
+                        Button(action: onStopButtonPressed) {
+                            Image(systemName: "stop.fill")
+                                .font(.system(size: 7, weight: .bold))
+                                .foregroundStyle(.white)
+                                .frame(width: 14, height: 14)
+                                .background(Circle().fill(Color.red.opacity(0.92)))
+                        }
+                        .buttonStyle(.plain)
+                        .transition(.opacity)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .frame(width: rightWingWidth, height: height)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.spring(response: 0.28, dampingFraction: 1.0), value: state.phase)
+    }
+}
+
 // MARK: - Waveform Views
 
 struct WaveformBar: View {
     let amplitude: CGFloat
 
     private let minHeight: CGFloat = 2
-    private let maxHeight: CGFloat = 20
+    private let maxHeight: CGFloat = 22
 
     var body: some View {
         Capsule()
@@ -333,7 +480,7 @@ struct WaveformView: View {
                 waveformBars(pulseTime: nil)
             }
         }
-        .frame(height: 20)
+        .frame(height: 24)
     }
 
     private func waveformBars(pulseTime: TimeInterval?) -> some View {
@@ -376,6 +523,65 @@ struct WaveformView: View {
     private func barDelay(for index: Int) -> Double {
         let distance = abs(CGFloat(index) - Self.centerIndex)
         return Double(distance) * 0.01
+    }
+}
+
+/// Tighter 5-bar waveform sized for the 36pt wing layout.
+struct CompactWaveformView: View {
+    let audioLevel: Float
+    var showsActivityPulse = false
+
+    private static let barCount = 5
+    private static let multipliers: [CGFloat] = [0.5, 0.75, 1.0, 0.75, 0.5]
+    private static let centerIndex = CGFloat((barCount - 1) / 2)
+
+    var body: some View {
+        Group {
+            if showsActivityPulse {
+                TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
+                    bars(pulseTime: context.date.timeIntervalSinceReferenceDate)
+                }
+            } else {
+                bars(pulseTime: nil)
+            }
+        }
+        .frame(height: 18)
+    }
+
+    private func bars(pulseTime: TimeInterval?) -> some View {
+        HStack(spacing: 1.5) {
+            ForEach(0..<Self.barCount, id: \.self) { index in
+                CompactWaveformBar(amplitude: amplitude(for: index, pulseTime: pulseTime))
+                    .animation(
+                        .spring(response: 0.18, dampingFraction: 0.88),
+                        value: audioLevel
+                    )
+            }
+        }
+    }
+
+    private func amplitude(for index: Int, pulseTime: TimeInterval?) -> CGFloat {
+        let level = CGFloat(max(audioLevel, 0))
+        let base = min(level * Self.multipliers[index], 1.0)
+        guard let pulseTime else { return base }
+        let traveling = CGFloat(0.5 + 0.5 * sin((pulseTime * 6.2) - Double(index) * 0.78))
+        let shimmer = CGFloat(0.5 + 0.5 * sin((pulseTime * 3.1) + Double(index) * 0.5))
+        let pulse = traveling * 0.22 + shimmer * 0.06
+        let saturationRelief = base * (0.74 + pulse)
+        let quietPulse = (1.0 - base) * (0.04 + pulse * 0.28)
+        return min(saturationRelief + quietPulse, 1.0)
+    }
+}
+
+struct CompactWaveformBar: View {
+    let amplitude: CGFloat
+    private let minHeight: CGFloat = 2
+    private let maxHeight: CGFloat = 14
+
+    var body: some View {
+        Capsule()
+            .fill(.white)
+            .frame(width: 2, height: minHeight + (maxHeight - minHeight) * amplitude)
     }
 }
 
@@ -452,7 +658,7 @@ struct ProcessingIndicatorView: View {
                     .rotationEffect(.degrees(rotation))
                     .frame(height: 20)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .transition(.opacity.combined(with: .scale(scale: 0.92)))
+                    .transition(.opacity)
                     .onAppear {
                         rotation = 0
                         withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
@@ -461,7 +667,7 @@ struct ProcessingIndicatorView: View {
                     }
             } else {
                 ProcessingWaveformView()
-                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                    .transition(.opacity)
             }
         }
         .task {
@@ -474,6 +680,107 @@ struct ProcessingIndicatorView: View {
                 }
             } catch {}
         }
+    }
+}
+
+/// Same hybrid waveform-then-spinner as `ProcessingIndicatorView`, sized to
+/// fit the 18pt winged menu-bar overlay. Uses tighter pills and a smaller
+/// spinner so the indicator stays inside the wing without the jolt to
+/// oversized capsules that the full-size indicator produced.
+struct CompactProcessingIndicatorView: View {
+    @State private var showsExtendedSpinner = false
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        ZStack {
+            if showsExtendedSpinner {
+                Circle()
+                    .trim(from: 0.1, to: 0.9)
+                    .stroke(Color.white, style: StrokeStyle(lineWidth: 2.0, lineCap: .round))
+                    .frame(width: 12, height: 12)
+                    .rotationEffect(.degrees(rotation))
+                    .frame(height: 18)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .transition(.opacity)
+                    .onAppear {
+                        rotation = 0
+                        withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
+                            rotation = 360
+                        }
+                    }
+            } else {
+                CompactProcessingWaveformView()
+                    .transition(.opacity)
+            }
+        }
+        .task {
+            showsExtendedSpinner = false
+            do {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    showsExtendedSpinner = true
+                }
+            } catch {}
+        }
+    }
+}
+
+struct CompactProcessingWaveformView: View {
+    private static let barCount = 5
+    private static let centerIndex = CGFloat((barCount - 1) / 2)
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
+            let time = context.date.timeIntervalSinceReferenceDate
+            HStack(spacing: 2) {
+                ForEach(0..<Self.barCount, id: \.self) { index in
+                    CompactProcessingPill(
+                        amplitude: amplitude(for: index, time: time),
+                        opacity: opacity(for: index, time: time)
+                    )
+                }
+            }
+            .frame(height: 18)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func phase(for index: Int, time: TimeInterval) -> Double {
+        let cycle = 1.05
+        let stagger = 0.11
+        return ((time - Double(index) * stagger).truncatingRemainder(dividingBy: cycle)) / cycle
+    }
+
+    private func pulse(for index: Int, time: TimeInterval) -> CGFloat {
+        let phase = phase(for: index, time: time)
+        let wave = 0.5 + 0.5 * sin((phase * 2.0 * .pi) - (.pi / 2.0))
+        return CGFloat(pow(wave, 1.9))
+    }
+
+    private func amplitude(for index: Int, time: TimeInterval) -> CGFloat {
+        let centerDistance = abs(CGFloat(index) - Self.centerIndex) / Self.centerIndex
+        let baseline = 0.18 + (1.0 - centerDistance) * 0.1
+        return min(baseline + pulse(for: index, time: time) * 0.68, 1.0)
+    }
+
+    private func opacity(for index: Int, time: TimeInterval) -> CGFloat {
+        0.42 + pulse(for: index, time: time) * 0.52
+    }
+}
+
+private struct CompactProcessingPill: View {
+    let amplitude: CGFloat
+    let opacity: CGFloat
+
+    private let minHeight: CGFloat = 2
+    private let maxHeight: CGFloat = 12
+
+    var body: some View {
+        Capsule()
+            .fill(.white)
+            .frame(width: 2, height: minHeight + (maxHeight - minHeight) * amplitude)
+            .opacity(opacity)
     }
 }
 
@@ -541,7 +848,7 @@ struct RecordingOverlayView: View {
                                 .transition(.opacity)
                         } else {
                             ProcessingIndicatorView()
-                                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                                .transition(.opacity)
                         }
                     }
 
@@ -549,7 +856,7 @@ struct RecordingOverlayView: View {
                         Group {
                             if state.isCommandMode {
                                 CommandModeIndicator()
-                                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                                    .transition(.opacity)
                             }
                         }
                         .frame(width: leadingAccessoryWidth, alignment: .center)
@@ -561,9 +868,9 @@ struct RecordingOverlayView: View {
                             if showsStopButton {
                                 Button(action: onStopButtonPressed) {
                                     Image(systemName: "stop.fill")
-                                        .font(.system(size: 9, weight: .bold))
+                                        .font(.system(size: 7, weight: .bold))
                                         .foregroundStyle(.white)
-                                        .frame(width: 20, height: 20)
+                                        .frame(width: 14, height: 14)
                                         .background(Circle().fill(Color.red.opacity(0.92)))
                                 }
                                 .buttonStyle(.plain)
@@ -577,9 +884,9 @@ struct RecordingOverlayView: View {
         }
         .padding(.horizontal, 12)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.phase)
-        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
-        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
+        .animation(.spring(response: 0.28, dampingFraction: 1.0), value: state.phase)
+        .animation(.spring(response: 0.28, dampingFraction: 1.0), value: state.recordingTriggerMode)
+        .animation(.spring(response: 0.28, dampingFraction: 1.0), value: state.isCommandMode)
     }
 }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -300,8 +300,13 @@ final class RecordingOverlayManager {
         }
 
         let width = overlayWidth
-        let overlap = screenHasNotch ? notchOverlap : 0
-        let height: CGFloat = 38 + overlap
+        let useCompact = (UserDefaults.standard.object(forKey: "use_compact_overlay") as? Bool) ?? true
+        // Compact mode: overlay sits flush with the menu bar on every display.
+        // notchOverlap equals the menu-bar height on non-notched screens too,
+        // so zero protrusion is universal — not notch-only. The legacy
+        // 38pt drop-down pill remains available when use_compact_overlay
+        // is explicitly toggled off.
+        let height: CGFloat = useCompact ? notchOverlap : 38 + (screenHasNotch ? notchOverlap : 0)
         let x = screen.frame.midX - width / 2
         let y = screen.frame.maxY - height
         return NSRect(x: x, y: y, width: width, height: height)
@@ -396,10 +401,23 @@ struct WingedRecordingView: View {
                         InitializingDotsView()
                             .transition(.opacity)
                     } else if showsLiveRecordingContent {
-                        CompactWaveformView(
-                            audioLevel: state.audioLevel,
-                            showsActivityPulse: state.phase == .recording
-                        )
+                        // Command-mode pencil sits directly above and centered
+                        // over the compact waveform inside the same wing
+                        // rectangle. Closes the gap between pill and winged
+                        // layouts: pill users already see a pencil during
+                        // command-mode dictation; winged users now do too.
+                        VStack(spacing: 1) {
+                            if state.isCommandMode {
+                                Image(systemName: "pencil")
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .foregroundStyle(.white.opacity(0.92))
+                                    .transition(.opacity)
+                            }
+                            CompactWaveformView(
+                                audioLevel: state.audioLevel,
+                                showsActivityPulse: state.phase == .recording
+                            )
+                        }
                         .transition(.opacity)
                     } else {
                         CompactProcessingIndicatorView()

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -516,6 +516,7 @@ struct GeneralSettingsView: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.openURL) private var openURL
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
+    @AppStorage("use_compact_overlay") private var useCompactOverlay = true
     @State private var apiKeyInput: String = ""
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
@@ -705,6 +706,9 @@ struct GeneralSettingsView: View {
                 }
                 SettingsCard("Audio During Dictation", icon: "speaker.slash.fill") {
                     dictationAudioSection
+                }
+                SettingsCard("Recording Overlay", icon: "rectangle.dashed") {
+                    overlaySection
                 }
                 SettingsCard("Edit Mode", icon: "pencil") {
                     commandModeSection
@@ -1093,6 +1097,27 @@ struct GeneralSettingsView: View {
             }
         }
     }
+
+    // MARK: Recording Overlay
+
+    private var overlaySection: some View {
+        VStack(spacing: 10) {
+            OverlayStyleOptionRow(
+                title: "Minimalist menu-bar overlay",
+                subtitle: "Two slim wings flank the camera notch and stay inside the menu bar. Never covers app tabs or toolbars.",
+                isMinimalist: true,
+                selection: $useCompactOverlay
+            )
+            OverlayStyleOptionRow(
+                title: "Drop-down pill",
+                subtitle: "Single pill hangs below the menu bar during recording. Larger and more visible, but covers a thin strip of whatever app is active.",
+                isMinimalist: false,
+                selection: $useCompactOverlay
+            )
+        }
+    }
+
+    // MARK: Audio During Dictation
 
     private var dictationAudioSection: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -66,6 +66,7 @@ struct SetupView: View {
         case commandMode
         case vocabulary
         case launchAtLogin
+        case overlayStyle
         case testTranscription
         case ready
     }
@@ -101,6 +102,7 @@ struct SetupView: View {
     @State private var isCapturingHoldShortcut = false
     @State private var isCapturingToggleShortcut = false
     @StateObject private var testHotkeyHarness = SetupTestHotkeyHarness()
+    @AppStorage("use_compact_overlay") private var useCompactOverlay = true
 
     private let totalSteps: [SetupStep] = SetupStep.allCases
     private var isCapturingShortcut: Bool {
@@ -244,6 +246,8 @@ struct SetupView: View {
             commandModeStep
         case .vocabulary:
             vocabularyStep
+        case .overlayStyle:
+            overlayStyleStep
         case .launchAtLogin:
             launchAtLoginStep
         case .testTranscription:
@@ -814,6 +818,39 @@ struct SetupView: View {
             .background(Color(nsColor: .controlBackgroundColor))
             .cornerRadius(8)
 
+        }
+    }
+
+    var overlayStyleStep: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "rectangle.dashed")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue)
+
+            Text("Recording overlay style")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Choose how the recording indicator looks while \(AppName.displayName) is dictating. You can change this later in Settings.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 10) {
+                OverlayStyleOptionRow(
+                    title: "Minimalist menu-bar overlay",
+                    subtitle: "Two slim wings flank the camera notch and stay inside the menu bar. Never covers app tabs or toolbars.",
+                    isMinimalist: true,
+                    selection: $useCompactOverlay
+                )
+                OverlayStyleOptionRow(
+                    title: "Drop-down pill",
+                    subtitle: "Single pill hangs below the menu bar during recording. Larger and more visible, but covers a thin strip of whatever app is active.",
+                    isMinimalist: false,
+                    selection: $useCompactOverlay
+                )
+            }
+            .padding(.top, 6)
         }
     }
 
@@ -1438,5 +1475,135 @@ struct HowToRow: View {
             Text(text)
                 .foregroundStyle(.secondary)
         }
+    }
+}
+
+/// Mini visual preview of one overlay style for the setup-flow option cards.
+/// Stylized MacBook top edge with the recording UI drawn as wings or pill.
+struct OverlayStylePreview: View {
+    let isMinimalist: Bool
+
+    private let frameWidth: CGFloat = 110
+    private let frameHeight: CGFloat = 56
+    private let menuBarHeight: CGFloat = 8
+    private let notchWidth: CGFloat = 26
+    private let notchHeight: CGFloat = 8
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            // Screen background — represents the host app behind the bar.
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color(nsColor: .windowBackgroundColor))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)
+                )
+
+            // Menu bar strip.
+            Rectangle()
+                .fill(Color.primary.opacity(0.10))
+                .frame(height: menuBarHeight)
+
+            // Tab strip stand-in below menu bar (so collisions read).
+            HStack(spacing: 3) {
+                ForEach(0..<5, id: \.self) { _ in
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(Color.primary.opacity(0.18))
+                        .frame(height: 5)
+                }
+            }
+            .padding(.horizontal, 6)
+            .padding(.top, menuBarHeight + 4)
+
+            // Notch (always visible).
+            UnevenRoundedRectangle(
+                topLeadingRadius: 0,
+                bottomLeadingRadius: 3,
+                bottomTrailingRadius: 3,
+                topTrailingRadius: 0
+            )
+            .fill(Color.black)
+            .frame(width: notchWidth, height: notchHeight)
+
+            // Style-specific overlay rendering.
+            if isMinimalist {
+                // Two slim wings flanking the notch, inside menu bar height.
+                HStack(spacing: notchWidth) {
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: 3,
+                        bottomTrailingRadius: 0,
+                        topTrailingRadius: 0
+                    )
+                    .fill(Color.black)
+                    .frame(width: 16, height: notchHeight)
+
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: 0,
+                        bottomTrailingRadius: 3,
+                        topTrailingRadius: 0
+                    )
+                    .fill(Color.black)
+                    .frame(width: 16, height: notchHeight)
+                }
+            } else {
+                // Drop-down pill hanging below the menu bar from the notch.
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: 5,
+                    bottomTrailingRadius: 5,
+                    topTrailingRadius: 0
+                )
+                .fill(Color.black)
+                .frame(width: notchWidth + 10, height: notchHeight + 12)
+            }
+        }
+        .frame(width: frameWidth, height: frameHeight)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+/// Shared picker row used by both Setup and Settings so the UI matches in both.
+struct OverlayStyleOptionRow: View {
+    let title: String
+    let subtitle: String
+    let isMinimalist: Bool
+    @Binding var selection: Bool
+
+    var body: some View {
+        let isSelected = (selection == isMinimalist)
+        Button(action: {
+            selection = isMinimalist
+        }) {
+            HStack(alignment: .center, spacing: 14) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isSelected ? Color.blue : Color.secondary)
+
+                OverlayStylePreview(isMinimalist: isMinimalist)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
## What happened

The recording indicator should stay out of the way during dictation. The drop-down pill works but hangs below the menu bar and covers the active app's tab bar or browser toolbar throughout the recording session. The user is dictating into that exact area, so the indicator competes with primary work content.

Modern notched MacBooks have dead space on either side of the camera notch. This overlay uses that space, sitting at the same height as the standard menu bar instead of dropping below it. No protrusion.

**This becomes the new default.** The drop-down pill is preserved as a configuration option in Settings and the Setup wizard for users who prefer it.

## Side-by-side: same app, same moment, different overlay

**Original drop-down pill** (now the alternative): hangs below the menu bar, partially covering the VS Code tab title.

<img src="https://assets.themarketingshow.com/bugs/freeflow/recording-overlay-pill-live-2026-04-29.png" width="700" alt="Drop-down recording pill hanging below the menu bar and partially covering the active VS Code tab title">

**New default** (minimalist menu-bar overlay): two slim panels flank the camera notch at menu-bar height. Same VS Code tab fully visible.

<img src="https://assets.themarketingshow.com/bugs/freeflow/recording-overlay-wings-live-2026-04-29.png" width="700" alt="Minimalist recording overlay flanking the camera notch at menu-bar height with the VS Code tab fully visible underneath">

## How the picker looks

**Setup wizard** — a new "Recording overlay style" step between Launch at Login and Test Transcription. Two preview cards with mini visual mock-ups; minimalist is selected as the default.

<img src="https://assets.themarketingshow.com/bugs/freeflow/recording-overlay-setup-wizard-2026-04-29.png" width="500" alt="Setup wizard step titled Recording overlay style with two preview cards showing the minimalist and drop-down pill options">

**Settings → Recording Overlay** — same picker, shared component (`OverlayStyleOptionRow`).

<img src="https://assets.themarketingshow.com/bugs/freeflow/recording-overlay-settings-picker-2026-04-29.png" width="500" alt="Settings page showing the Recording Overlay card with the same two-option picker as the Setup wizard">

## How it works

The two panels are anchored to the auxiliary-area boundaries of the camera notch and are exactly the menu-bar overlap tall. Zero protrusion below the menu bar. The notch x-range inside the panel renders solid black; the camera cutout naturally masks those pixels, producing the visual of two flanks around the notch without any per-machine geometry math.

A new `CompactWaveformView` (5 bars instead of 9, max bar height 14pt) fits the 36pt panel width. Stop button shrinks from the original to 14×14 to match. Same animation logic as `WaveformView`, just smaller dimensions.

## Default-flag rationale

`use_compact_overlay` defaults to `true` in `@AppStorage` and in the `UserDefaults` read on first launch. Existing users on the next update will see the new style. The drop-down pill is one click away in Settings → Recording Overlay (or during Re-run Setup). The default-flip is opinionated: on a notched MacBook the new style is strictly less disruptive — the indicator never overlaps work content. Users who explicitly prefer the older, more visible drop-down can switch in two clicks.

## Fallback behavior

- **Non-notched displays** — wings have nothing to flank, so the overlay falls back to the drop-down pill regardless of setting (`useWingedLayout` returns false).
- **Update-available state** — stays as the drop-down pill because its "Update Available" label is wider than a single panel can hold. After the update phase clears, recording-state overlays return to wings.
- **Failure feedback** — an X indicator appears on the right panel during the failure feedback phase.

## Files

`Sources/RecordingOverlay.swift`, `Sources/SettingsView.swift`, `Sources/SetupView.swift`. +439 / -13.

## Verified

- TC1 — Setup wizard shows the new "Recording overlay style" step between Launch at Login and Test Transcription. Both preview cards render their mini mock-ups. ✓
- TC2 — Settings shows the same picker as the wizard, shared component. ✓
- TC3 — Wings render flanking the notch during recording on a notched MacBook. Compact waveform left, stop button right. No protrusion below menu bar. ✓
- TC4 — Wings setting off shows the drop-down pill at full 38pt height. ✓
- TC5 — Failure feedback X appears on the right wing during the feedback phase. ✓
- TC6 — Update-available phase reverts to the drop-down pill, returns to wings after the update phase clears. ✓ (by inspection)
- TC7 — Non-notched display falls back to the drop-down pill even with the wings setting on. ✓ (by inspection — no non-notched display available for keyboard exercise)
- TC8 — A user on the new default sees no extra config required; an existing user can flip back via Settings in two clicks. ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two selectable recording overlay styles: "Minimalist menu-bar overlay" and "Drop-down pill", added to onboarding and General settings.
  * New compact "winged" overlay for notched displays with a centered black notch spacer.

* **Improvements**
  * Denser compact waveform and processing visuals and a smaller stop control for a clearer, more compact recording UI.
  * Smoother transitions and refined animation timing across overlay states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->