### PR TITLE
[codex] Add Caps Lock shortcut preset

### DIFF
--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -21,6 +21,7 @@ final class GlobalShortcutBackend {
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
     private var fnKeyIsDown = false
+    private var capsLockKeyIsDown = false
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
     var onEscapeKeyPressed: (() -> Bool)?
@@ -96,6 +97,7 @@ final class GlobalShortcutBackend {
 
     private func notifyBackendReset() {
         fnKeyIsDown = false
+        capsLockKeyIsDown = false
         _ = onInputEvent?(.backendReset)
     }
 
@@ -141,6 +143,8 @@ final class GlobalShortcutBackend {
 
         if event.keyCode == ModifierKeyEventState.fnKeyCode {
             fnKeyIsDown = isDown
+        } else if event.keyCode == ModifierKeyEventState.capsLockKeyCode {
+            capsLockKeyIsDown = isDown
         }
 
         return onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown)) == .consume
@@ -156,7 +160,8 @@ final class GlobalShortcutBackend {
         let snapshotDecision = onInputEvent?(
             .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
                 for: event,
-                trustedFunctionKeyIsDown: fnKeyIsDown
+                trustedFunctionKeyIsDown: fnKeyIsDown,
+                trustedCapsLockKeyIsDown: capsLockKeyIsDown
             ))
         ) ?? .passthrough
         let keyDecision = onInputEvent?(
@@ -170,7 +175,8 @@ final class GlobalShortcutBackend {
         let snapshotDecision = onInputEvent?(
             .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
                 for: event,
-                trustedFunctionKeyIsDown: fnKeyIsDown
+                trustedFunctionKeyIsDown: fnKeyIsDown,
+                trustedCapsLockKeyIsDown: capsLockKeyIsDown
             ))
         ) ?? .passthrough
         let keyDecision = onInputEvent?(

--- a/Sources/LocalShortcutCaptureBackend.swift
+++ b/Sources/LocalShortcutCaptureBackend.swift
@@ -58,9 +58,11 @@ final class LocalShortcutCaptureBackend {
     private func handleKeyDown(_ event: NSEvent) {
         if !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) {
             let trustedFn = pressedModifierKeyCodes.contains(ModifierKeyEventState.fnKeyCode)
+            let trustedCapsLock = pressedModifierKeyCodes.contains(ModifierKeyEventState.capsLockKeyCode)
             onInputEvent?(.modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
                 for: event,
-                trustedFunctionKeyIsDown: trustedFn
+                trustedFunctionKeyIsDown: trustedFn,
+                trustedCapsLockKeyIsDown: trustedCapsLock
             )))
             onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat))
         }

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -11,7 +11,8 @@ enum ModifierKeyEventState {
 
     static func pressedModifierKeyCodes(
         for event: NSEvent,
-        trustedFunctionKeyIsDown: Bool? = nil
+        trustedFunctionKeyIsDown: Bool? = nil,
+        trustedCapsLockKeyIsDown: Bool? = nil
     ) -> Set<UInt16> {
         ShortcutBinding.modifierKeyCodes.filter { keyCode in
             // macOS sets NSEvent.ModifierFlags.function for arrow keys, F-keys,
@@ -22,6 +23,9 @@ enum ModifierKeyEventState {
             if keyCode == fnKeyCode, let trustedFunctionKeyIsDown {
                 return trustedFunctionKeyIsDown
             }
+            if keyCode == capsLockKeyCode {
+                return trustedCapsLockKeyIsDown ?? false
+            }
             guard let mappedFlag = mappedFlag(for: keyCode) else {
                 return false
             }
@@ -30,6 +34,7 @@ enum ModifierKeyEventState {
     }
 
     static let fnKeyCode: UInt16 = 63
+    static let capsLockKeyCode = ShortcutBinding.capsLockKeyCode
 
     /// Reads the current system-wide Fn state. Useful for seeding a backend's
     /// tracked Fn state at start or after a tap reset, since flagsChanged events
@@ -46,6 +51,8 @@ enum ModifierKeyEventState {
             return .leftCommand
         case 56:
             return .leftShift
+        case 57:
+            return .capsLock
         case 58:
             return .leftOption
         case 59:

--- a/Sources/ShortcutBinding.swift
+++ b/Sources/ShortcutBinding.swift
@@ -129,6 +129,7 @@ extension ShortcutBinding {
         54: "Right Command",
         55: "Command",
         56: "Shift",
+        57: "Caps Lock",
         58: "Option",
         59: "Control",
         60: "Right Shift",

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -8,6 +8,7 @@ struct ShortcutModifiers: OptionSet, Hashable, Codable {
     static let option = ShortcutModifiers(rawValue: 1 << 2)
     static let shift = ShortcutModifiers(rawValue: 1 << 3)
     static let function = ShortcutModifiers(rawValue: 1 << 4)
+    static let capsLock = ShortcutModifiers(rawValue: 1 << 5)
 
     init(rawValue: Int) {
         self.rawValue = rawValue
@@ -30,6 +31,7 @@ struct ShortcutModifiers: OptionSet, Hashable, Codable {
         if contains(.option) { names.append("Option ⌥") }
         if contains(.shift) { names.append("Shift ⇧") }
         if contains(.function) { names.append("Fn 🌐") }
+        if contains(.capsLock) { names.append("Caps Lock ⇪") }
         return names
     }
 }
@@ -91,6 +93,7 @@ struct ShortcutConfiguration: Equatable {
 
 enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
     case fnKey = "fn"
+    case capsLock = "capsLock"
     case rightOption = "rightOption"
     case f5 = "f5"
 
@@ -99,6 +102,7 @@ enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
     var title: String {
         switch self {
         case .fnKey: return "Fn 🌐"
+        case .capsLock: return "Caps Lock ⇪"
         case .rightOption: return "Right Option ⌥"
         case .f5: return "F5"
         }
@@ -110,6 +114,14 @@ enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
             return ShortcutBinding(
                 keyCode: 63,
                 keyDisplay: "Fn",
+                modifiers: [],
+                kind: .modifierKey,
+                preset: self
+            )
+        case .capsLock:
+            return ShortcutBinding(
+                keyCode: ShortcutBinding.capsLockKeyCode,
+                keyDisplay: "Caps Lock",
                 modifiers: [],
                 kind: .modifierKey,
                 preset: self
@@ -338,12 +350,15 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     static let defaultHold = ShortcutPreset.fnKey.binding
     static let defaultToggle = ShortcutPreset.fnKey.binding.withAddedModifiers(.command)
 
-    static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
+    static let capsLockKeyCode: UInt16 = 57
+    static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
 
     static func logicalModifier(forKeyCode keyCode: UInt16) -> ShortcutModifiers? {
         switch keyCode {
         case 54, 55:
             return .command
+        case capsLockKeyCode:
+            return .capsLock
         case 59, 62:
             return .control
         case 58, 61:
@@ -389,6 +404,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         if modifiers.contains(.option) { keyCodes.insert(58) }
         if modifiers.contains(.shift) { keyCodes.insert(56) }
         if modifiers.contains(.function) { keyCodes.insert(63) }
+        if modifiers.contains(.capsLock) { keyCodes.insert(capsLockKeyCode) }
         return keyCodes
     }
 
@@ -399,6 +415,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         if modifiers.contains(.option) { keyCodes.formUnion([58, 61]) }
         if modifiers.contains(.shift) { keyCodes.formUnion([56, 60]) }
         if modifiers.contains(.function) { keyCodes.insert(63) }
+        if modifiers.contains(.capsLock) { keyCodes.insert(capsLockKeyCode) }
         return keyCodes
     }
 
@@ -420,6 +437,8 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             return "Shift"
         case 63:
             return "Fn"
+        case capsLockKeyCode:
+            return "Caps Lock"
         default:
             return "Modifier"
         }
@@ -456,6 +475,8 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             return "Right Shift \u{21E7}"
         case 63:
             return "Fn"
+        case capsLockKeyCode:
+            return "Caps Lock ⇪"
         default:
             return nil
         }
@@ -530,14 +551,15 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         return names
     }
 
-    private static let modifierDisplayOrder: [UInt16] = [55, 54, 59, 62, 58, 61, 56, 60, 63]
+    private static let modifierDisplayOrder: [UInt16] = [55, 54, 59, 62, 58, 61, 56, 60, 63, capsLockKeyCode]
 
     private static let modifierKeyCodeMatchSpecs: [(logicalModifier: ShortcutModifiers, keyCodes: Set<UInt16>)] = [
         (.command, [54, 55]),
         (.control, [59, 62]),
         (.option, [58, 61]),
         (.shift, [56, 60]),
-        (.function, [63])
+        (.function, [63]),
+        (.capsLock, [capsLockKeyCode])
     ]
 
     private static let modifierDisplaySpecs: [(logicalModifier: ShortcutModifiers, genericDisplayName: String, exactDisplayNames: [(UInt16, String)])] = [
@@ -545,6 +567,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         (.control, "Ctrl ⌃", [(59, "Ctrl ⌃"), (62, "Right Ctrl ⌃")]),
         (.option, "Option ⌥", [(58, "Option ⌥"), (61, "Right Option ⌥")]),
         (.shift, "Shift ⇧", [(56, "Shift ⇧"), (60, "Right Shift ⇧")]),
-        (.function, "Fn 🌐", [(63, "Fn 🌐")])
+        (.function, "Fn 🌐", [(63, "Fn 🌐")]),
+        (.capsLock, "Caps Lock ⇪", [(capsLockKeyCode, "Caps Lock ⇪")])
     ]
 }


### PR DESCRIPTION
## Summary
- Adds Caps Lock as a built-in shortcut preset alongside Fn, Right Option, and F5.
- Wires Caps Lock key code 57 through shortcut display, preset bindings, modifier matching, and local/global shortcut capture.
- Tracks Caps Lock from flagsChanged state explicitly so regular modifier snapshots do not infer it from the system latched flag alone.

## Validation
- `git diff --check`
- `make CODESIGN_IDENTITY=-`
