### PR TITLE
Fix Re-run Setup lockout when user closes wizard without completing

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -44,6 +44,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func handleShowSetup() {
+        // Single wizard at a time — opening a second leaks the first's
+        // willClose observer and breaks the bail-restore.
+        if let existing = setupWindow, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
         let wasCompleted = appState.hasCompletedSetup
         appState.hasCompletedSetup = false
         appState.stopAccessibilityPolling()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -44,10 +44,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func handleShowSetup() {
+        let wasCompleted = appState.hasCompletedSetup
         appState.hasCompletedSetup = false
         appState.stopAccessibilityPolling()
         appState.stopHotkeyMonitoring()
         showSetupWindow()
+
+        // Restore prior state if the user closes the wizard without completing.
+        // completeSetup() flips hasCompletedSetup back to true before window.close(),
+        // so the !hasCompletedSetup check below correctly skips the restore there.
+        if wasCompleted, let window = setupWindow {
+            NotificationCenter.default.addObserver(
+                forName: NSWindow.willCloseNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                guard let self = self else { return }
+                if !self.appState.hasCompletedSetup {
+                    self.appState.hasCompletedSetup = true
+                    self.appState.startHotkeyMonitoring()
+                    self.appState.startAccessibilityPolling()
+                    NSApp.setActivationPolicy(.accessory)
+                }
+            }
+        }
     }
 
     @objc private func handleShowSettings() {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -74,6 +74,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     self.appState.startAccessibilityPolling()
                     NSApp.setActivationPolicy(.accessory)
                 }
+                self.setupWindow = nil
             }
         }
     }


### PR DESCRIPTION
## What happened

I am in the Setup wizard a lot during testing — looking at how each step renders, checking copy, comparing to other parts of the app while iterating on the UI. So I am clicking **Re-run Setup...** from the menu bar fairly often, just to look at one step or another and then close the wizard.

Every time, the same thing: clicking Re-run Setup forced me to complete the entire setup process before the app would work again. The hotkey would not fire, dictation would not respond, and I would be sitting there going next, next, next, next, next through every step just to get back to the working state I had before opening the wizard.

## The bug

`AppDelegate.handleShowSetup()` does three destructive things at click time, before the user has done anything in the wizard:

```swift
@objc func handleShowSetup() {
    appState.hasCompletedSetup = false    // marks app as needing setup
    appState.stopAccessibilityPolling()   // stops accessibility monitoring
    appState.stopHotkeyMonitoring()       // stops global hotkey monitoring
    showSetupWindow()
}
```

`completeSetup()` (called when the user finishes the wizard) reverses all three. But there is no equivalent reversal for the wizard-close-without-completing path. The window has `.closable` in its style mask, so the user can close it any time, and the app is stuck.

The result: clicking **Re-run Setup** is effectively a one-way commit — peek at the wizard once and you have to grind through every step to unlock the app again.

## Repro

1. Use FreeFlow normally for a while so `hasCompletedSetup` is true and dictation works.
2. Menu bar → **Re-run Setup...**
3. The wizard opens. Click **Continue** a couple of times if you want, or just close it immediately.
4. Click the X to close the wizard window without reaching the final **Get Started** step.
5. Try to dictate.

Expected: dictation works because nothing actually changed.
Was: dictation does not respond. Hotkey monitoring is dead. To recover, re-open the wizard and complete every step.

## The fix

Snapshot the prior `hasCompletedSetup` value at click time. After showing the window, register a `willCloseNotification` observer that checks: did the user finish the wizard before closing?

- If `hasCompletedSetup` is true at close-time, `completeSetup()` ran first (it flips the flag back before calling `window.close()`), so do nothing — the completion path already restored everything.
- If `hasCompletedSetup` is still false at close-time AND the user was previously completed, the user bailed. Restore `hasCompletedSetup = true`, restart hotkey monitoring + accessibility polling, set the activation policy back to `.accessory`.

```swift
if wasCompleted, let window = setupWindow {
    NotificationCenter.default.addObserver(
        forName: NSWindow.willCloseNotification,
        object: window,
        queue: .main
    ) { [weak self] _ in
        guard let self = self else { return }
        if !self.appState.hasCompletedSetup {
            self.appState.hasCompletedSetup = true
            self.appState.startHotkeyMonitoring()
            self.appState.startAccessibilityPolling()
            NSApp.setActivationPolicy(.accessory)
        }
    }
}
```

## Files

`Sources/AppDelegate.swift`, +20 / -0.

## Behavior

- **Previously-completed user, completes wizard:** unchanged — `completeSetup()` runs, observer no-ops on `!hasCompletedSetup`, normal flow.
- **Previously-completed user, closes wizard with X:** NEW — observer restores prior state. App stays usable.
- **First-launch fresh user (`hasCompletedSetup` was already false), closes wizard with X:** unchanged — `wasCompleted` is false at click time, so the observer is not registered. First-launch wizard still requires explicit completion to mark the user as set up.
- **Hotkey monitoring, accessibility polling, activation policy:** all symmetric with what `completeSetup()` already does.

## Verified

- TC1 — Previously-completed user. Click Re-run Setup, click Continue twice, click the X. Try to dictate. ✓ Works without re-completing the wizard.
- TC2 — Previously-completed user. Click Re-run Setup, walk through every step, click Get Started. Dictation works as before. ✓ Completion path unchanged.
- TC3 — Fresh user (or user with `hasCompletedSetup=false`). Wizard shows on launch. Click X without completing. ✓ Wizard reappears on next launch, fresh-user behavior preserved (no premature `hasCompletedSetup=true`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent multiple setup windows by bringing an existing setup wizard to the front.
  * Ensure cancelling or completing setup reliably restores hotkey monitoring and accessibility polling.
  * Preserve and consistently restore the app’s activation/visibility and the "setup completed" state when entering or exiting setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->