### PR TITLE
Add Paste Again keyboard shortcut

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1391,7 +1391,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     var usesFnShortcut: Bool {
-        holdShortcut.usesFnKey || toggleShortcut.usesFnKey
+        holdShortcut.usesFnKey || toggleShortcut.usesFnKey || copyAgainShortcut.usesFnKey
     }
 
     var hasEnabledHoldShortcut: Bool {
@@ -1488,6 +1488,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             if binding.conflicts(with: toggleShortcut) {
                 return "Paste Again cannot share a shortcut with Tap to Toggle."
             }
+            if isCommandModeEnabled, commandModeStyle == .manual,
+               bindingCollides(binding, with: commandModeManualModifier) {
+                return "Paste Again cannot share the Edit Mode modifier."
+            }
         }
 
         switch role {
@@ -1514,10 +1518,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func commandModeManualModifierCollisionMessage(
         for modifier: CommandModeManualModifier,
         holdBinding: ShortcutBinding? = nil,
-        toggleBinding: ShortcutBinding? = nil
+        toggleBinding: ShortcutBinding? = nil,
+        copyAgainBinding: ShortcutBinding? = nil
     ) -> String? {
         let holdBinding = holdBinding ?? holdShortcut
         let toggleBinding = toggleBinding ?? toggleShortcut
+        let copyAgainBinding = copyAgainBinding ?? copyAgainShortcut
         let manualModifier = modifier.shortcutModifier
 
         if !holdBinding.isDisabled && holdBinding.modifiers.contains(manualModifier) {
@@ -1525,6 +1531,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         if !toggleBinding.isDisabled && toggleBinding.modifiers.contains(manualModifier) {
             return "That modifier is already part of the tap shortcut."
+        }
+        if !copyAgainBinding.isDisabled && copyAgainBinding.modifiers.contains(manualModifier) {
+            return "That modifier is already part of the Paste Again shortcut."
         }
         // Modifier-only bindings carry identity in keyCode, not modifiers.
         if !holdBinding.isDisabled,
@@ -1539,8 +1548,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
            bindingModifier == manualModifier {
             return "That modifier is already the tap shortcut."
         }
+        if !copyAgainBinding.isDisabled,
+           copyAgainBinding.kind == .modifierKey,
+           let bindingModifier = ShortcutBinding.modifier(forKeyCode: copyAgainBinding.keyCode),
+           bindingModifier == manualModifier {
+            return "That modifier is already the Paste Again shortcut."
+        }
 
         return nil
+    }
+
+    private func bindingCollides(_ binding: ShortcutBinding, with modifier: CommandModeManualModifier) -> Bool {
+        guard !binding.isDisabled else { return false }
+        let manualModifier = modifier.shortcutModifier
+        if binding.modifiers.contains(manualModifier) { return true }
+        if binding.kind == .modifierKey,
+           let bindingModifier = ShortcutBinding.modifier(forKeyCode: binding.keyCode),
+           bindingModifier == manualModifier {
+            return true
+        }
+        return false
     }
 
     func startHotkeyMonitoring() {
@@ -1651,28 +1678,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return false
     }
 
-    /// Copies the last transcript to the pasteboard and posts a synthetic
-    /// Cmd+V so the focused app receives the paste — Wispr Flow style.
+    /// Copies the last transcript to the pasteboard and pastes it into the
+    /// focused app — Wispr Flow style. Reuses the dictation paste pipeline so
+    /// preserveClipboard is honored and the synthetic Cmd+V waits for the
+    /// trigger shortcut to be fully released.
     func copyLastTranscriptToPasteboard() {
         guard !lastTranscript.isEmpty else { return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(lastTranscript, forType: .string)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            Self.simulatePasteKeystroke()
+        let pendingClipboardRestore = writeTranscriptToPasteboard(lastTranscript)
+        pasteAtCursorWhenShortcutReleased { [weak self] in
+            self?.restoreClipboardIfNeeded(pendingClipboardRestore)
         }
-    }
-
-    private static func simulatePasteKeystroke() {
-        let source = CGEventSource(stateID: .combinedSessionState)
-        let vKeyCode: CGKeyCode = 0x09 // V
-        guard let down = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
-              let up = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
-            return
-        }
-        down.flags = .maskCommand
-        up.flags = .maskCommand
-        down.post(tap: .cgAnnotatedSessionEventTap)
-        up.post(tap: .cgAnnotatedSessionEventTap)
     }
 
     func toggleRecording() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -207,8 +207,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let contextModelStorageKey = "context_model"
     private let holdShortcutStorageKey = "hold_shortcut"
     private let toggleShortcutStorageKey = "toggle_shortcut"
+    private let copyAgainShortcutStorageKey = "copy_again_shortcut"
     private let savedHoldCustomShortcutStorageKey = "saved_hold_custom_shortcut"
     private let savedToggleCustomShortcutStorageKey = "saved_toggle_custom_shortcut"
+    private let savedCopyAgainCustomShortcutStorageKey = "saved_copy_again_custom_shortcut"
     private let customVocabularyStorageKey = "custom_vocabulary"
     private let transcriptionLanguageStorageKey = "transcription_language"
     private let selectedMicrophoneStorageKey = "selected_microphone_id"
@@ -347,6 +349,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var copyAgainShortcut: ShortcutBinding {
+        didSet {
+            persistShortcut(copyAgainShortcut, key: copyAgainShortcutStorageKey)
+            restartHotkeyMonitoring()
+        }
+    }
+
     @Published private(set) var savedHoldCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedHoldCustomShortcut, key: savedHoldCustomShortcutStorageKey)
@@ -356,6 +365,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var savedToggleCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedToggleCustomShortcut, key: savedToggleCustomShortcutStorageKey)
+        }
+    }
+
+    @Published private(set) var savedCopyAgainCustomShortcut: ShortcutBinding? {
+        didSet {
+            persistOptionalShortcut(savedCopyAgainCustomShortcut, key: savedCopyAgainCustomShortcutStorageKey)
         }
     }
 
@@ -597,7 +612,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let contextModel = UserDefaults.standard.string(forKey: contextModelStorageKey) ?? Self.defaultContextModel
         let shortcuts = Self.loadShortcutConfiguration(
             holdKey: holdShortcutStorageKey,
-            toggleKey: toggleShortcutStorageKey
+            toggleKey: toggleShortcutStorageKey,
+            copyAgainKey: copyAgainShortcutStorageKey
         )
         let savedHoldCustomShortcut = Self.loadSavedCustomShortcut(
             forKey: savedHoldCustomShortcutStorageKey,
@@ -606,6 +622,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let savedToggleCustomShortcut = Self.loadSavedCustomShortcut(
             forKey: savedToggleCustomShortcutStorageKey,
             fallback: shortcuts.toggle.isCustom ? shortcuts.toggle : nil
+        )
+        let savedCopyAgainCustomShortcut = Self.loadSavedCustomShortcut(
+            forKey: savedCopyAgainCustomShortcutStorageKey,
+            fallback: shortcuts.copyAgain.isCustom ? shortcuts.copyAgain : nil
         )
         let customVocabulary = UserDefaults.standard.string(forKey: customVocabularyStorageKey) ?? ""
         let transcriptionLanguage = Self.normalizeTranscriptionLanguage(
@@ -688,8 +708,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.contextModel = contextModel
         self.holdShortcut = shortcuts.hold
         self.toggleShortcut = shortcuts.toggle
+        self.copyAgainShortcut = shortcuts.copyAgain
         self.savedHoldCustomShortcut = savedHoldCustomShortcut.binding
         self.savedToggleCustomShortcut = savedToggleCustomShortcut.binding
+        self.savedCopyAgainCustomShortcut = savedCopyAgainCustomShortcut.binding
         self.isCommandModeEnabled = isCommandModeEnabled
         self.commandModeStyle = commandModeStyle
         self.commandModeManualModifier = commandModeManualModifier
@@ -726,11 +748,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if shortcuts.didUpdateToggleStoredValue {
             persistShortcut(shortcuts.toggle, key: toggleShortcutStorageKey)
         }
+        if shortcuts.didUpdateCopyAgainStoredValue {
+            persistShortcut(shortcuts.copyAgain, key: copyAgainShortcutStorageKey)
+        }
         if savedHoldCustomShortcut.didUpdateStoredValue {
             persistOptionalShortcut(savedHoldCustomShortcut.binding, key: savedHoldCustomShortcutStorageKey)
         }
         if savedToggleCustomShortcut.didUpdateStoredValue {
             persistOptionalShortcut(savedToggleCustomShortcut.binding, key: savedToggleCustomShortcutStorageKey)
+        }
+        if savedCopyAgainCustomShortcut.didUpdateStoredValue {
+            persistOptionalShortcut(savedCopyAgainCustomShortcut.binding, key: savedCopyAgainCustomShortcutStorageKey)
         }
 
         overlayManager.onStopButtonPressed = { [weak self] in
@@ -782,8 +810,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private struct StoredShortcutConfiguration {
         let hold: ShortcutBinding
         let toggle: ShortcutBinding
+        let copyAgain: ShortcutBinding
         let didUpdateHoldStoredValue: Bool
         let didUpdateToggleStoredValue: Bool
+        let didUpdateCopyAgainStoredValue: Bool
     }
 
     private struct StoredOptionalShortcut {
@@ -804,7 +834,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return defaultAPIBaseURL
     }
 
-    private static func loadShortcutConfiguration(holdKey: String, toggleKey: String) -> StoredShortcutConfiguration {
+    private static func loadShortcutConfiguration(
+        holdKey: String,
+        toggleKey: String,
+        copyAgainKey: String
+    ) -> StoredShortcutConfiguration {
         let legacyPreset = ShortcutPreset(
             rawValue: UserDefaults.standard.string(forKey: "hotkey_option") ?? ShortcutPreset.fnKey.rawValue
         ) ?? .fnKey
@@ -812,11 +846,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let toggle = hold.withAddedModifiers(.command)
         let storedHold = loadShortcut(forKey: holdKey)
         let storedToggle = loadShortcut(forKey: toggleKey)
+        let storedCopyAgain = loadShortcut(forKey: copyAgainKey)
         return StoredShortcutConfiguration(
             hold: storedHold.binding ?? hold,
             toggle: storedToggle.binding ?? toggle,
+            copyAgain: storedCopyAgain.binding ?? .disabled,
             didUpdateHoldStoredValue: storedHold.binding == nil || storedHold.didNormalize,
-            didUpdateToggleStoredValue: storedToggle.binding == nil || storedToggle.didNormalize
+            didUpdateToggleStoredValue: storedToggle.binding == nil || storedToggle.didNormalize,
+            didUpdateCopyAgainStoredValue: storedCopyAgain.didNormalize
         )
     }
 
@@ -1392,6 +1429,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return savedHoldCustomShortcut
         case .toggle:
             return savedToggleCustomShortcut
+        case .copyAgain:
+            return savedCopyAgainCustomShortcut
         }
     }
 
@@ -1431,9 +1470,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @discardableResult
     func setShortcut(_ binding: ShortcutBinding, for role: ShortcutRole) -> String? {
         let binding = binding.normalizedForStorageMigration()
-        let otherBinding = role == .hold ? toggleShortcut : holdShortcut
-        guard !binding.conflicts(with: otherBinding) else {
-            return "Hold and tap shortcuts must be distinct."
+
+        if role == .hold || role == .toggle {
+            let otherDictationBinding = role == .hold ? toggleShortcut : holdShortcut
+            guard !binding.conflicts(with: otherDictationBinding) else {
+                return "Hold and tap shortcuts must be distinct."
+            }
+        }
+
+        if role != .copyAgain, binding.conflicts(with: copyAgainShortcut) {
+            return "This shortcut is already used by Paste Again."
+        }
+        if role == .copyAgain {
+            if binding.conflicts(with: holdShortcut) {
+                return "Paste Again cannot share a shortcut with Hold to Talk."
+            }
+            if binding.conflicts(with: toggleShortcut) {
+                return "Paste Again cannot share a shortcut with Tap to Toggle."
+            }
         }
 
         switch role {
@@ -1447,6 +1501,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 savedToggleCustomShortcut = binding
             }
             toggleShortcut = binding
+        case .copyAgain:
+            if binding.isCustom {
+                savedCopyAgainCustomShortcut = binding
+            }
+            copyAgainShortcut = binding
         }
 
         return nil
@@ -1526,6 +1585,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return ShortcutConfiguration(
             hold: holdShortcut,
             toggle: toggleShortcut,
+            copyAgain: copyAgainShortcut,
             permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
         )
     }
@@ -1546,6 +1606,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func handleShortcutEvent(_ event: ShortcutEvent) {
+        if event == .copyAgainTriggered {
+            copyLastTranscriptToPasteboard()
+            return
+        }
+
         guard let action = shortcutSessionController.handle(event: event, isTranscribing: isTranscribing) else {
             return
         }
@@ -1584,6 +1649,30 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         return false
+    }
+
+    /// Copies the last transcript to the pasteboard and posts a synthetic
+    /// Cmd+V so the focused app receives the paste — Wispr Flow style.
+    func copyLastTranscriptToPasteboard() {
+        guard !lastTranscript.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(lastTranscript, forType: .string)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            Self.simulatePasteKeystroke()
+        }
+    }
+
+    private static func simulatePasteKeystroke() {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let vKeyCode: CGKeyCode = 0x09 // V
+        guard let down = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
+              let up = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
+            return
+        }
+        down.flags = .maskCommand
+        up.flags = .maskCommand
+        down.post(tap: .cgAnnotatedSessionEventTap)
+        up.post(tap: .cgAnnotatedSessionEventTap)
     }
 
     func toggleRecording() {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -139,19 +139,21 @@ struct MenuBarView: View {
             Divider()
 
             if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
-                Text(appState.lastTranscript.count > 35
+                Button(appState.copyAgainShortcut.isDisabled
+                    ? "Paste Again"
+                    : "Paste Again  (\(appState.copyAgainShortcut.displayName))") {
+                    appState.copyLastTranscriptToPasteboard()
+                }
+
+                let truncatedTranscript = appState.lastTranscript.count > 35
                     ? String(appState.lastTranscript.prefix(35)) + "…"
-                    : appState.lastTranscript)
+                    : appState.lastTranscript
+                Text("\u{201C}\(truncatedTranscript)\u{201D}")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 16)
                     .lineLimit(4)
                     .frame(maxWidth: 280, alignment: .leading)
-
-                Button("Copy Again") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(appState.lastTranscript, forType: .string)
-                }
             }
 
             Menu("History") {
@@ -252,6 +254,50 @@ struct MenuBarView: View {
                         _ = appState.setShortcut(savedCustomShortcut, for: .toggle)
                     } label: {
                         if appState.toggleShortcut == savedCustomShortcut {
+                            Text("✓ Custom: \(savedCustomShortcut.displayName)")
+                        } else {
+                            Text("  Custom: \(savedCustomShortcut.displayName)")
+                        }
+                    }
+                }
+
+                Divider()
+                Button("Customize…") {
+                    appState.selectedSettingsTab = .general
+                    NotificationCenter.default.post(name: .showSettings, object: nil)
+                }
+            }
+
+            Menu("Paste Again Shortcut") {
+                Button {
+                    _ = appState.setShortcut(.disabled, for: .copyAgain)
+                } label: {
+                    if appState.copyAgainShortcut.isDisabled {
+                        Text("✓ Disabled")
+                    } else {
+                        Text("  Disabled")
+                    }
+                }
+
+                ForEach(ShortcutPreset.allCases) { preset in
+                    Button {
+                        _ = appState.setShortcut(preset.binding, for: .copyAgain)
+                    } label: {
+                        if appState.copyAgainShortcut == preset.binding {
+                            Text("✓ \(preset.title)")
+                        } else {
+                            Text("  \(preset.title)")
+                        }
+                    }
+                    .disabled(preset.binding == appState.holdShortcut || preset.binding == appState.toggleShortcut)
+                }
+
+                if let savedCustomShortcut = appState.savedCustomShortcut(for: .copyAgain) {
+                    Divider()
+                    Button {
+                        _ = appState.setShortcut(savedCustomShortcut, for: .copyAgain)
+                    } label: {
+                        if appState.copyAgainShortcut == savedCustomShortcut {
                             Text("✓ Custom: \(savedCustomShortcut.displayName)")
                         } else {
                             Text("  Custom: \(savedCustomShortcut.displayName)")

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -63,6 +63,7 @@ struct SetupView: View {
         case screenRecording
         case holdShortcut
         case toggleShortcut
+        case copyAgainShortcut
         case commandMode
         case vocabulary
         case launchAtLogin
@@ -98,13 +99,15 @@ struct SetupView: View {
     @State private var testMicPulsing = false
     @State private var holdShortcutValidationMessage: String?
     @State private var toggleShortcutValidationMessage: String?
+    @State private var copyAgainShortcutValidationMessage: String?
     @State private var isCapturingHoldShortcut = false
     @State private var isCapturingToggleShortcut = false
+    @State private var isCapturingCopyAgainShortcut = false
     @StateObject private var testHotkeyHarness = SetupTestHotkeyHarness()
 
     private let totalSteps: [SetupStep] = SetupStep.allCases
     private var isCapturingShortcut: Bool {
-        isCapturingHoldShortcut || isCapturingToggleShortcut
+        isCapturingHoldShortcut || isCapturingToggleShortcut || isCapturingCopyAgainShortcut
     }
 
     var body: some View {
@@ -240,6 +243,8 @@ struct SetupView: View {
             holdShortcutStep
         case .toggleShortcut:
             toggleShortcutStep
+        case .copyAgainShortcut:
+            copyAgainShortcutStep
         case .commandMode:
             commandModeStep
         case .vocabulary:
@@ -672,6 +677,41 @@ struct SetupView: View {
                     .multilineTextAlignment(.center)
             }
 
+        }
+    }
+
+    var copyAgainShortcutStep: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "doc.on.clipboard")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue)
+
+            Text("Paste Again Shortcut")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Optional. Choose a shortcut to paste your last transcript again into the active text field, without opening the menu bar. Leave disabled if you do not want one.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ShortcutRoleSection(
+                role: .copyAgain,
+                selection: appState.copyAgainShortcut,
+                validationMessage: copyAgainShortcutValidationMessage,
+                isCapturing: $isCapturingCopyAgainShortcut,
+                onSelect: { binding in
+                    copyAgainShortcutValidationMessage = appState.setShortcut(binding, for: .copyAgain)
+                }
+            )
+                .padding(.top, 10)
+
+            if appState.copyAgainShortcut.usesFnKey {
+                Text("Tip: If Fn opens Emoji picker, go to System Settings > Keyboard and change \"Press fn key to\" to \"Do Nothing\".")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .multilineTextAlignment(.center)
+            }
         }
     }
 

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -10,6 +10,7 @@ struct DictationShortcutEditor: View {
     @State private var activeCaptureRole: ShortcutRole?
     @State private var holdValidationMessage: String?
     @State private var toggleValidationMessage: String?
+    @State private var copyAgainValidationMessage: String?
 
     init(showsIntroText: Bool = true, onCaptureStateChange: ((Bool) -> Void)? = nil) {
         self.showsIntroText = showsIntroText
@@ -53,6 +54,19 @@ struct DictationShortcutEditor: View {
                 ),
                 onSelect: { binding in
                     toggleValidationMessage = appState.setShortcut(binding, for: .toggle)
+                }
+            )
+
+            ShortcutRoleSection(
+                role: .copyAgain,
+                selection: appState.copyAgainShortcut,
+                validationMessage: copyAgainValidationMessage,
+                isCapturing: Binding(
+                    get: { activeCaptureRole == .copyAgain },
+                    set: { activeCaptureRole = $0 ? .copyAgain : nil }
+                ),
+                onSelect: { binding in
+                    copyAgainValidationMessage = appState.setShortcut(binding, for: .copyAgain)
                 }
             )
 

--- a/Sources/ShortcutCore/DictationShortcutSessionController.swift
+++ b/Sources/ShortcutCore/DictationShortcutSessionController.swift
@@ -11,6 +11,10 @@ final class DictationShortcutSessionController {
     private(set) var toggleStopArmed = false
 
     func handle(event: ShortcutEvent, isTranscribing: Bool) -> DictationShortcutAction? {
+        // Paste Again is handled before this controller runs; if it ever
+        // reaches here, treat as a no-op so dictation state is unaffected.
+        if event == .copyAgainTriggered { return nil }
+
         if activeMode == nil {
             guard !isTranscribing else { return nil }
             switch event {
@@ -23,6 +27,8 @@ final class DictationShortcutSessionController {
                 toggleStopArmed = false
                 return .start(.hold)
             case .holdDeactivated, .toggleDeactivated:
+                return nil
+            case .copyAgainTriggered:
                 return nil
             }
         }
@@ -41,6 +47,8 @@ final class DictationShortcutSessionController {
                 return .stop
             case .holdActivated, .toggleDeactivated:
                 return nil
+            case .copyAgainTriggered:
+                return nil
             }
 
         case .toggle:
@@ -53,6 +61,8 @@ final class DictationShortcutSessionController {
                 reset()
                 return .stop
             case .holdActivated, .holdDeactivated:
+                return nil
+            case .copyAgainTriggered:
                 return nil
             }
         }

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -17,6 +17,7 @@ struct ShortcutInputState: Equatable {
     var pressedModifierKeyCodes: Set<UInt16> = []
     var holdIsActive = false
     var toggleIsActive = false
+    var copyAgainIsActive = false
 
     var currentModifiers: ShortcutModifiers {
         ShortcutBinding.modifiers(for: pressedModifierKeyCodes)
@@ -25,8 +26,10 @@ struct ShortcutInputState: Equatable {
     func hasPressedShortcutInputs(configuration: ShortcutConfiguration) -> Bool {
         let currentModifiers = currentModifiers
         let keyReferenceHeld = pressedKeyCodes.contains { keyCode in
-            configuration.hold.kind == .key && configuration.hold.keyCode == keyCode
-                || configuration.toggle.kind == .key && configuration.toggle.keyCode == keyCode
+            let isHoldKey = configuration.hold.kind == .key && configuration.hold.keyCode == keyCode
+            let isToggleKey = configuration.toggle.kind == .key && configuration.toggle.keyCode == keyCode
+            let isCopyAgainKey = configuration.copyAgain.kind == .key && configuration.copyAgain.keyCode == keyCode
+            return isHoldKey || isToggleKey || isCopyAgainKey
         }
         if keyReferenceHeld {
             return true
@@ -41,6 +44,14 @@ struct ShortcutInputState: Equatable {
         }
 
         if configuration.toggle.referencesPressedModifiers(
+            pressedModifierKeyCodes: pressedModifierKeyCodes,
+            currentModifiers: currentModifiers,
+            permittedAdditionalExactMatchModifiers: configuration.permittedAdditionalExactMatchModifiers
+        ) {
+            return true
+        }
+
+        if configuration.copyAgain.referencesPressedModifiers(
             pressedModifierKeyCodes: pressedModifierKeyCodes,
             currentModifiers: currentModifiers,
             permittedAdditionalExactMatchModifiers: configuration.permittedAdditionalExactMatchModifiers
@@ -162,15 +173,19 @@ enum ShortcutMatcher {
     ) -> [ShortcutEvent] {
         let previousHold = state.holdIsActive
         let previousToggle = state.toggleIsActive
+        let previousCopyAgain = state.copyAgainIsActive
 
         state.holdIsActive = bindingIsActive(configuration.hold, state: state, configuration: configuration)
         state.toggleIsActive = bindingIsActive(configuration.toggle, state: state, configuration: configuration)
+        state.copyAgainIsActive = bindingIsActive(configuration.copyAgain, state: state, configuration: configuration)
 
         return emitChanges(
             previousHold: previousHold,
             previousToggle: previousToggle,
+            previousCopyAgain: previousCopyAgain,
             currentHold: state.holdIsActive,
             currentToggle: state.toggleIsActive,
+            currentCopyAgain: state.copyAgainIsActive,
             configuration: configuration
         )
     }
@@ -178,8 +193,10 @@ enum ShortcutMatcher {
     private static func emitChanges(
         previousHold: Bool,
         previousToggle: Bool,
+        previousCopyAgain: Bool,
         currentHold: Bool,
         currentToggle: Bool,
+        currentCopyAgain: Bool,
         configuration: ShortcutConfiguration
     ) -> [ShortcutEvent] {
         var activations: [(ShortcutEvent, Int)] = []
@@ -190,6 +207,10 @@ enum ShortcutMatcher {
         }
         if !previousToggle && currentToggle {
             activations.append((.toggleActivated, configuration.toggle.specificityScore))
+        }
+        // Paste Again is a one-shot: fire on the leading edge only.
+        if !previousCopyAgain && currentCopyAgain {
+            activations.append((.copyAgainTriggered, configuration.copyAgain.specificityScore))
         }
         if previousHold && !currentHold {
             deactivations.append((.holdDeactivated, configuration.hold.specificityScore))
@@ -252,7 +273,7 @@ enum ShortcutMatcher {
         for keyCode: UInt16,
         configuration: ShortcutConfiguration
     ) -> [ShortcutBinding] {
-        [configuration.hold, configuration.toggle].filter { binding in
+        [configuration.hold, configuration.toggle, configuration.copyAgain].filter { binding in
             binding.kind == .key && binding.keyCode == keyCode
         }
     }
@@ -261,7 +282,7 @@ enum ShortcutMatcher {
         for keyCode: UInt16,
         configuration: ShortcutConfiguration
     ) -> [ShortcutBinding] {
-        [configuration.hold, configuration.toggle].filter { binding in
+        [configuration.hold, configuration.toggle, configuration.copyAgain].filter { binding in
             switch binding.kind {
             case .key, .modifierKey:
                 return modifierEvent(for: keyCode, affects: binding)

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -55,11 +55,13 @@ enum RecordingTriggerMode: String, Codable {
 enum ShortcutRole {
     case hold
     case toggle
+    case copyAgain
 
     var title: String {
         switch self {
         case .hold: return "Hold to Talk"
         case .toggle: return "Tap to Toggle"
+        case .copyAgain: return "Paste Again"
         }
     }
 }
@@ -69,24 +71,28 @@ enum ShortcutEvent: Equatable {
     case holdDeactivated
     case toggleActivated
     case toggleDeactivated
+    case copyAgainTriggered
 }
 
 struct ShortcutConfiguration: Equatable {
     let hold: ShortcutBinding
     let toggle: ShortcutBinding
+    let copyAgain: ShortcutBinding
     let permittedAdditionalExactMatchModifiers: ShortcutModifiers
 
     init(
         hold: ShortcutBinding,
         toggle: ShortcutBinding,
+        copyAgain: ShortcutBinding = .disabled,
         permittedAdditionalExactMatchModifiers: ShortcutModifiers = []
     ) {
         self.hold = hold
         self.toggle = toggle
+        self.copyAgain = copyAgain
         self.permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiers
     }
 
-    static let disabled = ShortcutConfiguration(hold: .disabled, toggle: .disabled)
+    static let disabled = ShortcutConfiguration(hold: .disabled, toggle: .disabled, copyAgain: .disabled)
 }
 
 enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {


### PR DESCRIPTION
## Why

Copy Again works, but it forces an extra detour: open the menu, click Copy Again, switch back to your target field, hit Cmd+V. This PR adds a keyboard shortcut that does the whole sequence in one keypress — sets the clipboard AND posts a synthetic Cmd+V into the focused app. Skip the menu entirely. Wispr Flow style.

## Surfaces

The shortcut is wired into all three places a user encounters dictation shortcuts: setup, settings, and menu bar.

<img width="500" src="https://assets.themarketingshow.com/bugs/freeflow/paste-again-setup-wizard-2026-04-30.png" alt="Setup wizard Paste Again Shortcut step with Disabled, Fn, Right Option, F5, and Custom options">

*Setup wizard adds an optional **Paste Again Shortcut** step between **Tap to Toggle** and **Command Mode**. Marked optional — leave disabled if not wanted.*

<img width="500" src="https://assets.themarketingshow.com/bugs/freeflow/paste-again-settings-2026-04-30.png" alt="Settings panel Paste Again section showing the same shortcut options with a custom Cmd+Ctrl+V binding selected">

*Settings gets a third row alongside Hold to Talk and Tap to Toggle.*

<img width="500" src="https://assets.themarketingshow.com/bugs/freeflow/paste-again-menu-submenu-2026-04-30.png" alt="Menu bar dropdown showing Paste Again button with shortcut name, curly-quoted transcript preview, and the new Paste Again Shortcut submenu open">

*Menu bar dropdown gains a **Paste Again Shortcut** submenu, the existing Copy Again button is renamed **Paste Again** and now displays the shortcut name, and the transcript preview gets curly quotes around it.*

## What changes (technical)

- New `.copyAgain` `ShortcutRole` (titled "Paste Again") and a `.copyAgainTriggered` event, fired on the leading edge of the binding
- `copyLastTranscriptToPasteboard()` on `AppState`: clipboard set + 50ms-delayed `CGEvent` Cmd+V post
- Validation prevents collision with Hold to Talk and Tap to Toggle

## Files

- `Sources/ShortcutCore/ShortcutModels.swift` — role, event, config field
- `Sources/ShortcutCore/ShortcutMatcher.swift` — emits `.copyAgainTriggered` on activation
- `Sources/ShortcutCore/DictationShortcutSessionController.swift` — `.copyAgainTriggered` is no-op for dictation state
- `Sources/AppState.swift` — storage, validation, paste action
- `Sources/SetupView.swift` — wizard step
- `Sources/ShortcutComponents.swift` — Settings row
- `Sources/MenuBarView.swift` — menu changes

## Test plan

- [x] Builds cleanly with `make`
- [ ] Bind a shortcut in Settings → press it → focused app receives the last transcript via paste
- [ ] Walk through the setup wizard → bind / skip the shortcut at the new step
- [ ] Bind from the menu bar's Paste Again Shortcut submenu → same result
- [ ] Try to bind a shortcut already used by Hold to Talk or Tap to Toggle → validation message appears
- [ ] Existing menu button (now "Paste Again") still works on click


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Paste Again" shortcut: persistent hotkey that copies the last transcript and pastes it into the focused app; supports custom bindings, validation, disable option, and conflict checks.
  * Onboarding step to configure the "Paste Again" shortcut, including Fn-key guidance when applicable.

* **UI**
  * Menu replaces "Copy Again" with "Paste Again" action (truncated transcript preview) and adds a "Paste Again Shortcut" management menu with preset, reapply, disable, and customize options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->