### PR TITLE
Replace recently-starred avatar row with recent contributors row

### DIFF
--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -348,6 +348,8 @@ struct SetupView: View {
                                     .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
                                 }
                                 .buttonStyle(.plain)
+                                .accessibilityLabel(Text(contributor.login))
+                                .accessibilityHint(Text("Open contributor profile"))
                             }
                         }
                         .clipped()
@@ -1383,10 +1385,14 @@ class GitHubMetadataCache: ObservableObject {
 
             var contributors: [GitHubContributor] = []
             let contributorsURL = URL(string: "https://api.github.com/repos/zachlatta/freeflow/contributors?per_page=15")!
-            let contributorsResult = try await URLSession.shared.data(from: contributorsURL)
-            if let contribHTTP = contributorsResult.1 as? HTTPURLResponse,
-               (200..<300).contains(contribHTTP.statusCode) {
-                contributors = (try? JSONDecoder().decode([GitHubContributor].self, from: contributorsResult.0)) ?? []
+            do {
+                let contributorsResult = try await URLSession.shared.data(from: contributorsURL)
+                if let contribHTTP = contributorsResult.1 as? HTTPURLResponse,
+                   (200..<300).contains(contribHTTP.statusCode) {
+                    contributors = try JSONDecoder().decode([GitHubContributor].self, from: contributorsResult.0)
+                }
+            } catch {
+                contributors = []
             }
 
             starCount = count

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -359,39 +359,6 @@ struct SetupView: View {
                     }
                     .clipped()
                 }
-
-                if !githubCache.recentStargazers.isEmpty {
-                    Divider()
-                    HStack(spacing: 8) {
-                        HStack(spacing: -6) {
-                            ForEach(githubCache.recentStargazers) { star in
-                                Button {
-                                    openURL(star.user.htmlUrl)
-                                } label: {
-                                    AsyncImage(url: star.user.avatarThumbnailUrl) { phase in
-                                        switch phase {
-                                        case .success(let image):
-                                            image.resizable().aspectRatio(contentMode: .fill)
-                                        default:
-                                            Color.gray.opacity(0.2)
-                                        }
-                                    }
-                                    .frame(width: 22, height: 22)
-                                    .clipShape(Circle())
-                                    .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                        .clipped()
-                        Text("recently starred")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .fixedSize()
-                        Spacer()
-                    }
-                    .clipped()
-                }
             }
             .padding(12)
             .background(

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -327,6 +327,39 @@ struct SetupView: View {
                     .buttonStyle(.plain)
                 }
 
+                if !githubCache.recentContributors.isEmpty {
+                    Divider()
+                    HStack(spacing: 8) {
+                        HStack(spacing: -6) {
+                            ForEach(githubCache.recentContributors) { contributor in
+                                Button {
+                                    openURL(contributor.htmlUrl)
+                                } label: {
+                                    AsyncImage(url: contributor.avatarThumbnailUrl) { phase in
+                                        switch phase {
+                                        case .success(let image):
+                                            image.resizable().aspectRatio(contentMode: .fill)
+                                        default:
+                                            Color.gray.opacity(0.2)
+                                        }
+                                    }
+                                    .frame(width: 22, height: 22)
+                                    .clipShape(Circle())
+                                    .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .clipped()
+                        Text("recent contributors")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .fixedSize()
+                        Spacer()
+                    }
+                    .clipped()
+                }
+
                 if !githubCache.recentStargazers.isEmpty {
                     Divider()
                     HStack(spacing: 8) {
@@ -1317,12 +1350,32 @@ struct GitHubStarUser: Decodable {
     }
 }
 
+struct GitHubContributor: Decodable, Identifiable {
+    let id: Int
+    let login: String
+    let avatarUrl: URL
+    let htmlUrl: URL
+
+    var avatarThumbnailUrl: URL {
+        let separator = avatarUrl.absoluteString.contains("?") ? "&" : "?"
+        return URL(string: avatarUrl.absoluteString + "\(separator)s=44") ?? avatarUrl
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case login
+        case avatarUrl = "avatar_url"
+        case htmlUrl = "html_url"
+    }
+}
+
 @MainActor
 class GitHubMetadataCache: ObservableObject {
     static let shared = GitHubMetadataCache()
 
     @Published var starCount: Int?
     @Published var recentStargazers: [GitHubStarRecord] = []
+    @Published var recentContributors: [GitHubContributor] = []
     @Published var isLoading = true
 
     private var lastFetchDate: Date?
@@ -1361,8 +1414,17 @@ class GitHubMetadataCache: ObservableObject {
                 }
             }
 
+            var contributors: [GitHubContributor] = []
+            let contributorsURL = URL(string: "https://api.github.com/repos/zachlatta/freeflow/contributors?per_page=15")!
+            let contributorsResult = try await URLSession.shared.data(from: contributorsURL)
+            if let contribHTTP = contributorsResult.1 as? HTTPURLResponse,
+               (200..<300).contains(contribHTTP.statusCode) {
+                contributors = (try? JSONDecoder().decode([GitHubContributor].self, from: contributorsResult.0)) ?? []
+            }
+
             starCount = count
             recentStargazers = recent
+            recentContributors = contributors
             isLoading = false
             lastFetchDate = Date()
         } catch {


### PR DESCRIPTION
## What

The welcome card under the GitHub repo box currently shows a "recently starred" avatar row. This PR replaces it with a "recent contributors" row. One avatar row, contributors only.

**Before** (current upstream — just stargazers):

<img src="https://assets.themarketingshow.com/bugs/freeflow/welcome-card-stargazers-only-cropped-2026-04-29.png" width="600" alt="Welcome card showing only the recently-starred avatar row under the GitHub repo box">

**After** (this PR — contributors row in the same spot, no stargazers row):

<img src="https://assets.themarketingshow.com/bugs/freeflow/welcome-card-contributors-only-cropped-2026-04-29.png" width="600" alt="Welcome card showing only the recent contributors avatar row under the GitHub repo box">

## Why

Stargazers clicked a button. Contributors shipped code. The card has limited vertical real estate, and the social-proof spot under the repo box should go to the people who actually built FreeFlow.

Tagging the people this PR is meant to spotlight so they actually see it: @marcbodea @zachlatta @iris-sfg @taciturnaxolotl @zodwick @baslefeber @romanr @cathreya @Nanjiifr @ncan33 @thsunkid. Selfishly, I am in there too — that is part of the point.

This is the more opinionated of the two variants in this cluster. It removes a row that existing users have come to expect — a stronger taste call than just adding something new. The argument is that for the same vertical space, the contributors row is a strict upgrade.

## How

Two commits:

1. **Add contributors row** — `GitHubContributor` Decodable + Identifiable struct alongside `GitHubStarUser`, `recentContributors` `@Published` property on `GitHubMetadataCache`, fetch path in `fetchIfNeeded()`, HStack rendering above the existing stargazers HStack.
2. **Drop stargazers HStack** — keeps stargazer fetching in `GitHubMetadataCache` because the star count badge above the avatar row continues to use it. Only the avatar UI is removed.

Same row pattern as the existing stargazer avatars: 22pt circles, -6pt overlap, caption-2 caption font.

## Companion PR

This is the replacement variant. If you would rather KEEP the stargazers row and just ADD contributors above it, see the companion PR (additive variant) #160. Pick whichever fits your taste, or neither.

## Files

`Sources/SetupView.swift`, +34 / -5.

## Behavior

- **Existing users** — they previously saw a "recently starred" row; after this PR, they see a "recent contributors" row in the same spot.
- **Star count badge** — unchanged. Still rendered above the avatar row using `recentStargazers.count`.
- **Network failure / GitHub API down** — empty `recentContributors` array, the `if !.isEmpty` guard hides the row cleanly.

## Verified

- Welcome screen shows one avatar row under the repo box: contributors only. No "recently starred" row. ✓
- Click a contributor avatar — that user's GitHub profile opens in the default browser. ✓
- Star count badge above the row continues to render. ✓
- Cache reload (relaunch the app) does not crash. ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced "recently starred" with a "recent contributors" section in the welcome view.
  * Shows contributor avatars and lets users tap an avatar to open the contributor's GitHub profile.
  * Recent contributors are fetched and displayed automatically when available.

* **Accessibility**
  * Added accessibility labels and hints for contributor avatar buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->