### PR TITLE
Add recent contributors avatar row to welcome screen above stargazers

### DIFF
--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -327,6 +327,39 @@ struct SetupView: View {
                     .buttonStyle(.plain)
                 }
 
+                if !githubCache.recentContributors.isEmpty {
+                    Divider()
+                    HStack(spacing: 8) {
+                        HStack(spacing: -6) {
+                            ForEach(githubCache.recentContributors) { contributor in
+                                Button {
+                                    openURL(contributor.htmlUrl)
+                                } label: {
+                                    AsyncImage(url: contributor.avatarThumbnailUrl) { phase in
+                                        switch phase {
+                                        case .success(let image):
+                                            image.resizable().aspectRatio(contentMode: .fill)
+                                        default:
+                                            Color.gray.opacity(0.2)
+                                        }
+                                    }
+                                    .frame(width: 22, height: 22)
+                                    .clipShape(Circle())
+                                    .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .clipped()
+                        Text("recent contributors")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .fixedSize()
+                        Spacer()
+                    }
+                    .clipped()
+                }
+
                 if !githubCache.recentStargazers.isEmpty {
                     Divider()
                     HStack(spacing: 8) {
@@ -1317,12 +1350,32 @@ struct GitHubStarUser: Decodable {
     }
 }
 
+struct GitHubContributor: Decodable, Identifiable {
+    let id: Int
+    let login: String
+    let avatarUrl: URL
+    let htmlUrl: URL
+
+    var avatarThumbnailUrl: URL {
+        let separator = avatarUrl.absoluteString.contains("?") ? "&" : "?"
+        return URL(string: avatarUrl.absoluteString + "\(separator)s=44") ?? avatarUrl
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case login
+        case avatarUrl = "avatar_url"
+        case htmlUrl = "html_url"
+    }
+}
+
 @MainActor
 class GitHubMetadataCache: ObservableObject {
     static let shared = GitHubMetadataCache()
 
     @Published var starCount: Int?
     @Published var recentStargazers: [GitHubStarRecord] = []
+    @Published var recentContributors: [GitHubContributor] = []
     @Published var isLoading = true
 
     private var lastFetchDate: Date?
@@ -1361,8 +1414,17 @@ class GitHubMetadataCache: ObservableObject {
                 }
             }
 
+            var contributors: [GitHubContributor] = []
+            let contributorsURL = URL(string: "https://api.github.com/repos/zachlatta/freeflow/contributors?per_page=15")!
+            let contributorsResult = try await URLSession.shared.data(from: contributorsURL)
+            if let contribHTTP = contributorsResult.1 as? HTTPURLResponse,
+               (200..<300).contains(contribHTTP.statusCode) {
+                contributors = (try? JSONDecoder().decode([GitHubContributor].self, from: contributorsResult.0)) ?? []
+            }
+
             starCount = count
             recentStargazers = recent
+            recentContributors = contributors
             isLoading = false
             lastFetchDate = Date()
         } catch {


### PR DESCRIPTION
## What

The welcome card already shows a "recently starred" avatar row under the GitHub repo box. This adds a second avatar row above it: "recent contributors." Stargazers clicked a button. Contributors shipped code. Both deserve a spot, so this version keeps both.

**Before** (current upstream — just stargazers):

<img src="https://assets.themarketingshow.com/bugs/freeflow/welcome-card-stargazers-only-cropped-2026-04-29.png" width="600" alt="Welcome card showing only the recently-starred avatar row under the GitHub repo box">

**After** (this PR — contributors above stargazers):

<img src="https://assets.themarketingshow.com/bugs/freeflow/welcome-card-both-rows-cropped-2026-04-29.png" width="600" alt="Welcome card showing two avatar rows: recent contributors above, recently starred below">

## Why

Stargazers and contributors are different communities. Right now the welcome screen acknowledges only the first one. Felt off that the people who actually shipped the code that runs in front of every new user got no spotlight on the welcome screen.

(The companion PR (replacement variant) — #161 — tags the contributors directly so they get pinged. This one keeps it tag-free since the existing stargazers row stays, so the framing is additive rather than spotlighting any one group.)

## How

- New `GitHubContributor` Decodable + Identifiable struct alongside the existing `GitHubStarUser`.
- New `recentContributors` `@Published` property on `GitHubMetadataCache`.
- Fetch from `/repos/zachlatta/freeflow/contributors?per_page=15` in `fetchIfNeeded()`.
- HStack of avatar buttons rendered above the existing stargazers HStack inside the welcome card. Click any avatar to open that contributor's GitHub profile via `openURL`.

Same row pattern as the existing stargazer avatars: 22pt circles, -6pt overlap, caption-2 caption font. Visually consistent.

## Companion PR

This is the additive variant. If you would rather DROP the stargazers row entirely and keep just contributors, see the companion PR (replacement variant) #161 — same contributors-row code, plus one extra deletion. Pick whichever fits your taste, or neither.

## Files

`Sources/SetupView.swift`, +62 / -0.

## Behavior

- **Network failure / GitHub API down** — empty `recentContributors` array. The `if !.isEmpty` guard hides the row cleanly. Same fallback as the existing stargazers row.
- **All other surfaces** — unchanged.

## Verified

- Welcome screen shows two avatar rows under the repo box: contributors above, recently-starred below. ✓
- Click a contributor avatar — that user's GitHub profile opens in the default browser. ✓
- Cache reload (relaunch the app) does not crash; both rows reload independently. ✓
- Star count badge above the rows continues to render using `recentStargazers.count`. ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added a recent contributors section displaying clickable contributor avatars in the setup view
- Contributor avatars link to contributor profiles
- Recent contributors are fetched from GitHub and populate automatically when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->