### PR TITLE
Add Copy Literal/Cleaned buttons to Run Log + Open Run Log menu shortcut

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -236,6 +236,11 @@ struct MenuBarView: View {
                 NotificationCenter.default.post(name: .showSettings, object: nil)
             }
 
+            Button("Open Run Log") {
+                appState.selectedSettingsTab = .runLog
+                NotificationCenter.default.post(name: .showSettings, object: nil)
+            }
+
             Divider()
 
             Button(appState.isDebugOverlayActive ? "Stop Debug Overlay" : "Debug Overlay") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1887,6 +1887,10 @@ struct RunLogEntryView: View {
     @State private var showPostProcessingPrompt = false
     @State private var copiedTranscript = false
     @State private var copiedTranscriptResetWorkItem: DispatchWorkItem?
+    @State private var copiedRawTranscript = false
+    @State private var copiedRawTranscriptResetWorkItem: DispatchWorkItem?
+    @State private var copiedCleanedTranscript = false
+    @State private var copiedCleanedTranscriptResetWorkItem: DispatchWorkItem?
 
     private var isError: Bool {
         item.postProcessingStatus.hasPrefix("Error:")
@@ -2125,9 +2129,23 @@ struct RunLogEntryView: View {
                                             .font(.system(.caption, design: .monospaced))
                                             .textSelection(.enabled)
                                             .padding(8)
+                                            .padding(.trailing, 24)
                                             .frame(maxWidth: .infinity, alignment: .leading)
                                             .background(Color(nsColor: .controlBackgroundColor))
                                             .cornerRadius(4)
+                                            .overlay(alignment: .topTrailing) {
+                                                Button {
+                                                    copyRawTranscriptToPasteboard()
+                                                } label: {
+                                                    Image(systemName: copiedRawTranscript ? "checkmark" : "doc.on.doc")
+                                                        .font(.caption)
+                                                        .foregroundStyle(copiedRawTranscript ? .green : .secondary)
+                                                        .padding(6)
+                                                        .contentShape(Rectangle())
+                                                }
+                                                .buttonStyle(.plain)
+                                                .help(copiedRawTranscript ? "Copied literal transcript" : "Copy literal transcript")
+                                            }
                                     } else {
                                         Text("(empty transcript)")
                                             .font(.caption)
@@ -2178,9 +2196,23 @@ struct RunLogEntryView: View {
                                             .font(.system(.caption, design: .monospaced))
                                             .textSelection(.enabled)
                                             .padding(8)
+                                            .padding(.trailing, 24)
                                             .frame(maxWidth: .infinity, alignment: .leading)
                                             .background(Color(nsColor: .controlBackgroundColor))
                                             .cornerRadius(4)
+                                            .overlay(alignment: .topTrailing) {
+                                                Button {
+                                                    copyCleanedTranscriptToPasteboard()
+                                                } label: {
+                                                    Image(systemName: copiedCleanedTranscript ? "checkmark" : "doc.on.doc")
+                                                        .font(.caption)
+                                                        .foregroundStyle(copiedCleanedTranscript ? .green : .secondary)
+                                                        .padding(6)
+                                                        .contentShape(Rectangle())
+                                                }
+                                                .buttonStyle(.plain)
+                                                .help(copiedCleanedTranscript ? "Copied cleaned transcript" : "Copy cleaned transcript")
+                                            }
                                     }
                                 }
                             }
@@ -2221,6 +2253,38 @@ struct RunLogEntryView: View {
             copiedTranscriptResetWorkItem = nil
         }
         copiedTranscriptResetWorkItem = resetWorkItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: resetWorkItem)
+    }
+
+    private func copyRawTranscriptToPasteboard() {
+        guard !item.rawTranscript.isEmpty else { return }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(item.rawTranscript, forType: .string)
+        copiedRawTranscript = true
+
+        copiedRawTranscriptResetWorkItem?.cancel()
+        let resetWorkItem = DispatchWorkItem {
+            copiedRawTranscript = false
+            copiedRawTranscriptResetWorkItem = nil
+        }
+        copiedRawTranscriptResetWorkItem = resetWorkItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: resetWorkItem)
+    }
+
+    private func copyCleanedTranscriptToPasteboard() {
+        guard !item.postProcessedTranscript.isEmpty else { return }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(item.postProcessedTranscript, forType: .string)
+        copiedCleanedTranscript = true
+
+        copiedCleanedTranscriptResetWorkItem?.cancel()
+        let resetWorkItem = DispatchWorkItem {
+            copiedCleanedTranscript = false
+            copiedCleanedTranscriptResetWorkItem = nil
+        }
+        copiedCleanedTranscriptResetWorkItem = resetWorkItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: resetWorkItem)
     }
 }


### PR DESCRIPTION
## What

Two small UX additions to the Run Log:

1. **Copy buttons on each transcript block.** In an expanded Run Log entry, the raw transcript (Step 2) and the post-processed transcript (Step 3) each get a small copy icon in the top-right corner. Useful when post-processing trims too aggressively and you want the literal dictation, or vice versa. The existing top-bar copy button is unchanged.
2. **Open Run Log menu shortcut.** A new "Open Run Log" item in the menu bar dropdown jumps directly to the Run Log tab without navigating Settings first.

## Screenshot

<img width="500" src="https://assets.themarketingshow.com/bugs/freeflow/run-log-copy-buttons-menu-shortcut-2026-04-30.png" alt="FreeFlow menu bar dropdown showing the new Open Run Log item, with a Run Log entry expanded in the background showing copy icons on the raw and cleaned transcript blocks">

## Test plan

- [x] Builds cleanly with `make`
- [ ] Click Copy Literal → clipboard contains raw transcript
- [ ] Click Copy Cleaned → clipboard contains post-processed transcript
- [ ] Top-bar copy button continues to behave as before
- [ ] Click "Open Run Log" → Settings opens directly on Run Log tab


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open Run Log" menu-bar button for quick access to run logs in settings
  * Added copy-to-clipboard buttons for both raw and cleaned transcripts in the Run Log view with visual confirmation feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->