### PR TITLE
Append a space after sentence-ending punctuation on paste

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2924,8 +2924,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let pasteboard = NSPasteboard.general
         let snapshot = preserveClipboard ? PreservedPasteboardSnapshot(pasteboard: pasteboard) : nil
 
+        // Append a space when ending with sentence-ending punctuation so the
+        // next dictation does not jam against the prior period.
+        let textToWrite: String
+        if let last = transcript.last, ".!?".contains(last) {
+            textToWrite = transcript + " "
+        } else {
+            textToWrite = transcript
+        }
+
         pasteboard.clearContents()
-        pasteboard.setString(transcript, forType: .string)
+        pasteboard.setString(textToWrite, forType: .string)
 
         guard let snapshot else { return nil }
         return PendingClipboardRestore(snapshot: snapshot, expectedChangeCount: pasteboard.changeCount)


### PR DESCRIPTION
## What happened

Dictated something, dictated again right after, ended up with the second sentence jammed against the period of the first. No space.

```
This is a test.This is another test.Hey, how are you today?You know what?I'm doing pretty darn good.
```

The expected version, with normal sentence spacing:

```
This is a test. This is another test. Hey, how are you today? You know what? I'm doing pretty darn good.
```

Each transition lost a space, so back-to-back dictations always read like one run-on paragraph. Fine for one-off dictation, awkward the moment you stack two.

## The fix

In `writeTranscriptToPasteboard`, append a single space when the transcript ends with sentence-ending punctuation (`.`, `!`, or `?`). The trailing space is invisible in the single-dictation case (and most text fields trim trailing whitespace on submit anyway) but it gives the next dictation room to breathe.

```swift
let textToWrite: String
if let last = transcript.last, ".!?".contains(last) {
    textToWrite = transcript + " "
} else {
    textToWrite = transcript
}
```

## Why not other approaches

- **Track state across dictations and prepend a space on the next one** — works but adds a `lastEndedWithSentencePunctuation` flag and focus-change reset. State for what is really a one-character output decision.
- **Read the character before the cursor via accessibility API** — most robust but heavier and requires AX integration just for this case.
- **Always append a space regardless of last character** — would create trailing whitespace in mid-sentence dictation (lists, partial input), which is annoying.

The "only when ending with `.!?`" check keeps the trailing space invisible where it does not help and cleanly separates the back-to-back case where it does.

## Files

`Sources/AppState.swift`. +10 / -1.

## Behavior

- **Single dictation, ends with `.!?`** — trailing space appended. Invisible visually; trimmed on submit by most apps.
- **Single dictation, no sentence-ending punctuation** (mid-sentence input, partial phrases, lists) — unchanged.
- **Back-to-back dictations at the same field** — the prior trailing space cleanly separates the next sentence.

## Verified

Tested on a notched MacBook Pro. Dictated five sentences back-to-back across five separate hotkey triggers, pasting into the same text field each time. The actual rendered output:

<img src="https://assets.themarketingshow.com/bugs/freeflow/back-to-back-dictation-spaced-2026-04-29.png" width="700" alt="Five back-to-back dictations rendered with proper sentence spacing">

All four sentence transitions spaced correctly (after `.`, `.`, `?`, `?`). Pre-fix the same five triggers would have produced one wall of text with no spaces between the sentences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified transcript clipboard copy behavior to append an extra trailing space when text ends with sentence-ending punctuation (`.`, `!`, `?`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->