### PR TITLE
Confirm before switching Base URL on detected provider mismatch

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -460,7 +460,15 @@ struct GeneralSettingsView: View {
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var keyValidationProviderLabel: String?
+    @State private var pendingProviderSwitch: PendingProviderSwitch?
+    @State private var pendingValidationTask: Task<Void, Never>?
     @FocusState private var apiKeyFocused: Bool
+
+    private struct PendingProviderSwitch {
+        let preset: TranscriptionService.ProviderPreset
+        let fromProviderName: String
+        let key: String
+    }
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
@@ -893,6 +901,21 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.red)
                     .font(.caption)
                     .fixedSize(horizontal: false, vertical: true)
+            } else if let pending = pendingProviderSwitch {
+                HStack(alignment: .center, spacing: 12) {
+                    Label(
+                        "\(pending.preset.displayName) key validated. Switch Base URL from \(pending.fromProviderName) to \(pending.preset.displayName)?",
+                        systemImage: "checkmark.circle.fill"
+                    )
+                    .foregroundStyle(.blue)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    Button("Switch to \(pending.preset.displayName)") {
+                        applyPendingProviderSwitch()
+                    }
+                    .controlSize(.small)
+                }
             } else if keyValidationSuccess {
                 let successText: String = {
                     if let provider = keyValidationProviderLabel {
@@ -925,6 +948,18 @@ struct GeneralSettingsView: View {
                             keyValidationError = nil
                             keyValidationSuccess = false
                             keyValidationProviderLabel = nil
+                            pendingProviderSwitch = nil
+                            // 400ms debounce so a paste fires auto-switch without
+                            // waiting for blur, while typing-in-progress does not
+                            // spam validation calls.
+                            pendingValidationTask?.cancel()
+                            pendingValidationTask = Task {
+                                try? await Task.sleep(nanoseconds: 400_000_000)
+                                guard !Task.isCancelled else { return }
+                                await MainActor.run {
+                                    autoSwitchProviderIfNeeded()
+                                }
+                            }
                         }
                         .opacity(shouldRevealMaskedKey ? 0 : 1)
                         .allowsHitTesting(!shouldRevealMaskedKey)
@@ -957,6 +992,11 @@ struct GeneralSettingsView: View {
                     validateAndSaveKey()
                 }
                 .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)
+            }
+            .onChange(of: apiKeyFocused) { focused in
+                if !focused {
+                    autoSwitchProviderIfNeeded()
+                }
             }
 
             DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
@@ -1015,6 +1055,66 @@ struct GeneralSettingsView: View {
         guard !apiKeyFocused else { return false }
         let typed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         return typed.count >= 16
+    }
+
+    private var resolvedBaseURLInput: String {
+        let trimmed = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? AppState.defaultAPIBaseURL : trimmed
+    }
+
+    /// On blur or after a debounced paste, if the typed key's provider does
+    /// not match the configured Base URL's provider AND we have a preset for
+    /// the typed key's provider, validate the key against that preset's URL.
+    /// On success, stash a PendingProviderSwitch — the UI surfaces a Switch
+    /// button so the user explicitly opts in. No silent URL-flipping.
+    private func autoSwitchProviderIfNeeded() {
+        let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty,
+              let keyProvider = TranscriptionService.detectProviderFromKey(key: key),
+              let preset = TranscriptionService.providerPreset(forName: keyProvider) else {
+            return
+        }
+        let urlProvider = TranscriptionService.detectProviderFromHost(baseURL: resolvedBaseURLInput)
+        guard urlProvider != keyProvider else { return }
+
+        let currentProviderName = urlProvider ?? "current"
+
+        isValidatingKey = true
+        keyValidationError = nil
+        keyValidationSuccess = false
+        keyValidationProviderLabel = nil
+        pendingProviderSwitch = nil
+
+        Task {
+            let errorMessage = await TranscriptionService.validateAPIKeyDetailed(key, baseURL: preset.baseURL)
+            await MainActor.run {
+                isValidatingKey = false
+                if let error = errorMessage {
+                    keyValidationError = "\(preset.displayName) rejected the key (\(error)). Kept your \(currentProviderName) settings."
+                } else {
+                    pendingProviderSwitch = PendingProviderSwitch(
+                        preset: preset,
+                        fromProviderName: currentProviderName,
+                        key: key
+                    )
+                }
+            }
+        }
+    }
+
+    private func applyPendingProviderSwitch() {
+        guard let pending = pendingProviderSwitch else { return }
+        let preset = pending.preset
+        apiBaseURLInput = preset.baseURL
+        appState.apiBaseURL = preset.baseURL
+        appState.transcriptionModel = preset.transcriptionModel
+        appState.postProcessingModel = preset.postProcessingModel
+        appState.postProcessingFallbackModel = preset.postProcessingFallbackModel
+        appState.contextModel = preset.contextModel
+        appState.apiKey = pending.key
+        keyValidationProviderLabel = preset.displayName
+        keyValidationSuccess = true
+        pendingProviderSwitch = nil
     }
 
     private func validateAndSaveKey() {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -459,6 +459,7 @@ struct GeneralSettingsView: View {
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
+    @State private var keyValidationProviderLabel: String?
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
@@ -883,34 +884,50 @@ struct GeneralSettingsView: View {
 
     private var apiKeySection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("\(AppName.displayName) uses the configured transcription model with your selected OpenAI-compatible provider.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            // Status banner sits above the field — the prominent slot.
+            // Priority: validation error > validation success > live provider
+            // status (host + key prefix detection) > caption fallback.
+            if let error = keyValidationError {
+                Label(error, systemImage: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if keyValidationSuccess {
+                let successText: String = {
+                    if let provider = keyValidationProviderLabel {
+                        return "API key saved — Validated as \(provider)"
+                    }
+                    return "API key saved"
+                }()
+                Label(successText, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
+            } else if let status = providerStatusLabel {
+                Label(status.text, systemImage: status.isMismatch ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    .foregroundStyle(status.isMismatch ? .orange : .green)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("\(AppName.displayName) uses the configured transcription model with your selected OpenAI-compatible provider.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
 
             HStack(spacing: 8) {
-                SecureField("Enter your Groq API key", text: $apiKeyInput)
+                SecureField("Paste your API key", text: $apiKeyInput)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .disabled(isValidatingKey)
                     .onChange(of: apiKeyInput) { _ in
                         keyValidationError = nil
                         keyValidationSuccess = false
+                        keyValidationProviderLabel = nil
                     }
 
                 Button(isValidatingKey ? "Validating..." : "Save") {
                     validateAndSaveKey()
                 }
                 .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)
-            }
-
-            if let error = keyValidationError {
-                Label(error, systemImage: "xmark.circle.fill")
-                    .foregroundStyle(.red)
-                    .font(.caption)
-            } else if keyValidationSuccess {
-                Label("API key saved", systemImage: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-                    .font(.caption)
             }
 
             DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
@@ -940,25 +957,70 @@ struct GeneralSettingsView: View {
     private func validateAndSaveKey() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         let baseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
         isValidatingKey = true
         keyValidationError = nil
         keyValidationSuccess = false
+        keyValidationProviderLabel = nil
 
         Task {
-            let valid = await TranscriptionService.validateAPIKey(
-                key,
-                baseURL: baseURL.isEmpty ? AppState.defaultAPIBaseURL : baseURL
-            )
+            let valid = await TranscriptionService.validateAPIKey(key, baseURL: resolvedBaseURL)
             await MainActor.run {
                 isValidatingKey = false
                 if valid {
                     appState.apiKey = key
                     keyValidationSuccess = true
+                    keyValidationProviderLabel = TranscriptionService.detectProvider(baseURL: resolvedBaseURL, key: key)
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
                 }
             }
         }
+    }
+
+    /// Live status line above the API key field. Returns `nil` when there is
+    /// no input and no saved key (the caption fallback shows). When a saved
+    /// or in-progress key is present, returns:
+    ///   - `(text: "Configured for Groq", isMismatch: false)` when the
+    ///     configured Base URL host maps to a known provider, optionally with
+    ///     a key preview when both are non-empty
+    ///   - `(text: "OpenAI key with Groq Base URL — open Advanced Provider Settings to switch.", isMismatch: true)`
+    ///     when the typed key's provider does not match the host's
+    private var providerStatusLabel: (text: String, isMismatch: Bool)? {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBaseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = trimmedBaseURL.isEmpty ? AppState.defaultAPIBaseURL : trimmedBaseURL
+
+        let savedKey = appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidateKey = trimmedKey.isEmpty ? savedKey : trimmedKey
+        if candidateKey.isEmpty { return nil }
+
+        let hostProvider = TranscriptionService.detectProviderFromHost(baseURL: resolvedBaseURL)
+        let keyProvider = TranscriptionService.detectProviderFromKey(key: candidateKey)
+
+        if let hostProvider, let keyProvider,
+           keyProvider != hostProvider,
+           keyProvider != "OpenAI-compatible" {
+            return ("\(keyProvider) key with \(hostProvider) Base URL — open Advanced Provider Settings to switch.", true)
+        }
+
+        if let hostProvider {
+            if !candidateKey.isEmpty, let preview = providerKeyPreview(candidateKey) {
+                return ("Configured for \(hostProvider) — \(preview)", false)
+            }
+            return ("Configured for \(hostProvider).", false)
+        }
+
+        return nil
+    }
+
+    /// Six-and-six preview of an API key — `gsk_5B…zX9p2c`. Returns nil if
+    /// the key is too short to preview without revealing the middle.
+    private func providerKeyPreview(_ key: String) -> String? {
+        guard key.count >= 14 else { return nil }
+        let prefix = key.prefix(6)
+        let suffix = key.suffix(6)
+        return "\(prefix)…\(suffix)"
     }
 
     // MARK: Output Language

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -460,6 +460,7 @@ struct GeneralSettingsView: View {
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var keyValidationProviderLabel: String?
+    @FocusState private var apiKeyFocused: Bool
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
@@ -914,15 +915,43 @@ struct GeneralSettingsView: View {
             }
 
             HStack(spacing: 8) {
-                SecureField("Paste your API key", text: $apiKeyInput)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
-                    .disabled(isValidatingKey)
-                    .onChange(of: apiKeyInput) { _ in
-                        keyValidationError = nil
-                        keyValidationSuccess = false
-                        keyValidationProviderLabel = nil
+                ZStack {
+                    TextField("Paste your API key", text: editableMaskedKeyBinding)
+                        .focused($apiKeyFocused)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                        .disabled(isValidatingKey)
+                        .onChange(of: apiKeyInput) { _ in
+                            keyValidationError = nil
+                            keyValidationSuccess = false
+                            keyValidationProviderLabel = nil
+                        }
+                        .opacity(shouldRevealMaskedKey ? 0 : 1)
+                        .allowsHitTesting(!shouldRevealMaskedKey)
+
+                    if shouldRevealMaskedKey {
+                        HStack {
+                            Text(maskedDisplayKey(apiKeyInput) ?? apiKeyInput)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.primary)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(Color(nsColor: .textBackgroundColor))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                        )
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            apiKeyFocused = true
+                        }
                     }
+                }
 
                 Button(isValidatingKey ? "Validating..." : "Save") {
                     validateAndSaveKey()
@@ -952,6 +981,40 @@ struct GeneralSettingsView: View {
             }
             .padding(.top, 4)
         }
+    }
+
+    /// Renders an API key as `prefix6 + 16 chars + suffix6` so the user can
+    /// identify which key is loaded without exposing the middle. Default uses
+    /// bullet for the read-only display; callers pass an asterisk for the
+    /// editable display so clicking into the field does not flood it with
+    /// heavy dots.
+    private func maskedDisplayKey(_ key: String, char: Character = "•") -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 16 else { return nil }
+        let middle = String(repeating: char, count: 16)
+        return "\(trimmed.prefix(6))\(middle)\(trimmed.suffix(6))"
+    }
+
+    /// Editable binding that shows the key as `prefix6 + 16 asterisks + suffix6`
+    /// while still letting the user Cmd-A and paste a fresh value over the top.
+    /// Any input still containing an asterisk is rejected — that signals the
+    /// user typed mid-mask rather than doing a full replacement.
+    private var editableMaskedKeyBinding: Binding<String> {
+        Binding(
+            get: { maskedDisplayKey(apiKeyInput, char: "*") ?? apiKeyInput },
+            set: { newValue in
+                if newValue.contains("*") { return }
+                apiKeyInput = newValue
+            }
+        )
+    }
+
+    /// Show the masked-preview view (instead of the editable field) when the
+    /// field is unfocused AND has enough content to safely mask.
+    private var shouldRevealMaskedKey: Bool {
+        guard !apiKeyFocused else { return false }
+        let typed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return typed.count >= 16
     }
 
     private func validateAndSaveKey() {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -74,6 +74,7 @@ struct SetupView: View {
     @State private var micPermissionGranted = false
     @State private var accessibilityGranted = false
     @State private var apiKeyInput: String = ""
+    @FocusState private var apiKeyFocused: Bool
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
@@ -413,13 +414,41 @@ struct SetupView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("API Key")
                             .font(.headline)
-                        SecureField("Paste your API key", text: $apiKeyInput)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
-                            .disabled(isValidatingKey)
-                            .onChange(of: apiKeyInput) { _ in
-                                keyValidationError = nil
+                        ZStack {
+                            TextField("Paste your API key", text: editableMaskedKeyBinding)
+                                .focused($apiKeyFocused)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.body, design: .monospaced))
+                                .disabled(isValidatingKey)
+                                .onChange(of: apiKeyInput) { _ in
+                                    keyValidationError = nil
+                                }
+                                .opacity(shouldRevealMaskedKey ? 0 : 1)
+                                .allowsHitTesting(!shouldRevealMaskedKey)
+
+                            if shouldRevealMaskedKey {
+                                HStack {
+                                    Text(maskedDisplayKey(apiKeyInput) ?? apiKeyInput)
+                                        .font(.system(.body, design: .monospaced))
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 5)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .fill(Color(nsColor: .textBackgroundColor))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                                )
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    apiKeyFocused = true
+                                }
                             }
+                        }
 
                         if let error = keyValidationError {
                             Label(error, systemImage: "xmark.circle.fill")
@@ -1278,6 +1307,38 @@ struct SetupView: View {
             }
             testAudioRecorder = nil
         }
+    }
+
+    /// Renders an API key as `prefix6 + 16 chars + suffix6` so the user can
+    /// identify which key is loaded without exposing the middle. Default
+    /// uses bullet for the read-only display; callers pass an asterisk for
+    /// the editable display.
+    private func maskedDisplayKey(_ key: String, char: Character = "•") -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 16 else { return nil }
+        let middle = String(repeating: char, count: 16)
+        return "\(trimmed.prefix(6))\(middle)\(trimmed.suffix(6))"
+    }
+
+    /// Editable binding that shows the key as `prefix6 + 16 asterisks + suffix6`
+    /// while still letting the user Cmd-A and paste a fresh value over the top.
+    /// Any input still containing an asterisk is rejected.
+    private var editableMaskedKeyBinding: Binding<String> {
+        Binding(
+            get: { maskedDisplayKey(apiKeyInput, char: "*") ?? apiKeyInput },
+            set: { newValue in
+                if newValue.contains("*") { return }
+                apiKeyInput = newValue
+            }
+        )
+    }
+
+    /// Show the masked-preview view (instead of the editable field) when the
+    /// field is unfocused AND has enough content to safely mask.
+    private var shouldRevealMaskedKey: Bool {
+        guard !apiKeyFocused else { return false }
+        let typed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return typed.count >= 16
     }
 
 }

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -44,6 +44,57 @@ class TranscriptionService {
         }
     }
 
+    private static let providerHostMap: [(host: String, name: String)] = [
+        ("api.groq.com", "Groq"),
+        ("api.openai.com", "OpenAI"),
+        ("api.x.ai", "xAI (Grok)"),
+        ("api.anthropic.com", "Anthropic"),
+        ("api.cerebras.ai", "Cerebras"),
+        ("api.together.xyz", "Together AI"),
+        ("api.deepseek.com", "DeepSeek"),
+        ("api.mistral.ai", "Mistral"),
+        ("generativelanguage.googleapis.com", "Google AI (Gemini)"),
+        ("api.fireworks.ai", "Fireworks"),
+        ("api.perplexity.ai", "Perplexity"),
+        ("openrouter.ai", "OpenRouter"),
+        ("api.lemonfox.ai", "Lemonfox"),
+    ]
+
+    /// Provider name inferred from the base URL host. Most reliable signal
+    /// because the host is the actual endpoint the request will hit.
+    static func detectProviderFromHost(baseURL: String) -> String? {
+        let host = (try? normalizedBaseURL(from: baseURL))?.host?.lowercased() ?? ""
+        for (h, name) in providerHostMap where host.contains(h) {
+            return name
+        }
+        if host == "localhost" || host == "127.0.0.1" || host.hasSuffix(".local") {
+            return "Local server"
+        }
+        return nil
+    }
+
+    /// Provider name inferred from the API key's prefix. Distinct prefixes
+    /// only — generic `sk-` falls back to OpenAI-compatible since multiple
+    /// providers ship that shape.
+    static func detectProviderFromKey(key: String) -> String? {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedKey.hasPrefix("gsk_") { return "Groq" }
+        if trimmedKey.hasPrefix("sk-ant-") { return "Anthropic" }
+        if trimmedKey.hasPrefix("xai-") { return "xAI (Grok)" }
+        if trimmedKey.hasPrefix("hf_") { return "Hugging Face" }
+        if trimmedKey.hasPrefix("csk-") { return "Cerebras" }
+        if trimmedKey.hasPrefix("sk-proj-") { return "OpenAI" }
+        if trimmedKey.hasPrefix("sk-") { return "OpenAI-compatible" }
+        return nil
+    }
+
+    /// Combined detection: prefer the host (definitive endpoint), fall back
+    /// to the key prefix when the host is unknown. Returns nil for unknown.
+    static func detectProvider(baseURL: String, key: String) -> String? {
+        if let host = detectProviderFromHost(baseURL: baseURL) { return host }
+        return detectProviderFromKey(key: key)
+    }
+
     // Upload audio file, submit for transcription, poll until done, return text
     func transcribe(fileURL: URL) async throws -> String {
         guard !Task.isCancelled else {

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -25,22 +25,89 @@ class TranscriptionService {
         self.language = (trimmedLanguage?.isEmpty == false) ? trimmedLanguage : nil
     }
 
-    // Validate API key by hitting a lightweight endpoint
+    // Validate API key by hitting a lightweight endpoint.
     static func validateAPIKey(_ key: String, baseURL: String = "https://api.groq.com/openai/v1") async -> Bool {
-        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        guard let baseURL = try? normalizedBaseURL(from: baseURL) else { return false }
+        return await validateAPIKeyDetailed(key, baseURL: baseURL) == nil
+    }
 
-        var request = URLRequest(url: baseURL.appendingPathComponent("models"))
+    /// Returns nil on success, or a specific error message on failure. Used
+    /// when the caller needs to distinguish transient failures from "key is
+    /// wrong for this provider."
+    static func validateAPIKeyDetailed(_ key: String, baseURL: String = "https://api.groq.com/openai/v1") async -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "API key is empty." }
+        guard let url = try? normalizedBaseURL(from: baseURL) else {
+            return "Base URL is not a valid URL: \(baseURL)"
+        }
+
+        var request = URLRequest(url: url.appendingPathComponent("models"))
         request.timeoutInterval = 10
         request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await LLMAPITransport.data(for: request)
+            let (data, response) = try await LLMAPITransport.data(for: request)
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-            return status == 200
+            if status == 200 { return nil }
+
+            let bodyText = String(data: data, encoding: .utf8) ?? ""
+            let snippet = String(bodyText.prefix(200))
+            switch status {
+            case 401: return "Invalid API key for \(url.host ?? "this provider")."
+            case 403: return "Key lacks permission for this endpoint (HTTP 403)."
+            case 404: return "Endpoint not found at \(url.absoluteString) (HTTP 404)."
+            case 429: return "Rate limit reached (HTTP 429). \(snippet)"
+            case 500..<600: return "Provider server error (HTTP \(status))."
+            default: return "Validation failed (HTTP \(status)). \(snippet)"
+            }
+        } catch let urlError as URLError {
+            switch urlError.code {
+            case .cannotFindHost, .dnsLookupFailed:
+                return "Cannot reach \(url.host ?? "the host"). Check the Base URL."
+            case .timedOut:
+                return "Request timed out reaching \(url.host ?? "the provider")."
+            case .notConnectedToInternet:
+                return "No internet connection."
+            default:
+                return "Network error: \(urlError.localizedDescription)"
+            }
         } catch {
-            return false
+            return "Validation failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// One-click switch presets — only providers that ship a transcription
+    /// endpoint matching the app's expected /audio/transcriptions shape.
+    struct ProviderPreset {
+        let displayName: String
+        let baseURL: String
+        let transcriptionModel: String
+        let postProcessingModel: String
+        let postProcessingFallbackModel: String
+        let contextModel: String
+    }
+
+    static func providerPreset(forName name: String) -> ProviderPreset? {
+        switch name {
+        case "Groq":
+            return ProviderPreset(
+                displayName: "Groq",
+                baseURL: "https://api.groq.com/openai/v1",
+                transcriptionModel: "whisper-large-v3",
+                postProcessingModel: "openai/gpt-oss-20b",
+                postProcessingFallbackModel: "meta-llama/llama-4-scout-17b-16e-instruct",
+                contextModel: "meta-llama/llama-4-scout-17b-16e-instruct"
+            )
+        case "OpenAI", "OpenAI-compatible":
+            return ProviderPreset(
+                displayName: "OpenAI",
+                baseURL: "https://api.openai.com/v1",
+                transcriptionModel: "whisper-1",
+                postProcessingModel: "gpt-4o-mini",
+                postProcessingFallbackModel: "gpt-4o",
+                contextModel: "gpt-4o-mini"
+            )
+        default:
+            return nil
         }
     }
 


### PR DESCRIPTION
## Why

Pasting an API key from a different provider than the one the Base URL points at used to either silently fail with a 401 (because the old Base URL got the wrong-provider key) or, if a silent auto-switch was wired up, flip URL+models to whatever the key prefix detected — both paths take agency away from the user.

This adds a verify-first auto-switch with explicit confirmation:

1. Field blur or 400ms after paste fires `autoSwitchProviderIfNeeded`.
2. If the typed key's provider does not match the configured Base URL host's provider AND there is a preset for the typed key's provider, the key is validated against THAT preset's URL.
3. On success, the UI surfaces a blue banner with a `Switch to OpenAI` button on the right. The user explicitly opts in.
4. Button click applies the preset (URL + four model fields) and lights the green success label.
5. On validation failure, a specific error replaces the banner — current settings are preserved.

<img width="600" src="https://assets.themarketingshow.com/bugs/freeflow/api-key-confirm-before-switch-banner-2026-04-30.png" alt="API Key card showing a blue checkmark banner that reads OpenAI key validated, Switch Base URL from Groq to OpenAI question mark, with a Switch to OpenAI button on the right">

*The blue confirmation banner. User pasted an OpenAI key while the Base URL still pointed at Groq. The app validated the key against `api.openai.com` (preserving the user's existing Groq settings until they opt in), and surfaced the Switch button.*

Bidirectional: works in both directions (Groq → OpenAI, OpenAI → Groq) via the same provider-preset lookup. Pending state clears when the user types in the field.

## Stacked on #169 + #170

This PR builds on the provider-feedback PR (#169, adds `detectProvider` helpers) and the masked-key PR (#170, adds the `apiKeyFocused` state used for the blur trigger). The cumulative diff against `main` includes all three. Once the parents merge, this PR rebases to show only the confirm-before-switch surface (~174 lines).

## Surface

- `Sources/TranscriptionService.swift` — `validateAPIKeyDetailed` (returns `nil` on success or a specific error message), `ProviderPreset` struct, `providerPreset(forName:)` lookup table for Groq + OpenAI.
- `Sources/SettingsView.swift` — `PendingProviderSwitch` state, `autoSwitchProviderIfNeeded`, `applyPendingProviderSwitch`, debounced task scheduling on `apiKeyInput.onChange`, blur trigger on `apiKeyFocused.onChange`, banner UI in `apiKeySection`.

## Test plan

- [x] Builds cleanly with `make`
- [ ] With Groq configured, paste a valid OpenAI key → blue banner appears within 500ms with a `Switch to OpenAI` button
- [ ] Click the Switch button → Base URL + four model fields swap to OpenAI defaults, green success label reads `API key saved — Validated as OpenAI`
- [ ] With Groq configured, paste a fake `sk-` key → red error banner reads `OpenAI rejected the key (...). Kept your Groq settings.` Base URL stays Groq.
- [ ] Type a partial key (still has prefix `sk-`) → no API call yet, debounce holds
- [ ] Same flow in reverse (OpenAI configured, paste a `gsk_` key) works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced API key security with masked display and focus-aware preview modes
  * Real-time validation with detailed error messages for configuration issues
  * Automatic provider detection from API key and base URL configuration
  * Visual status indicators showing validation results and pending provider switches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->