### PR TITLE
Add recent transcript history to menu bar

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -20,6 +20,13 @@ struct MenuBarView: View {
         return item.rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private func transcriptFull(for item: PipelineHistoryItem) -> String {
+        if !item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return item.postProcessedTranscript
+        }
+        return item.rawTranscript
+    }
+
     private func transcriptSnippet(for item: PipelineHistoryItem) -> String {
         let text = transcriptText(for: item)
             .replacingOccurrences(of: "\n", with: " ")
@@ -154,7 +161,7 @@ struct MenuBarView: View {
                     ForEach(recentHistoryItems) { item in
                         let transcript = transcriptText(for: item)
                         Button {
-                            copyTranscriptToPasteboard(transcript)
+                            copyTranscriptToPasteboard(transcriptFull(for: item))
                         } label: {
                             Text(transcriptSnippet(for: item))
                         }

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -8,6 +8,37 @@ struct MenuBarView: View {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
     }
 
+    private var recentHistoryItems: [PipelineHistoryItem] {
+        Array(appState.pipelineHistory.filter { !transcriptText(for: $0).isEmpty }.prefix(10))
+    }
+
+    private func transcriptText(for item: PipelineHistoryItem) -> String {
+        let cleaned = item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cleaned.isEmpty {
+            return cleaned
+        }
+        return item.rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func transcriptSnippet(for item: PipelineHistoryItem) -> String {
+        let text = transcriptText(for: item)
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return "(no transcript)" }
+        return text.count > 48 ? String(text.prefix(48)) + "..." : text
+    }
+
+    private func copyTranscriptToPasteboard(_ transcript: String) {
+        guard !transcript.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(transcript, forType: .string)
+    }
+
+    private func openRunLog() {
+        appState.selectedSettingsTab = .runLog
+        NotificationCenter.default.post(name: .showSettings, object: nil)
+    }
+
     var body: some View {
         VStack(spacing: 4) {
             Text("\(AppName.displayName) v\(appVersion)")
@@ -98,8 +129,9 @@ struct MenuBarView: View {
                     .lineLimit(3)
             }
 
+            Divider()
+
             if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
-                Divider()
                 Text(appState.lastTranscript.count > 35
                     ? String(appState.lastTranscript.prefix(35)) + "…"
                     : appState.lastTranscript)
@@ -112,6 +144,28 @@ struct MenuBarView: View {
                 Button("Copy Again") {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(appState.lastTranscript, forType: .string)
+                }
+            }
+
+            Menu("History") {
+                if recentHistoryItems.isEmpty {
+                    Text("No transcripts yet")
+                } else {
+                    ForEach(recentHistoryItems) { item in
+                        let transcript = transcriptText(for: item)
+                        Button {
+                            copyTranscriptToPasteboard(transcript)
+                        } label: {
+                            Text(transcriptSnippet(for: item))
+                        }
+                        .disabled(transcript.isEmpty)
+                    }
+
+                    Divider()
+                }
+
+                Button("Open Run Log") {
+                    openRunLog()
                 }
             }
 
@@ -233,11 +287,6 @@ struct MenuBarView: View {
             }
 
             Button("Settings") {
-                NotificationCenter.default.post(name: .showSettings, object: nil)
-            }
-
-            Button("Open Run Log") {
-                appState.selectedSettingsTab = .runLog
                 NotificationCenter.default.post(name: .showSettings, object: nil)
             }
 


### PR DESCRIPTION
## Summary
- Added a new `History` menu to surface up to 10 recent non-empty transcripts from pipeline history.
- Each history item shows a cleaned, truncated snippet and copies the full transcript to the pasteboard when selected.
- Moved `Open Run Log` into the new History menu and kept the menu bar layout separation clearer with a dedicated divider.

## Testing
- Not run (not requested).
- Reviewed the `MenuBarView.swift` diff to confirm history items filter empty transcripts, trim whitespace, and fall back to raw transcript text when needed.
- Verified the `Open Run Log` action still routes to the run log settings tab via `showSettings`.

Closes #150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a History dropdown showing up to 10 recent transcripts.
  * Added ability to copy full transcript content to the clipboard from the History menu.
  * Moved "Open Run Log" into the History menu for streamlined access.

* **UI/UX Improvements**
  * Adjusted menu divider placement for improved spacing and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->