### PR TITLE
Show which provider the saved API key is for, warn on mismatch

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -459,6 +459,7 @@ struct GeneralSettingsView: View {
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
+    @State private var keyValidationProviderLabel: String?
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
@@ -883,34 +884,50 @@ struct GeneralSettingsView: View {
 
     private var apiKeySection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("\(AppName.displayName) uses the configured transcription model with your selected OpenAI-compatible provider.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            // Status banner sits above the field — the prominent slot.
+            // Priority: validation error > validation success > live provider
+            // status (host + key prefix detection) > caption fallback.
+            if let error = keyValidationError {
+                Label(error, systemImage: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if keyValidationSuccess {
+                let successText: String = {
+                    if let provider = keyValidationProviderLabel {
+                        return "API key saved — Validated as \(provider)"
+                    }
+                    return "API key saved"
+                }()
+                Label(successText, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
+            } else if let status = providerStatusLabel {
+                Label(status.text, systemImage: status.isMismatch ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    .foregroundStyle(status.isMismatch ? .orange : .green)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("\(AppName.displayName) uses the configured transcription model with your selected OpenAI-compatible provider.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
 
             HStack(spacing: 8) {
-                SecureField("Enter your Groq API key", text: $apiKeyInput)
+                SecureField("Paste your API key", text: $apiKeyInput)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .disabled(isValidatingKey)
                     .onChange(of: apiKeyInput) { _ in
                         keyValidationError = nil
                         keyValidationSuccess = false
+                        keyValidationProviderLabel = nil
                     }
 
                 Button(isValidatingKey ? "Validating..." : "Save") {
                     validateAndSaveKey()
                 }
                 .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)
-            }
-
-            if let error = keyValidationError {
-                Label(error, systemImage: "xmark.circle.fill")
-                    .foregroundStyle(.red)
-                    .font(.caption)
-            } else if keyValidationSuccess {
-                Label("API key saved", systemImage: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-                    .font(.caption)
             }
 
             DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
@@ -940,25 +957,70 @@ struct GeneralSettingsView: View {
     private func validateAndSaveKey() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         let baseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
         isValidatingKey = true
         keyValidationError = nil
         keyValidationSuccess = false
+        keyValidationProviderLabel = nil
 
         Task {
-            let valid = await TranscriptionService.validateAPIKey(
-                key,
-                baseURL: baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
-            )
+            let valid = await TranscriptionService.validateAPIKey(key, baseURL: resolvedBaseURL)
             await MainActor.run {
                 isValidatingKey = false
                 if valid {
                     appState.apiKey = key
                     keyValidationSuccess = true
+                    keyValidationProviderLabel = TranscriptionService.detectProvider(baseURL: resolvedBaseURL, key: key)
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
                 }
             }
         }
+    }
+
+    /// Live status line above the API key field. Returns `nil` when there is
+    /// no input and no saved key (the caption fallback shows). When a saved
+    /// or in-progress key is present, returns:
+    ///   - `(text: "Configured for Groq", isMismatch: false)` when the
+    ///     configured Base URL host maps to a known provider, optionally with
+    ///     a key preview when both are non-empty
+    ///   - `(text: "OpenAI key with Groq Base URL — open Advanced Provider Settings to switch.", isMismatch: true)`
+    ///     when the typed key's provider does not match the host's
+    private var providerStatusLabel: (text: String, isMismatch: Bool)? {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBaseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = trimmedBaseURL.isEmpty ? AppState.defaultAPIBaseURL : trimmedBaseURL
+
+        let savedKey = appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidateKey = trimmedKey.isEmpty ? savedKey : trimmedKey
+        if candidateKey.isEmpty { return nil }
+
+        let hostProvider = TranscriptionService.detectProviderFromHost(baseURL: resolvedBaseURL)
+        let keyProvider = TranscriptionService.detectProviderFromKey(key: candidateKey)
+
+        if let hostProvider, let keyProvider,
+           keyProvider != hostProvider,
+           keyProvider != "OpenAI-compatible" {
+            return ("\(keyProvider) key with \(hostProvider) Base URL — open Advanced Provider Settings to switch.", true)
+        }
+
+        if let hostProvider {
+            if !candidateKey.isEmpty, let preview = providerKeyPreview(candidateKey) {
+                return ("Configured for \(hostProvider) — \(preview)", false)
+            }
+            return ("Configured for \(hostProvider).", false)
+        }
+
+        return nil
+    }
+
+    /// Six-and-six preview of an API key — `gsk_5B…zX9p2c`. Returns nil if
+    /// the key is too short to preview without revealing the middle.
+    private func providerKeyPreview(_ key: String) -> String? {
+        guard key.count >= 14 else { return nil }
+        let prefix = key.prefix(6)
+        let suffix = key.suffix(6)
+        return "\(prefix)…\(suffix)"
     }
 
     // MARK: Output Language

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -44,6 +44,57 @@ class TranscriptionService {
         }
     }
 
+    private static let providerHostMap: [(host: String, name: String)] = [
+        ("api.groq.com", "Groq"),
+        ("api.openai.com", "OpenAI"),
+        ("api.x.ai", "xAI (Grok)"),
+        ("api.anthropic.com", "Anthropic"),
+        ("api.cerebras.ai", "Cerebras"),
+        ("api.together.xyz", "Together AI"),
+        ("api.deepseek.com", "DeepSeek"),
+        ("api.mistral.ai", "Mistral"),
+        ("generativelanguage.googleapis.com", "Google AI (Gemini)"),
+        ("api.fireworks.ai", "Fireworks"),
+        ("api.perplexity.ai", "Perplexity"),
+        ("openrouter.ai", "OpenRouter"),
+        ("api.lemonfox.ai", "Lemonfox"),
+    ]
+
+    /// Provider name inferred from the base URL host. Most reliable signal
+    /// because the host is the actual endpoint the request will hit.
+    static func detectProviderFromHost(baseURL: String) -> String? {
+        let host = (try? normalizedBaseURL(from: baseURL))?.host?.lowercased() ?? ""
+        for (h, name) in providerHostMap where host.contains(h) {
+            return name
+        }
+        if host == "localhost" || host == "127.0.0.1" || host.hasSuffix(".local") {
+            return "Local server"
+        }
+        return nil
+    }
+
+    /// Provider name inferred from the API key's prefix. Distinct prefixes
+    /// only — generic `sk-` falls back to OpenAI-compatible since multiple
+    /// providers ship that shape.
+    static func detectProviderFromKey(key: String) -> String? {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedKey.hasPrefix("gsk_") { return "Groq" }
+        if trimmedKey.hasPrefix("sk-ant-") { return "Anthropic" }
+        if trimmedKey.hasPrefix("xai-") { return "xAI (Grok)" }
+        if trimmedKey.hasPrefix("hf_") { return "Hugging Face" }
+        if trimmedKey.hasPrefix("csk-") { return "Cerebras" }
+        if trimmedKey.hasPrefix("sk-proj-") { return "OpenAI" }
+        if trimmedKey.hasPrefix("sk-") { return "OpenAI-compatible" }
+        return nil
+    }
+
+    /// Combined detection: prefer the host (definitive endpoint), fall back
+    /// to the key prefix when the host is unknown. Returns nil for unknown.
+    static func detectProvider(baseURL: String, key: String) -> String? {
+        if let host = detectProviderFromHost(baseURL: baseURL) { return host }
+        return detectProviderFromKey(key: key)
+    }
+
     // Upload audio file, submit for transcription, poll until done, return text
     func transcribe(fileURL: URL) async throws -> String {
         guard !Task.isCancelled else {


### PR DESCRIPTION
## Why

Most users paste an API key once and forget about it. Months later they want to swap providers, and the existing API Key card had three rough edges:

1. It did not say which provider the saved key was for — once entered, the key just sat as a row of dots
2. The placeholder hard-coded `Enter your Groq API key`, even though the field accepts any OpenAI-compatible provider
3. Pasting a key from a different provider produced a confusing 401, because the Base URL still pointed at the old provider

This PR adds a live status line above the field that fixes all three.

<img width="600" src="https://assets.themarketingshow.com/bugs/freeflow/api-key-provider-status-2026-04-30.png" alt="API Key card showing a green Configured for Groq status line above the API key field">

*The green `Configured for Groq` status line is what this PR adds. The masked-key visual in the field is from a separate PR and not part of this diff.*

## What changes

**New status banner above the field.** Three states:

- `Configured for Groq — gsk_5B…zX9p2c` (green, informational) when the configured Base URL host maps to a known provider. Key preview is six-and-six so the user can identify which key is loaded without exposing the middle.
- `OpenAI key with Groq Base URL — open Advanced Provider Settings to switch.` (orange, mismatch warning) when the typed key's provider does not match the host's provider. Generic `sk-` keys are treated as ambiguous (no warning).
- The original caption text as fallback when no key is configured yet.

**Validation banner moves above the field** to the prominent slot, replacing the live status line on success. Reads `API key saved — Validated as Groq` when validation succeeded and the provider was detected.

**Generic placeholder.** `Enter your Groq API key` → `Paste your API key`.

## Surface

- `Sources/TranscriptionService.swift` — three pure-function helpers:
  - `detectProviderFromHost(baseURL:)` covers 14 hosts (Groq, OpenAI, xAI, Anthropic, Cerebras, Together AI, DeepSeek, Mistral, Google AI, Fireworks, Perplexity, OpenRouter, Lemonfox, plus localhost / .local for self-hosted)
  - `detectProviderFromKey(key:)` covers distinctive prefixes (`gsk_`, `sk-ant-`, `xai-`, `hf_`, `csk-`, `sk-proj-`, generic `sk-`)
  - `detectProvider(baseURL:key:)` combines both — host first (definitive), key prefix as fallback
- `Sources/SettingsView.swift` — new `providerStatusLabel` computed property and restructured `apiKeySection` body (banner above field, generic placeholder, success label includes provider name)

## Test plan

- [x] Builds cleanly with `make`
- [ ] Settings shows `Configured for Groq` on view load when a Groq key is saved
- [ ] Type an `sk-ant-` key in the field → status flips to `Anthropic key with Groq Base URL — open Advanced Provider Settings to switch.` (orange)
- [ ] Type a generic `sk-` key → no orange warning (ambiguous)
- [ ] Save a valid key → success label reads `API key saved — Validated as Groq`
- [ ] Empty card (no key, no input) → caption text fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned API key settings interface with unified validation messaging and prominent status banners
  * Added automatic provider detection from API key format and base URL configuration
  * Enhanced validation with provider consistency checks and mismatch guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->