### PR TITLE
Fix Advanced Provider Settings click race + grey out unused Reset buttons

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -143,6 +143,7 @@ struct ProviderSettingsFields: View {
                     appState.apiBaseURL = AppState.defaultAPIBaseURL
                 }
                 .font(.caption)
+                .disabled(apiBaseURLInput == AppState.defaultAPIBaseURL)
             }
 
             if showsModelDescription {
@@ -171,6 +172,7 @@ struct ProviderSettingsFields: View {
                         appState.postProcessingModel = AppState.defaultPostProcessingModel
                     }
                     .font(.caption)
+                    .disabled(postProcessingModelDraft == AppState.defaultPostProcessingModel)
                 }
                 Text("Used for transcript cleanup and Edit Mode transforms.")
                     .font(.caption)
@@ -197,6 +199,7 @@ struct ProviderSettingsFields: View {
                         appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
                     }
                     .font(.caption)
+                    .disabled(postProcessingFallbackModelDraft == AppState.defaultPostProcessingFallbackModel)
                 }
                 Text("Used as the explicit retry model for transcript cleanup and Edit Mode transforms.")
                     .font(.caption)
@@ -223,6 +226,7 @@ struct ProviderSettingsFields: View {
                         appState.contextModel = AppState.defaultContextModel
                     }
                     .font(.caption)
+                    .disabled(contextModelDraft == AppState.defaultContextModel)
                 }
                 Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
                     .font(.caption)
@@ -249,6 +253,7 @@ struct ProviderSettingsFields: View {
                         appState.transcriptionModel = AppState.defaultTranscriptionModel
                     }
                     .font(.caption)
+                    .disabled(transcriptionModelDraft == AppState.defaultTranscriptionModel)
                 }
                 Text("Used for speech-to-text transcription.")
                     .font(.caption)
@@ -913,24 +918,36 @@ struct GeneralSettingsView: View {
                     .font(.caption)
             }
 
-            DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Divider()
-                    ProviderSettingsFields(
-                        apiBaseURLInput: $apiBaseURLInput,
-                        transcriptionAPIURLInput: $transcriptionAPIURLInput,
-                        transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
-                        showsModelDescription: false
-                    )
+            VStack(alignment: .leading, spacing: 8) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        advancedProviderSettingsExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: advancedProviderSettingsExpanded ? "chevron.down" : "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 12)
+                        Text("Advanced Provider Settings")
+                            .foregroundStyle(.primary)
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
                 }
-            } label: {
-                HStack {
-                    Text("Advanced Provider Settings")
-                    Spacer()
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    advancedProviderSettingsExpanded.toggle()
+                .buttonStyle(.plain)
+
+                if advancedProviderSettingsExpanded {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Divider()
+                        ProviderSettingsFields(
+                            apiBaseURLInput: $apiBaseURLInput,
+                            transcriptionAPIURLInput: $transcriptionAPIURLInput,
+                            transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
+                            showsModelDescription: false
+                        )
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
             .padding(.top, 4)


### PR DESCRIPTION
## Why

Two small fixes in the API Key card area.

**Click race on the disclosure.** The "Advanced Provider Settings" disclosure used both `DisclosureGroup`'s built-in label tap AND a manual `.onTapGesture` on the same label. Clicks on the label often fired both handlers in the same frame, the toggles cancelled, and the row "did not take." Replaced with a manual `VStack` + `Button` + chevron pattern — one click target, full-row hit area, animated expand/collapse.

<img width="600" src="https://assets.themarketingshow.com/bugs/freeflow/api-key-disclosure-targeted-blur-2026-04-30.png" alt="FreeFlow Settings panel showing the API Key card with the Advanced Provider Settings disclosure row in its new collapsed state. The green status line and key field above it are blurred to indicate they are unrelated to this PR.">

*Settings view with the new disclosure row in focus (chevron + label, single click). The blurred rows above are unrelated to this PR.*

**Reset buttons that did nothing.** The five "Reset to Default" buttons in `ProviderSettingsFields` were always enabled and always clickable, even when the field already held the default value. Now they disable when there is nothing to reset.

<img width="600" src="https://assets.themarketingshow.com/bugs/freeflow/advanced-provider-reset-buttons-2026-04-30.png" alt="Advanced Provider Settings panel with all Reset to Default buttons greyed out because the adjacent fields hold default values">

*All five Reset to Default buttons greyed out — every adjacent field holds the default value, so there is nothing to reset.*

## Files

- `Sources/SettingsView.swift`

## Test plan

- [x] Builds cleanly with `make`
- [ ] Click anywhere on the "Advanced Provider Settings" row → expands once, no double-toggle
- [ ] All five "Reset to Default" buttons grey out when the adjacent field holds the default value, enable when the user types something different
