### PR TITLE
Allow disabling both dictation shortcuts

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1415,9 +1415,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func setShortcut(_ binding: ShortcutBinding, for role: ShortcutRole) -> String? {
         let binding = binding.normalizedForStorageMigration()
         let otherBinding = role == .hold ? toggleShortcut : holdShortcut
-        if binding.isDisabled && otherBinding.isDisabled {
-            return "At least one shortcut must remain enabled."
-        }
         guard !binding.conflicts(with: otherBinding) else {
             return "Hold and tap shortcuts must be distinct."
         }

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -127,7 +127,6 @@ struct MenuBarView: View {
                         Text("  Disabled")
                     }
                 }
-                .disabled(appState.toggleShortcut.isDisabled)
 
                 ForEach(ShortcutPreset.allCases) { preset in
                     Button {
@@ -172,7 +171,6 @@ struct MenuBarView: View {
                         Text("  Disabled")
                     }
                 }
-                .disabled(appState.holdShortcut.isDisabled)
 
                 ForEach(ShortcutPreset.allCases) { preset in
                     Button {

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -19,9 +19,15 @@ struct DictationShortcutEditor: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             if showsIntroText {
-                Text("Hold to record, tap to start and stop, and press the toggle shortcut while holding to latch into tap mode. You can disable either workflow if you only want one.")
+                Text("Hold to record, tap to start and stop, and press the toggle shortcut while holding to latch into tap mode. You can disable either workflow or turn both shortcuts off.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+
+            if appState.holdShortcut.isDisabled && appState.toggleShortcut.isDisabled {
+                Label("Both dictation shortcuts are disabled.", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
             }
 
             ShortcutRoleSection(


### PR DESCRIPTION
## Summary
- Remove the restriction that forced at least one dictation shortcut to stay enabled.
- Let users disable the hold and toggle shortcuts independently from the menu bar.
- Show an in-editor warning when both dictation shortcuts are disabled.
- Update the helper text to reflect that either or both workflows can be turned off.

## Testing
- Not run
- Reviewed the shortcut validation flow to confirm the disabled-state guard was removed.
- Reviewed the menu bar shortcut menus to confirm disabled options are no longer blocked.

Closes #155 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now disable both dictation shortcuts simultaneously, previously restricted to keeping at least one active.
  * Added visual warning indicator when both shortcuts are disabled.

* **UI/UX Improvements**
  * Updated instructional text to clarify available configuration options for shortcut management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->