### PR TITLE
Mark checkForUpdates as @MainActor to avoid an NSAlert hang

### DIFF
--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -211,6 +211,7 @@ final class UpdateManager: ObservableObject {
 
     // MARK: - Check for Updates
 
+    @MainActor
     func checkForUpdates(userInitiated: Bool) async {
         let currentBuildTag = Bundle.main.infoDictionary?["FreeFlowBuildTag"] as? String
         let currentVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"


### PR DESCRIPTION
## What happened

Clicking Check for Updates from the menu bar got stuck in the disabled "Checking for Updates..." state. The button never returned to its idle label. No alert was ever shown, no error was logged.

<img src="https://assets.themarketingshow.com/bugs/freeflow/check-for-updates-stuck-2026-04-30.png" width="500" alt="FreeFlow menu bar dropdown showing the Check for Updates button stuck in the disabled Checking for Updates state with no alert visible">

## The bug

`UpdateManager.checkForUpdates(userInitiated:)` is `async` but `UpdateManager` is not `@MainActor`-isolated. The function:

1. Sets `isChecking = true`
2. Awaits `URLSession.shared.data(for: request)`, which releases main during the network call
3. After the await, post-await code can resume on a background executor (Swift concurrency picks one based on the called function's actor isolation, which here is none)
4. Calls `showUpdateAlert()` (or one of the `showUpToDate` / `showError` / `showRecentRelease` variants), each of which calls `NSAlert.runModal()`

`NSAlert.runModal()` must be called from the main thread. Apple documents this. Calling it from a background executor is undefined behavior; on macOS Sonoma it can hang waiting for an event loop that never spins on that thread. When it hangs, `defer { isChecking = false }` never fires because the function never returns.

The bug is intermittent because Combine's `@Published` marshalling sometimes happens to resume the continuation on main, masking the issue.

## The fix

A single `@MainActor` annotation on `checkForUpdates(userInitiated:)`. After the URLSession await, control hops back to main before the modal call. URLSession's async API still releases main during the wait, so this is not a UI-blocking change — just a correctness annotation.

## Files

`Sources/UpdateManager.swift` — one line added.

## Behavior

- **Healthy paths**: zero behavioral change. The function previously resumed on main most of the time via `@Published` Combine marshalling, which is why the bug is intermittent.
- **Edge case**: deterministic resume on main, no more hang risk.

## Verified by inspection

- Every caller already runs from a `@MainActor` context: SwiftUI `Button` action closures (which inherit `@MainActor`), and the periodic-check timer handler that explicitly uses `Task { @MainActor in ... }`.
- No new `await` boundaries introduced in callers.
- I did not reproduce the hang at the keyboard during this PR — the screenshot is from an earlier session where the stuck state appeared. The fix follows from the documented `runModal` requirement plus the actor isolation analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the update checking mechanism with improved thread-safety measures to ensure more reliable update notifications and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->