### PR TITLE
Masked API key display in Settings and Setup wizard with click-to-edit

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -459,6 +459,7 @@ struct GeneralSettingsView: View {
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
+    @State private var keyValidationProviderLabel: String?
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
@@ -883,34 +884,50 @@ struct GeneralSettingsView: View {
 
     private var apiKeySection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("\(AppName.displayName) uses the configured transcription model with your selected OpenAI-compatible provider.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            // Status banner sits above the field — the prominent slot.
+            // Priority: validation error > validation success > live provider
+            // status (host + key prefix detection) > caption fallback.
+            if let error = keyValidationError {
+                Label(error, systemImage: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if keyValidationSuccess {
+                let successText: String = {
+                    if let provider = keyValidationProviderLabel {
+                        return "API key saved — Validated as \(provider)"
+                    }
+                    return "API key saved"
+                }()
+                Label(successText, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
+            } else if let status = providerStatusLabel {
+                Label(status.text, systemImage: status.isMismatch ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    .foregroundStyle(status.isMismatch ? .orange : .green)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("\(AppName.displayName) uses the configured transcription model with your selected OpenAI-compatible provider.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
 
             HStack(spacing: 8) {
-                SecureField("Enter your Groq API key", text: $apiKeyInput)
+                SecureField("Paste your API key", text: $apiKeyInput)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .disabled(isValidatingKey)
                     .onChange(of: apiKeyInput) { _ in
                         keyValidationError = nil
                         keyValidationSuccess = false
+                        keyValidationProviderLabel = nil
                     }
 
                 Button(isValidatingKey ? "Validating..." : "Save") {
                     validateAndSaveKey()
                 }
                 .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)
-            }
-
-            if let error = keyValidationError {
-                Label(error, systemImage: "xmark.circle.fill")
-                    .foregroundStyle(.red)
-                    .font(.caption)
-            } else if keyValidationSuccess {
-                Label("API key saved", systemImage: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-                    .font(.caption)
             }
 
             DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
@@ -940,25 +957,70 @@ struct GeneralSettingsView: View {
     private func validateAndSaveKey() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         let baseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
         isValidatingKey = true
         keyValidationError = nil
         keyValidationSuccess = false
+        keyValidationProviderLabel = nil
 
         Task {
-            let valid = await TranscriptionService.validateAPIKey(
-                key,
-                baseURL: baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
-            )
+            let valid = await TranscriptionService.validateAPIKey(key, baseURL: resolvedBaseURL)
             await MainActor.run {
                 isValidatingKey = false
                 if valid {
                     appState.apiKey = key
                     keyValidationSuccess = true
+                    keyValidationProviderLabel = TranscriptionService.detectProvider(baseURL: resolvedBaseURL, key: key)
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
                 }
             }
         }
+    }
+
+    /// Live status line above the API key field. Returns `nil` when there is
+    /// no input and no saved key (the caption fallback shows). When a saved
+    /// or in-progress key is present, returns:
+    ///   - `(text: "Configured for Groq", isMismatch: false)` when the
+    ///     configured Base URL host maps to a known provider, optionally with
+    ///     a key preview when both are non-empty
+    ///   - `(text: "OpenAI key with Groq Base URL — open Advanced Provider Settings to switch.", isMismatch: true)`
+    ///     when the typed key's provider does not match the host's
+    private var providerStatusLabel: (text: String, isMismatch: Bool)? {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBaseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = trimmedBaseURL.isEmpty ? AppState.defaultAPIBaseURL : trimmedBaseURL
+
+        let savedKey = appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidateKey = trimmedKey.isEmpty ? savedKey : trimmedKey
+        if candidateKey.isEmpty { return nil }
+
+        let hostProvider = TranscriptionService.detectProviderFromHost(baseURL: resolvedBaseURL)
+        let keyProvider = TranscriptionService.detectProviderFromKey(key: candidateKey)
+
+        if let hostProvider, let keyProvider,
+           keyProvider != hostProvider,
+           keyProvider != "OpenAI-compatible" {
+            return ("\(keyProvider) key with \(hostProvider) Base URL — open Advanced Provider Settings to switch.", true)
+        }
+
+        if let hostProvider {
+            if !candidateKey.isEmpty, let preview = providerKeyPreview(candidateKey) {
+                return ("Configured for \(hostProvider) — \(preview)", false)
+            }
+            return ("Configured for \(hostProvider).", false)
+        }
+
+        return nil
+    }
+
+    /// Six-and-six preview of an API key — `gsk_5B…zX9p2c`. Returns nil if
+    /// the key is too short to preview without revealing the middle.
+    private func providerKeyPreview(_ key: String) -> String? {
+        guard key.count >= 14 else { return nil }
+        let prefix = key.prefix(6)
+        let suffix = key.suffix(6)
+        return "\(prefix)…\(suffix)"
     }
 
     // MARK: Output Language

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -460,6 +460,7 @@ struct GeneralSettingsView: View {
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var keyValidationProviderLabel: String?
+    @FocusState private var apiKeyFocused: Bool
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
@@ -914,15 +915,43 @@ struct GeneralSettingsView: View {
             }
 
             HStack(spacing: 8) {
-                SecureField("Paste your API key", text: $apiKeyInput)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
-                    .disabled(isValidatingKey)
-                    .onChange(of: apiKeyInput) { _ in
-                        keyValidationError = nil
-                        keyValidationSuccess = false
-                        keyValidationProviderLabel = nil
+                ZStack {
+                    TextField("Paste your API key", text: editableMaskedKeyBinding)
+                        .focused($apiKeyFocused)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                        .disabled(isValidatingKey)
+                        .onChange(of: apiKeyInput) { _ in
+                            keyValidationError = nil
+                            keyValidationSuccess = false
+                            keyValidationProviderLabel = nil
+                        }
+                        .opacity(shouldRevealMaskedKey ? 0 : 1)
+                        .allowsHitTesting(!shouldRevealMaskedKey)
+
+                    if shouldRevealMaskedKey {
+                        HStack {
+                            Text(maskedDisplayKey(apiKeyInput) ?? apiKeyInput)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.primary)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(Color(nsColor: .textBackgroundColor))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                        )
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            apiKeyFocused = true
+                        }
                     }
+                }
 
                 Button(isValidatingKey ? "Validating..." : "Save") {
                     validateAndSaveKey()
@@ -952,6 +981,40 @@ struct GeneralSettingsView: View {
             }
             .padding(.top, 4)
         }
+    }
+
+    /// Renders an API key as `prefix6 + 16 chars + suffix6` so the user can
+    /// identify which key is loaded without exposing the middle. Default uses
+    /// bullet for the read-only display; callers pass an asterisk for the
+    /// editable display so clicking into the field does not flood it with
+    /// heavy dots.
+    private func maskedDisplayKey(_ key: String, char: Character = "•") -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 16 else { return nil }
+        let middle = String(repeating: char, count: 16)
+        return "\(trimmed.prefix(6))\(middle)\(trimmed.suffix(6))"
+    }
+
+    /// Editable binding that shows the key as `prefix6 + 16 asterisks + suffix6`
+    /// while still letting the user Cmd-A and paste a fresh value over the top.
+    /// Any input still containing an asterisk is rejected — that signals the
+    /// user typed mid-mask rather than doing a full replacement.
+    private var editableMaskedKeyBinding: Binding<String> {
+        Binding(
+            get: { maskedDisplayKey(apiKeyInput, char: "*") ?? apiKeyInput },
+            set: { newValue in
+                if newValue.contains("*") { return }
+                apiKeyInput = newValue
+            }
+        )
+    }
+
+    /// Show the masked-preview view (instead of the editable field) when the
+    /// field is unfocused AND has enough content to safely mask.
+    private var shouldRevealMaskedKey: Bool {
+        guard !apiKeyFocused else { return false }
+        let typed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return typed.count >= 16
     }
 
     private func validateAndSaveKey() {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -74,6 +74,7 @@ struct SetupView: View {
     @State private var micPermissionGranted = false
     @State private var accessibilityGranted = false
     @State private var apiKeyInput: String = ""
+    @FocusState private var apiKeyFocused: Bool
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
@@ -413,13 +414,41 @@ struct SetupView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("API Key")
                             .font(.headline)
-                        SecureField("Paste your API key", text: $apiKeyInput)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
-                            .disabled(isValidatingKey)
-                            .onChange(of: apiKeyInput) { _ in
-                                keyValidationError = nil
+                        ZStack {
+                            TextField("Paste your API key", text: editableMaskedKeyBinding)
+                                .focused($apiKeyFocused)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.body, design: .monospaced))
+                                .disabled(isValidatingKey)
+                                .onChange(of: apiKeyInput) { _ in
+                                    keyValidationError = nil
+                                }
+                                .opacity(shouldRevealMaskedKey ? 0 : 1)
+                                .allowsHitTesting(!shouldRevealMaskedKey)
+
+                            if shouldRevealMaskedKey {
+                                HStack {
+                                    Text(maskedDisplayKey(apiKeyInput) ?? apiKeyInput)
+                                        .font(.system(.body, design: .monospaced))
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 5)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .fill(Color(nsColor: .textBackgroundColor))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                                )
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    apiKeyFocused = true
+                                }
                             }
+                        }
 
                         if let error = keyValidationError {
                             Label(error, systemImage: "xmark.circle.fill")
@@ -1278,6 +1307,38 @@ struct SetupView: View {
             }
             testAudioRecorder = nil
         }
+    }
+
+    /// Renders an API key as `prefix6 + 16 chars + suffix6` so the user can
+    /// identify which key is loaded without exposing the middle. Default
+    /// uses bullet for the read-only display; callers pass an asterisk for
+    /// the editable display.
+    private func maskedDisplayKey(_ key: String, char: Character = "•") -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 16 else { return nil }
+        let middle = String(repeating: char, count: 16)
+        return "\(trimmed.prefix(6))\(middle)\(trimmed.suffix(6))"
+    }
+
+    /// Editable binding that shows the key as `prefix6 + 16 asterisks + suffix6`
+    /// while still letting the user Cmd-A and paste a fresh value over the top.
+    /// Any input still containing an asterisk is rejected.
+    private var editableMaskedKeyBinding: Binding<String> {
+        Binding(
+            get: { maskedDisplayKey(apiKeyInput, char: "*") ?? apiKeyInput },
+            set: { newValue in
+                if newValue.contains("*") { return }
+                apiKeyInput = newValue
+            }
+        )
+    }
+
+    /// Show the masked-preview view (instead of the editable field) when the
+    /// field is unfocused AND has enough content to safely mask.
+    private var shouldRevealMaskedKey: Bool {
+        guard !apiKeyFocused else { return false }
+        let typed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return typed.count >= 16
     }
 
 }

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -44,6 +44,57 @@ class TranscriptionService {
         }
     }
 
+    private static let providerHostMap: [(host: String, name: String)] = [
+        ("api.groq.com", "Groq"),
+        ("api.openai.com", "OpenAI"),
+        ("api.x.ai", "xAI (Grok)"),
+        ("api.anthropic.com", "Anthropic"),
+        ("api.cerebras.ai", "Cerebras"),
+        ("api.together.xyz", "Together AI"),
+        ("api.deepseek.com", "DeepSeek"),
+        ("api.mistral.ai", "Mistral"),
+        ("generativelanguage.googleapis.com", "Google AI (Gemini)"),
+        ("api.fireworks.ai", "Fireworks"),
+        ("api.perplexity.ai", "Perplexity"),
+        ("openrouter.ai", "OpenRouter"),
+        ("api.lemonfox.ai", "Lemonfox"),
+    ]
+
+    /// Provider name inferred from the base URL host. Most reliable signal
+    /// because the host is the actual endpoint the request will hit.
+    static func detectProviderFromHost(baseURL: String) -> String? {
+        let host = (try? normalizedBaseURL(from: baseURL))?.host?.lowercased() ?? ""
+        for (h, name) in providerHostMap where host.contains(h) {
+            return name
+        }
+        if host == "localhost" || host == "127.0.0.1" || host.hasSuffix(".local") {
+            return "Local server"
+        }
+        return nil
+    }
+
+    /// Provider name inferred from the API key's prefix. Distinct prefixes
+    /// only — generic `sk-` falls back to OpenAI-compatible since multiple
+    /// providers ship that shape.
+    static func detectProviderFromKey(key: String) -> String? {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedKey.hasPrefix("gsk_") { return "Groq" }
+        if trimmedKey.hasPrefix("sk-ant-") { return "Anthropic" }
+        if trimmedKey.hasPrefix("xai-") { return "xAI (Grok)" }
+        if trimmedKey.hasPrefix("hf_") { return "Hugging Face" }
+        if trimmedKey.hasPrefix("csk-") { return "Cerebras" }
+        if trimmedKey.hasPrefix("sk-proj-") { return "OpenAI" }
+        if trimmedKey.hasPrefix("sk-") { return "OpenAI-compatible" }
+        return nil
+    }
+
+    /// Combined detection: prefer the host (definitive endpoint), fall back
+    /// to the key prefix when the host is unknown. Returns nil for unknown.
+    static func detectProvider(baseURL: String, key: String) -> String? {
+        if let host = detectProviderFromHost(baseURL: baseURL) { return host }
+        return detectProviderFromKey(key: key)
+    }
+
     // Upload audio file, submit for transcription, poll until done, return text
     func transcribe(fileURL: URL) async throws -> String {
         guard !Task.isCancelled else {


### PR DESCRIPTION
## Why

The API Key field used to render the saved key as a featureless row of dots, indistinguishable from any other masked password field. Once you had pasted a key, you could not tell which one was loaded. Months later when swapping providers, the only signal was "this field has dots in it" — not which key, not which provider.

This shows the saved key as `prefix6 + 16 dots + suffix6` (`gsk_5B••••••••••••••••zX9p2c`) when the field is not focused. Tapping the field swaps to a regular `TextField` showing the same content with asterisks in place of the dots, so Cmd+A + paste replaces the value cleanly. On blur, the field returns to the dotted display.

Same treatment lands in the Setup wizard so re-running setup with a saved key shows the readable display rather than an opaque row of dots.

## Stacked on #169

This PR depends on #169 (provider feedback). The cumulative diff against `main` includes both PRs' changes. Once #169 merges, this PR will rebase to show only the masked-key surface (~138 lines).

## What changes

- **`Sources/SettingsView.swift`** — `apiKeySection` swaps the `SecureField` for a `ZStack` of an editable `TextField` plus a masked `Text` overlay. New helpers: `maskedDisplayKey(_:char:)`, `editableMaskedKeyBinding`, `shouldRevealMaskedKey`. New `@FocusState apiKeyFocused`.
- **`Sources/SetupView.swift`** — same `ZStack` pattern in the wizard's API Key step. Same three helpers.

## Test plan

- [x] Builds cleanly with `make`
- [ ] Save a key in Settings → blur the field → field shows `prefix6 + 16 dots + suffix6`
- [ ] Click the masked display → field swaps to editable TextField with `prefix6 + 16 asterisks + suffix6`
- [ ] Cmd+A + paste a fresh key → value replaces cleanly, no asterisk leakage
- [ ] Blur the field → returns to dotted display with the new key
- [ ] Re-run setup → API Key step shows the same masked display for a saved key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key input fields now automatically mask displayed values when unfocused, showing only beginning and ending characters for enhanced security
  * Added automatic API provider detection with alerts when the provider doesn't match your configured host
  * Consolidated API key validation status into a single indicator banner for clearer feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->