### PR TITLE
Masked API key display in Settings and Setup wizard with click-to-edit

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -524,6 +524,7 @@ struct GeneralSettingsView: View {
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
+    @FocusState private var apiKeyFocused: Bool
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
@@ -953,14 +954,42 @@ struct GeneralSettingsView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 8) {
-                SecureField("Enter your Groq API key", text: $apiKeyInput)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
-                    .disabled(isValidatingKey)
-                    .onChange(of: apiKeyInput) { _ in
-                        keyValidationError = nil
-                        keyValidationSuccess = false
+                ZStack {
+                    TextField("Paste your API key", text: editableMaskedKeyBinding)
+                        .focused($apiKeyFocused)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                        .disabled(isValidatingKey)
+                        .onChange(of: apiKeyInput) { _ in
+                            keyValidationError = nil
+                            keyValidationSuccess = false
+                        }
+                        .opacity(shouldRevealMaskedKey ? 0 : 1)
+                        .allowsHitTesting(!shouldRevealMaskedKey)
+
+                    if shouldRevealMaskedKey {
+                        HStack {
+                            Text(maskedDisplayKey(apiKeyInput) ?? apiKeyInput)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.primary)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(Color(nsColor: .textBackgroundColor))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                        )
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            apiKeyFocused = true
+                        }
                     }
+                }
 
                 Button(isValidatingKey ? "Validating..." : "Save") {
                     validateAndSaveKey()
@@ -1000,6 +1029,40 @@ struct GeneralSettingsView: View {
             }
             .padding(.top, 4)
         }
+    }
+
+    /// Renders an API key as `prefix6 + 16 chars + suffix6` so the user can
+    /// identify which key is loaded without exposing the middle. Default uses
+    /// bullet for the read-only display; callers pass an asterisk for the
+    /// editable display so clicking into the field does not flood it with
+    /// heavy dots.
+    private func maskedDisplayKey(_ key: String, char: Character = "•") -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 16 else { return nil }
+        let middle = String(repeating: char, count: 16)
+        return "\(trimmed.prefix(6))\(middle)\(trimmed.suffix(6))"
+    }
+
+    /// Editable binding that shows the key as `prefix6 + 16 asterisks + suffix6`
+    /// while still letting the user Cmd-A and paste a fresh value over the top.
+    /// Any input still containing an asterisk is rejected — that signals the
+    /// user typed mid-mask rather than doing a full replacement.
+    private var editableMaskedKeyBinding: Binding<String> {
+        Binding(
+            get: { maskedDisplayKey(apiKeyInput, char: "*") ?? apiKeyInput },
+            set: { newValue in
+                if newValue.contains("*") { return }
+                apiKeyInput = newValue
+            }
+        )
+    }
+
+    /// Show the masked-preview view (instead of the editable field) when the
+    /// field is unfocused AND has enough content to safely mask.
+    private var shouldRevealMaskedKey: Bool {
+        guard !apiKeyFocused else { return false }
+        let typed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return typed.count >= 16
     }
 
     private func validateAndSaveKey() {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -74,6 +74,7 @@ struct SetupView: View {
     @State private var micPermissionGranted = false
     @State private var accessibilityGranted = false
     @State private var apiKeyInput: String = ""
+    @FocusState private var apiKeyFocused: Bool
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
@@ -413,13 +414,41 @@ struct SetupView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("API Key")
                             .font(.headline)
-                        SecureField("Paste your API key", text: $apiKeyInput)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
-                            .disabled(isValidatingKey)
-                            .onChange(of: apiKeyInput) { _ in
-                                keyValidationError = nil
+                        ZStack {
+                            TextField("Paste your API key", text: editableMaskedKeyBinding)
+                                .focused($apiKeyFocused)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.body, design: .monospaced))
+                                .disabled(isValidatingKey)
+                                .onChange(of: apiKeyInput) { _ in
+                                    keyValidationError = nil
+                                }
+                                .opacity(shouldRevealMaskedKey ? 0 : 1)
+                                .allowsHitTesting(!shouldRevealMaskedKey)
+
+                            if shouldRevealMaskedKey {
+                                HStack {
+                                    Text(maskedDisplayKey(apiKeyInput) ?? apiKeyInput)
+                                        .font(.system(.body, design: .monospaced))
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 5)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .fill(Color(nsColor: .textBackgroundColor))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                                )
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    apiKeyFocused = true
+                                }
                             }
+                        }
 
                         if let error = keyValidationError {
                             Label(error, systemImage: "xmark.circle.fill")
@@ -1278,6 +1307,38 @@ struct SetupView: View {
             }
             testAudioRecorder = nil
         }
+    }
+
+    /// Renders an API key as `prefix6 + 16 chars + suffix6` so the user can
+    /// identify which key is loaded without exposing the middle. Default
+    /// uses bullet for the read-only display; callers pass an asterisk for
+    /// the editable display.
+    private func maskedDisplayKey(_ key: String, char: Character = "•") -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 16 else { return nil }
+        let middle = String(repeating: char, count: 16)
+        return "\(trimmed.prefix(6))\(middle)\(trimmed.suffix(6))"
+    }
+
+    /// Editable binding that shows the key as `prefix6 + 16 asterisks + suffix6`
+    /// while still letting the user Cmd-A and paste a fresh value over the top.
+    /// Any input still containing an asterisk is rejected.
+    private var editableMaskedKeyBinding: Binding<String> {
+        Binding(
+            get: { maskedDisplayKey(apiKeyInput, char: "*") ?? apiKeyInput },
+            set: { newValue in
+                if newValue.contains("*") { return }
+                apiKeyInput = newValue
+            }
+        )
+    }
+
+    /// Show the masked-preview view (instead of the editable field) when the
+    /// field is unfocused AND has enough content to safely mask.
+    private var shouldRevealMaskedKey: Bool {
+        guard !apiKeyFocused else { return false }
+        let typed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return typed.count >= 16
     }
 
 }


### PR DESCRIPTION
## Why

The API Key field used to render the saved key as a featureless row of dots, indistinguishable from any other masked password field. Once you had pasted a key, you could not tell which one was loaded. Months later when swapping providers, the only signal was \"this field has dots in it\" — not which key, not which provider.

This shows the saved key as `prefix6 + 16 dots + suffix6` (`gsk_5B••••••••••••••••zX9p2c`) when the field is not focused. Tapping the field swaps to a regular `TextField` showing the same content with asterisks in place of the dots, so Cmd+A + paste replaces the value cleanly. On blur, the field returns to the dotted display.

Same treatment lands in the Setup wizard so re-running setup with a saved key shows the readable display rather than an opaque row of dots.

## Note on #170

This PR replaces #170. The previous one was stacked on #169 (provider feedback) so the GitHub diff conflated two independent changes. This branch is rebased onto plain `main` and contains only the masked-display surface (~138 lines). #170 will be closed in favor of this one.

## What changes

- **`Sources/SettingsView.swift`** — `apiKeySection` swaps the `SecureField` for a `ZStack` of an editable `TextField` plus a masked `Text` overlay. New helpers: `maskedDisplayKey(_:char:)`, `editableMaskedKeyBinding`, `shouldRevealMaskedKey`. New `@FocusState apiKeyFocused`.
- **`Sources/SetupView.swift`** — same `ZStack` pattern in the wizard's API Key step. Same three helpers.

## Test plan

- [x] Builds cleanly with `make`
- [x] Save a key in Settings, blur the field, field shows `prefix6 + 16 dots + suffix6`
- [x] Click the masked display, field swaps to editable TextField with `prefix6 + 16 asterisks + suffix6`
- [x] Cmd+A + paste a fresh key, value replaces cleanly, no asterisk leakage
- [x] Blur the field, returns to dotted display with the new key
- [x] Re-run setup, API Key step shows the same masked display for a saved key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key input fields now display a secure masked preview when unfocused, showing the first and last 6 characters for quick identification. The full editable field appears when focused for entering or updating your key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->