### PR TITLE
Add Open Run Log and Check for Updates buttons to the menu bar

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -241,13 +241,20 @@ struct MenuBarView: View {
                 NotificationCenter.default.post(name: .showSettings, object: nil)
             }
 
-            Button(updateManager.isChecking ? "Checking for Updates..." : "Check for Updates") {
+            Button {
                 Task {
                     await updateManager.checkForUpdates(userInitiated: true)
                 }
+            } label: {
+                HStack(spacing: 6) {
+                    if updateManager.isChecking {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(updateManager.isChecking ? "Checking for Updates..." : "Check for Updates")
+                }
             }
             .disabled(updateManager.isChecking)
-
             Divider()
 
             Button(appState.isDebugOverlayActive ? "Stop Debug Overlay" : "Debug Overlay") {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -236,6 +236,18 @@ struct MenuBarView: View {
                 NotificationCenter.default.post(name: .showSettings, object: nil)
             }
 
+            Button("Open Run Log") {
+                appState.selectedSettingsTab = .runLog
+                NotificationCenter.default.post(name: .showSettings, object: nil)
+            }
+
+            Button(updateManager.isChecking ? "Checking for Updates..." : "Check for Updates") {
+                Task {
+                    await updateManager.checkForUpdates(userInitiated: true)
+                }
+            }
+            .disabled(updateManager.isChecking)
+
             Divider()
 
             Button(appState.isDebugOverlayActive ? "Stop Debug Overlay" : "Debug Overlay") {


### PR DESCRIPTION
Both functions already live in Settings; the menu bar dropdown is the natural fast path. "Open Run Log" jumps to the Run Log tab. "Check for Updates" runs a manual update check and shows a spinner while in flight.

<img src="https://assets.themarketingshow.com/bugs/freeflow/menu-bar-check-updates-runlog-2026-04-30.png" width="500" alt="FreeFlow Dev menu bar dropdown showing the two new buttons between Settings and the Debug Overlay divider">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open Run Log" button to the menu bar for quick access to logs.
  * Added a manual update-check button in the menu bar that shows a spinner and "Checking for Updates..." while a check is in progress and is disabled during the check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->