### PR TITLE
Add Debug settings tab and update overlay controls

### DIFF
--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -20,10 +20,6 @@ struct FreeFlowApp: App {
 struct MenuBarLabel: View {
     @EnvironmentObject var appState: AppState
 
-    private var isDevBundle: Bool {
-        (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) == "FreeFlow Dev"
-    }
-
     private var iconName: String {
         if appState.isRecording { return "record.circle" }
         if appState.isTranscribing { return "ellipsis.circle" }
@@ -31,7 +27,7 @@ struct MenuBarLabel: View {
     }
 
     var body: some View {
-        if isDevBundle && !appState.isRecording && !appState.isTranscribing {
+        if AppBuild.isDevBundle && !appState.isRecording && !appState.isTranscribing {
             Image(nsImage: StampedMenuBarIcon.templateImage)
                 .renderingMode(.template)
         } else {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -25,8 +25,15 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case prompts
     case macros
     case runLog
+    case debug
 
     var id: String { rawValue }
+
+    static var visibleCases: [SettingsTab] {
+        allCases.filter { tab in
+            tab != .debug || AppBuild.isDevBundle
+        }
+    }
 
     var title: String {
         switch self {
@@ -34,6 +41,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .prompts: return "Prompts"
         case .macros: return "Voice Macros"
         case .runLog: return "Run Log"
+        case .debug: return "Debug"
         }
     }
 
@@ -43,7 +51,14 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .prompts: return "text.bubble"
         case .macros: return "music.mic"
         case .runLog: return "clock.arrow.circlepath"
+        case .debug: return "wrench.and.screwdriver"
         }
+    }
+}
+
+enum AppBuild {
+    static var isDevBundle: Bool {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) == "FreeFlow Dev"
     }
 }
 
@@ -509,6 +524,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var selectedSettingsTab: SettingsTab? = .general
     @Published var pipelineHistory: [PipelineHistoryItem] = []
     @Published var debugStatusMessage = "Idle"
+    @Published var debugShowsUpdateReminderAfterDictation = false
     @Published var lastRawTranscript = ""
     @Published var lastPostProcessedTranscript = ""
     @Published var lastPostProcessingPrompt = ""
@@ -2825,6 +2841,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func showPostTranscriptionUpdateReminderIfNeeded() -> Bool {
+        if debugShowsUpdateReminderAfterDictation {
+            showDebugUpdateAvailableOverlay()
+            return true
+        }
+
         let updateManager = UpdateManager.shared
         guard updateManager.shouldShowPostTranscriptionReminder() else { return false }
 
@@ -2840,6 +2861,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         return true
+    }
+
+    @MainActor
+    func showDebugUpdateAvailableOverlay() {
+        let updateManager = UpdateManager.shared
+        let version = updateManager.latestReleaseVersion.isEmpty ? "9.9.9" : updateManager.latestReleaseVersion
+        let dismissToken = UUID()
+        pendingOverlayDismissToken = dismissToken
+        overlayManager.showUpdateAvailable(version: version)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + postTranscriptionUpdateReminderDuration) { [weak self] in
+            guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
+            self.pendingOverlayDismissToken = nil
+            self.overlayManager.dismiss()
+        }
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2868,6 +2868,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let updateManager = UpdateManager.shared
         let version = updateManager.latestReleaseVersion.isEmpty ? "9.9.9" : updateManager.latestReleaseVersion
         let dismissToken = UUID()
+        if isDebugOverlayActive || debugOverlayTimer != nil {
+            stopDebugOverlay()
+        }
         pendingOverlayDismissToken = dismissToken
         overlayManager.showUpdateAvailable(version: version)
 

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -236,12 +236,6 @@ struct MenuBarView: View {
                 NotificationCenter.default.post(name: .showSettings, object: nil)
             }
 
-            Divider()
-
-            Button(appState.isDebugOverlayActive ? "Stop Debug Overlay" : "Debug Overlay") {
-                appState.toggleDebugOverlay()
-            }
-
             if updateManager.updateAvailable {
                 Divider()
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -403,14 +403,11 @@ struct SettingsView: View {
     var body: some View {
         HStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 2) {
-                ForEach(SettingsTab.allCases) { tab in
+                ForEach(SettingsTab.visibleCases) { tab in
                     Button {
                         appState.selectedSettingsTab = tab
                     } label: {
-                        Label(tab.title, systemImage: tab.icon)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 10)
+                        SettingsSidebarRow(title: tab.title, icon: tab.icon)
                             .background(
                                 RoundedRectangle(cornerRadius: 6)
                                     .fill(appState.selectedSettingsTab == tab
@@ -420,6 +417,7 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.plain)
                 }
+
                 Spacer()
             }
             .padding(10)
@@ -438,9 +436,76 @@ struct SettingsView: View {
                     VoiceMacrosSettingsView()
                 case .runLog:
                     RunLogView()
+                case .debug:
+                    DebugSettingsView()
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+private struct SettingsSidebarRow: View {
+    let title: String
+    let icon: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .regular))
+                .frame(width: 16, height: 16, alignment: .center)
+                .foregroundStyle(.primary)
+
+            Text(title)
+                .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 10)
+    }
+}
+
+// MARK: - Debug Settings
+
+struct DebugSettingsView: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Debug")
+                    .font(.largeTitle.bold())
+
+                SettingsCard("Overlay", icon: "wrench.and.screwdriver") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Show the recording overlay with simulated audio levels.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Button(appState.isDebugOverlayActive ? "Stop Debug Overlay" : "Debug Overlay") {
+                            appState.toggleDebugOverlay()
+                        }
+                    }
+                }
+
+                SettingsCard("Update Overlay", icon: "arrow.down.circle") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Display the update available overlay after dictation finishes.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Toggle("Show after dictation", isOn: $appState.debugShowsUpdateReminderAfterDictation)
+
+                        Button("Show Update Overlay Now") {
+                            appState.showDebugUpdateAvailableOverlay()
+                        }
+                    }
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added a dev-only `Debug` tab to Settings, with its sidebar entry hidden outside the dev bundle.
- Moved debug overlay controls out of the menu bar and into a dedicated Debug settings panel.
- Added a debug toggle to force the post-dictation update reminder overlay, plus a manual trigger button.
- Centralized dev bundle detection in `AppBuild` and updated the menu bar icon logic to use it.

## Testing
- Not run
- Verified the settings sidebar only renders `SettingsTab.visibleCases`, excluding `Debug` in non-dev builds.
- Verified the Debug tab renders `DebugSettingsView` and includes controls for both overlay behaviors.
- Verified the menu bar no longer shows the debug overlay button, while update availability behavior remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Debug settings tab (visible in dev builds) with controls to toggle the debug recording overlay, a "Show after dictation" update-reminder toggle, and a "Show Update Overlay Now" action to force the update overlay.

* **Refactor**
  * Removed debug overlay control from the menu bar and consolidated debug controls in the Debug settings panel.
  * Standardized settings sidebar row rendering and improved menu bar icon/dev-mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->