### PR TITLE
Add Caps Lock shortcut preset

### DIFF
--- a/Sources/CapsLockPhysicalKeyMonitor.swift
+++ b/Sources/CapsLockPhysicalKeyMonitor.swift
@@ -18,6 +18,7 @@ enum CapsLockPhysicalKeyMonitorError: LocalizedError {
 final class CapsLockPhysicalKeyMonitor {
     private var manager: IOHIDManager?
     private let runLoopMode = CFRunLoopMode.commonModes.rawValue
+    private var capsLockIsDown = false
 
     var onStateChanged: ((Bool) -> Void)?
 
@@ -26,8 +27,9 @@ final class CapsLockPhysicalKeyMonitor {
 
         let manager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
         let matching: CFDictionary = [
-            kIOHIDElementUsagePageKey: kHIDPage_KeyboardOrKeypad,
-            kIOHIDElementUsageKey: kHIDUsage_KeyboardCapsLock
+            kIOHIDElementTypeKey: NSNumber(value: kIOHIDElementTypeInput_Button.rawValue),
+            kIOHIDElementUsagePageKey: NSNumber(value: kHIDPage_KeyboardOrKeypad),
+            kIOHIDElementUsageKey: NSNumber(value: kHIDUsage_KeyboardCapsLock)
         ] as CFDictionary
 
         IOHIDManagerSetInputValueMatching(manager, matching)
@@ -48,6 +50,7 @@ final class CapsLockPhysicalKeyMonitor {
         guard openResult == kIOReturnSuccess else {
             IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
             IOHIDManagerRegisterInputValueCallback(manager, nil, nil)
+            capsLockIsDown = false
             os_log(.error, log: capsLockPhysicalKeyLog, "Caps Lock HID monitor failed to open: %{public}d", openResult)
             throw CapsLockPhysicalKeyMonitorError.openFailed(openResult)
         }
@@ -62,6 +65,7 @@ final class CapsLockPhysicalKeyMonitor {
         IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
         IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
         self.manager = nil
+        capsLockIsDown = false
     }
 
     deinit {
@@ -70,11 +74,16 @@ final class CapsLockPhysicalKeyMonitor {
 
     private func handleInputValue(_ value: IOHIDValue) {
         let element = IOHIDValueGetElement(value)
-        guard IOHIDElementGetUsagePage(element) == kHIDPage_KeyboardOrKeypad,
+        guard IOHIDElementGetType(element) == kIOHIDElementTypeInput_Button,
+              IOHIDElementGetUsagePage(element) == kHIDPage_KeyboardOrKeypad,
               IOHIDElementGetUsage(element) == kHIDUsage_KeyboardCapsLock else {
             return
         }
 
-        onStateChanged?(IOHIDValueGetIntegerValue(value) != 0)
+        let isDown = IOHIDValueGetIntegerValue(value) != 0
+        guard isDown != capsLockIsDown else { return }
+
+        capsLockIsDown = isDown
+        onStateChanged?(isDown)
     }
 }

--- a/Sources/CapsLockPhysicalKeyMonitor.swift
+++ b/Sources/CapsLockPhysicalKeyMonitor.swift
@@ -1,0 +1,80 @@
+import Foundation
+import IOKit.hid
+import os.log
+
+private let capsLockPhysicalKeyLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Shortcuts")
+
+enum CapsLockPhysicalKeyMonitorError: LocalizedError {
+    case openFailed(IOReturn)
+
+    var errorDescription: String? {
+        switch self {
+        case .openFailed(let result):
+            return "Caps Lock shortcut monitoring could not start because the HID keyboard monitor failed with code \(result)."
+        }
+    }
+}
+
+final class CapsLockPhysicalKeyMonitor {
+    private var manager: IOHIDManager?
+    private let runLoopMode = CFRunLoopMode.commonModes.rawValue
+
+    var onStateChanged: ((Bool) -> Void)?
+
+    func start() throws {
+        stop()
+
+        let manager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
+        let matching: CFDictionary = [
+            kIOHIDElementUsagePageKey: kHIDPage_KeyboardOrKeypad,
+            kIOHIDElementUsageKey: kHIDUsage_KeyboardCapsLock
+        ] as CFDictionary
+
+        IOHIDManagerSetInputValueMatching(manager, matching)
+        IOHIDManagerRegisterInputValueCallback(
+            manager,
+            { context, _, _, value in
+                guard let context else { return }
+                let monitor = Unmanaged<CapsLockPhysicalKeyMonitor>
+                    .fromOpaque(context)
+                    .takeUnretainedValue()
+                monitor.handleInputValue(value)
+            },
+            Unmanaged.passUnretained(self).toOpaque()
+        )
+        IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
+
+        let openResult = IOHIDManagerOpen(manager, IOOptionBits(kIOHIDOptionsTypeNone))
+        guard openResult == kIOReturnSuccess else {
+            IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
+            IOHIDManagerRegisterInputValueCallback(manager, nil, nil)
+            os_log(.error, log: capsLockPhysicalKeyLog, "Caps Lock HID monitor failed to open: %{public}d", openResult)
+            throw CapsLockPhysicalKeyMonitorError.openFailed(openResult)
+        }
+
+        self.manager = manager
+    }
+
+    func stop() {
+        guard let manager else { return }
+
+        IOHIDManagerRegisterInputValueCallback(manager, nil, nil)
+        IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
+        IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
+        self.manager = nil
+    }
+
+    deinit {
+        stop()
+    }
+
+    private func handleInputValue(_ value: IOHIDValue) {
+        let element = IOHIDValueGetElement(value)
+        guard IOHIDElementGetUsagePage(element) == kHIDPage_KeyboardOrKeypad,
+              IOHIDElementGetUsage(element) == kHIDUsage_KeyboardCapsLock else {
+            return
+        }
+
+        onStateChanged?(IOHIDValueGetIntegerValue(value) != 0)
+    }
+}

--- a/Sources/CapsLockPhysicalKeyMonitor.swift
+++ b/Sources/CapsLockPhysicalKeyMonitor.swift
@@ -16,9 +16,11 @@ enum CapsLockPhysicalKeyMonitorError: LocalizedError {
 }
 
 final class CapsLockPhysicalKeyMonitor {
+    private typealias ElementIdentifier = UInt
+
     private var manager: IOHIDManager?
     private let runLoopMode = CFRunLoopMode.commonModes.rawValue
-    private var capsLockIsDown = false
+    private var capsLockStatesByElement: [ElementIdentifier: Bool] = [:]
 
     var onStateChanged: ((Bool) -> Void)?
 
@@ -50,7 +52,7 @@ final class CapsLockPhysicalKeyMonitor {
         guard openResult == kIOReturnSuccess else {
             IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
             IOHIDManagerRegisterInputValueCallback(manager, nil, nil)
-            capsLockIsDown = false
+            capsLockStatesByElement.removeAll()
             os_log(.error, log: capsLockPhysicalKeyLog, "Caps Lock HID monitor failed to open: %{public}d", openResult)
             throw CapsLockPhysicalKeyMonitorError.openFailed(openResult)
         }
@@ -65,7 +67,7 @@ final class CapsLockPhysicalKeyMonitor {
         IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
         IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
         self.manager = nil
-        capsLockIsDown = false
+        capsLockStatesByElement.removeAll()
     }
 
     deinit {
@@ -81,9 +83,18 @@ final class CapsLockPhysicalKeyMonitor {
         }
 
         let isDown = IOHIDValueGetIntegerValue(value) != 0
-        guard isDown != capsLockIsDown else { return }
+        let elementID = Self.elementIdentifier(for: element)
+        guard capsLockStatesByElement[elementID] != isDown else { return }
 
-        capsLockIsDown = isDown
-        onStateChanged?(isDown)
+        let wasAnyCapsLockDown = capsLockStatesByElement.values.contains(true)
+        capsLockStatesByElement[elementID] = isDown
+        let isAnyCapsLockDown = capsLockStatesByElement.values.contains(true)
+        guard wasAnyCapsLockDown != isAnyCapsLockDown else { return }
+
+        onStateChanged?(isAnyCapsLockDown)
+    }
+
+    private static func elementIdentifier(for element: IOHIDElement) -> ElementIdentifier {
+        UInt(bitPattern: Unmanaged.passUnretained(element).toOpaque())
     }
 }

--- a/Sources/CapsLockPhysicalKeyMonitor.swift
+++ b/Sources/CapsLockPhysicalKeyMonitor.swift
@@ -16,7 +16,12 @@ enum CapsLockPhysicalKeyMonitorError: LocalizedError {
 }
 
 final class CapsLockPhysicalKeyMonitor {
-    private typealias ElementIdentifier = UInt
+    private typealias DeviceIdentifier = UInt
+
+    private struct ElementIdentifier: Hashable {
+        let deviceID: DeviceIdentifier
+        let cookie: IOHIDElementCookie
+    }
 
     private var manager: IOHIDManager?
     private let runLoopMode = CFRunLoopMode.commonModes.rawValue
@@ -46,11 +51,23 @@ final class CapsLockPhysicalKeyMonitor {
             },
             Unmanaged.passUnretained(self).toOpaque()
         )
+        IOHIDManagerRegisterDeviceRemovalCallback(
+            manager,
+            { context, _, _, device in
+                guard let context else { return }
+                let monitor = Unmanaged<CapsLockPhysicalKeyMonitor>
+                    .fromOpaque(context)
+                    .takeUnretainedValue()
+                monitor.handleDeviceRemoval(device)
+            },
+            Unmanaged.passUnretained(self).toOpaque()
+        )
         IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
 
         let openResult = IOHIDManagerOpen(manager, IOOptionBits(kIOHIDOptionsTypeNone))
         guard openResult == kIOReturnSuccess else {
             IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
+            IOHIDManagerRegisterDeviceRemovalCallback(manager, nil, nil)
             IOHIDManagerRegisterInputValueCallback(manager, nil, nil)
             capsLockStatesByElement.removeAll()
             os_log(.error, log: capsLockPhysicalKeyLog, "Caps Lock HID monitor failed to open: %{public}d", openResult)
@@ -63,6 +80,7 @@ final class CapsLockPhysicalKeyMonitor {
     func stop() {
         guard let manager else { return }
 
+        IOHIDManagerRegisterDeviceRemovalCallback(manager, nil, nil)
         IOHIDManagerRegisterInputValueCallback(manager, nil, nil)
         IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), runLoopMode)
         IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
@@ -94,7 +112,26 @@ final class CapsLockPhysicalKeyMonitor {
         onStateChanged?(isAnyCapsLockDown)
     }
 
+    private func handleDeviceRemoval(_ device: IOHIDDevice) {
+        let deviceID = Self.deviceIdentifier(for: device)
+        let wasAnyCapsLockDown = capsLockStatesByElement.values.contains(true)
+        capsLockStatesByElement = capsLockStatesByElement.filter { elementID, _ in
+            elementID.deviceID != deviceID
+        }
+        let isAnyCapsLockDown = capsLockStatesByElement.values.contains(true)
+        guard wasAnyCapsLockDown != isAnyCapsLockDown else { return }
+
+        onStateChanged?(isAnyCapsLockDown)
+    }
+
     private static func elementIdentifier(for element: IOHIDElement) -> ElementIdentifier {
-        UInt(bitPattern: Unmanaged.passUnretained(element).toOpaque())
+        ElementIdentifier(
+            deviceID: deviceIdentifier(for: IOHIDElementGetDevice(element)),
+            cookie: IOHIDElementGetCookie(element)
+        )
+    }
+
+    private static func deviceIdentifier(for device: IOHIDDevice) -> DeviceIdentifier {
+        UInt(bitPattern: Unmanaged.passUnretained(device).toOpaque())
     }
 }

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -21,6 +21,7 @@ final class GlobalShortcutBackend {
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
     private var fnKeyIsDown = false
+    private var capsLockKeyIsDown = false
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
     var onEscapeKeyPressed: (() -> Bool)?
@@ -96,6 +97,7 @@ final class GlobalShortcutBackend {
 
     private func notifyBackendReset() {
         fnKeyIsDown = false
+        capsLockKeyIsDown = false
         _ = onInputEvent?(.backendReset)
     }
 
@@ -141,6 +143,8 @@ final class GlobalShortcutBackend {
 
         if event.keyCode == ModifierKeyEventState.fnKeyCode {
             fnKeyIsDown = isDown
+        } else if event.keyCode == ModifierKeyEventState.capsLockKeyCode {
+            capsLockKeyIsDown = isDown
         }
 
         return onInputEvent?(.modifierChanged(keyCode: event.keyCode, isDown: isDown)) == .consume
@@ -156,7 +160,8 @@ final class GlobalShortcutBackend {
         let snapshotDecision = onInputEvent?(
             .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
                 for: event,
-                trustedFunctionKeyIsDown: fnKeyIsDown
+                trustedFunctionKeyIsDown: fnKeyIsDown,
+                trustedCapsLockKeyIsDown: capsLockKeyIsDown
             ))
         ) ?? .passthrough
         let keyDecision = onInputEvent?(
@@ -170,7 +175,8 @@ final class GlobalShortcutBackend {
         let snapshotDecision = onInputEvent?(
             .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
                 for: event,
-                trustedFunctionKeyIsDown: fnKeyIsDown
+                trustedFunctionKeyIsDown: fnKeyIsDown,
+                trustedCapsLockKeyIsDown: capsLockKeyIsDown
             ))
         ) ?? .passthrough
         let keyDecision = onInputEvent?(

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -6,6 +6,7 @@ private let shortcutLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "
 enum GlobalShortcutBackendError: LocalizedError {
     case eventTapUnavailable
     case eventTapRunLoopSourceUnavailable
+    case capsLockPhysicalMonitorUnavailable(String)
 
     var errorDescription: String? {
         switch self {
@@ -13,6 +14,8 @@ enum GlobalShortcutBackendError: LocalizedError {
             return "Global shortcut monitoring could not start. \(AppName.displayName) requires keyboard monitoring permission for global shortcuts."
         case .eventTapRunLoopSourceUnavailable:
             return "Global shortcut monitoring could not start because the event tap run loop source could not be created."
+        case .capsLockPhysicalMonitorUnavailable(let reason):
+            return "Global shortcut monitoring could not start for Caps Lock. \(reason)"
         }
     }
 }
@@ -22,14 +25,23 @@ final class GlobalShortcutBackend {
     private var eventTapRunLoopSource: CFRunLoopSource?
     private var fnKeyIsDown = false
     private var capsLockKeyIsDown = false
+    private var capsLockPhysicalKeyMonitor: CapsLockPhysicalKeyMonitor?
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
     var onEscapeKeyPressed: (() -> Bool)?
 
-    func start() throws {
+    func start(tracksCapsLock: Bool = false) throws {
         stop()
         try installEventTap()
         fnKeyIsDown = ModifierKeyEventState.currentFunctionKeyIsDown()
+        if tracksCapsLock {
+            do {
+                try installCapsLockPhysicalKeyMonitor()
+            } catch {
+                tearDownEventTap()
+                throw error
+            }
+        }
     }
 
     func stop() {
@@ -93,6 +105,7 @@ final class GlobalShortcutBackend {
             CFMachPortInvalidate(tap)
         }
         eventTap = nil
+        tearDownCapsLockPhysicalKeyMonitor()
     }
 
     private func notifyBackendReset() {
@@ -141,6 +154,11 @@ final class GlobalShortcutBackend {
             return false
         }
 
+        if event.keyCode == ModifierKeyEventState.capsLockKeyCode,
+           capsLockPhysicalKeyMonitor != nil {
+            return false
+        }
+
         if event.keyCode == ModifierKeyEventState.fnKeyCode {
             fnKeyIsDown = isDown
         } else if event.keyCode == ModifierKeyEventState.capsLockKeyCode {
@@ -183,5 +201,29 @@ final class GlobalShortcutBackend {
             .keyChanged(keyCode: event.keyCode, isDown: false, isRepeat: false)
         ) ?? .passthrough
         return snapshotDecision == .consume || keyDecision == .consume
+    }
+
+    private func installCapsLockPhysicalKeyMonitor() throws {
+        let monitor = CapsLockPhysicalKeyMonitor()
+        monitor.onStateChanged = { [weak self] isDown in
+            guard let self else { return }
+            capsLockKeyIsDown = isDown
+            _ = onInputEvent?(.modifierChanged(
+                keyCode: ModifierKeyEventState.capsLockKeyCode,
+                isDown: isDown
+            ))
+        }
+
+        do {
+            try monitor.start()
+            capsLockPhysicalKeyMonitor = monitor
+        } catch {
+            throw GlobalShortcutBackendError.capsLockPhysicalMonitorUnavailable(error.localizedDescription)
+        }
+    }
+
+    private func tearDownCapsLockPhysicalKeyMonitor() {
+        capsLockPhysicalKeyMonitor?.stop()
+        capsLockPhysicalKeyMonitor = nil
     }
 }

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -25,6 +25,7 @@ final class GlobalShortcutBackend {
     private var eventTapRunLoopSource: CFRunLoopSource?
     private var fnKeyIsDown = false
     private var capsLockKeyIsDown = false
+    private var capsLockConsumeDecision: ShortcutConsumeDecision = .passthrough
     private var capsLockPhysicalKeyMonitor: CapsLockPhysicalKeyMonitor?
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
@@ -111,6 +112,7 @@ final class GlobalShortcutBackend {
     private func notifyBackendReset() {
         fnKeyIsDown = false
         capsLockKeyIsDown = false
+        capsLockConsumeDecision = .passthrough
         _ = onInputEvent?(.backendReset)
     }
 
@@ -121,6 +123,10 @@ final class GlobalShortcutBackend {
             if let tap = eventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)
                 fnKeyIsDown = ModifierKeyEventState.currentFunctionKeyIsDown()
+                // The eventTap can reseed fnKeyIsDown from NSEvent state, but
+                // capsLockKeyIsDown cannot use modifier flags because they
+                // report the latched Caps Lock state, not the physical key.
+                // The HID monitor will restore it on the next physical edge.
             }
             return Unmanaged.passUnretained(event)
 
@@ -154,14 +160,12 @@ final class GlobalShortcutBackend {
             return false
         }
 
-        if event.keyCode == ModifierKeyEventState.capsLockKeyCode,
-           capsLockPhysicalKeyMonitor != nil {
-            return false
-        }
-
         if event.keyCode == ModifierKeyEventState.fnKeyCode {
             fnKeyIsDown = isDown
         } else if event.keyCode == ModifierKeyEventState.capsLockKeyCode {
+            guard capsLockPhysicalKeyMonitor == nil else {
+                return capsLockConsumeDecision == .consume
+            }
             capsLockKeyIsDown = isDown
         }
 
@@ -208,10 +212,10 @@ final class GlobalShortcutBackend {
         monitor.onStateChanged = { [weak self] isDown in
             guard let self else { return }
             capsLockKeyIsDown = isDown
-            _ = onInputEvent?(.modifierChanged(
+            capsLockConsumeDecision = onInputEvent?(.modifierChanged(
                 keyCode: ModifierKeyEventState.capsLockKeyCode,
                 isDown: isDown
-            ))
+            )) ?? .passthrough
         }
 
         do {

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -29,7 +29,7 @@ final class HotkeyManager {
             self?.onEscapeKeyPressed?() ?? false
         }
         do {
-            try backend.start()
+            try backend.start(tracksCapsLock: configuration.hold.usesCapsLockKey || configuration.toggle.usesCapsLockKey)
         } catch {
             backend.onInputEvent = nil
             backend.onEscapeKeyPressed = nil

--- a/Sources/LocalShortcutCaptureBackend.swift
+++ b/Sources/LocalShortcutCaptureBackend.swift
@@ -58,9 +58,11 @@ final class LocalShortcutCaptureBackend {
     private func handleKeyDown(_ event: NSEvent) {
         if !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) {
             let trustedFn = pressedModifierKeyCodes.contains(ModifierKeyEventState.fnKeyCode)
+            let trustedCapsLock = pressedModifierKeyCodes.contains(ModifierKeyEventState.capsLockKeyCode)
             onInputEvent?(.modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(
                 for: event,
-                trustedFunctionKeyIsDown: trustedFn
+                trustedFunctionKeyIsDown: trustedFn,
+                trustedCapsLockKeyIsDown: trustedCapsLock
             )))
             onInputEvent?(.keyChanged(keyCode: event.keyCode, isDown: true, isRepeat: event.isARepeat))
         }

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -11,7 +11,8 @@ enum ModifierKeyEventState {
 
     static func pressedModifierKeyCodes(
         for event: NSEvent,
-        trustedFunctionKeyIsDown: Bool? = nil
+        trustedFunctionKeyIsDown: Bool? = nil,
+        trustedCapsLockKeyIsDown: Bool? = nil
     ) -> Set<UInt16> {
         ShortcutBinding.modifierKeyCodes.filter { keyCode in
             // macOS sets NSEvent.ModifierFlags.function for arrow keys, F-keys,
@@ -22,6 +23,9 @@ enum ModifierKeyEventState {
             if keyCode == fnKeyCode, let trustedFunctionKeyIsDown {
                 return trustedFunctionKeyIsDown
             }
+            if keyCode == capsLockKeyCode {
+                return trustedCapsLockKeyIsDown ?? false
+            }
             guard let mappedFlag = mappedFlag(for: keyCode) else {
                 return false
             }
@@ -30,6 +34,7 @@ enum ModifierKeyEventState {
     }
 
     static let fnKeyCode: UInt16 = 63
+    static let capsLockKeyCode = ShortcutBinding.capsLockKeyCode
 
     /// Reads the current system-wide Fn state. Useful for seeding a backend's
     /// tracked Fn state at start or after a tap reset, since flagsChanged events
@@ -46,6 +51,8 @@ enum ModifierKeyEventState {
             return .leftCommand
         case 56:
             return .leftShift
+        case 57:
+            return .capsLock
         case 58:
             return .leftOption
         case 59:

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -23,6 +23,9 @@ enum ModifierKeyEventState {
             if keyCode == fnKeyCode, let trustedFunctionKeyIsDown {
                 return trustedFunctionKeyIsDown
             }
+            // Unlike fnKeyCode/trustedFunctionKeyIsDown, Caps Lock cannot
+            // fall back to event flags: they report the latched lock state.
+            // Without trustedCapsLockKeyIsDown, treat capsLockKeyCode as up.
             if keyCode == capsLockKeyCode {
                 return trustedCapsLockKeyIsDown ?? false
             }

--- a/Sources/ShortcutBinding.swift
+++ b/Sources/ShortcutBinding.swift
@@ -129,6 +129,7 @@ extension ShortcutBinding {
         54: "Right Command",
         55: "Command",
         56: "Shift",
+        57: "Caps Lock",
         58: "Option",
         59: "Control",
         60: "Right Shift",

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -204,6 +204,11 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         return keyCode == 63 || modifiers.contains(.function)
     }
 
+    var usesCapsLockKey: Bool {
+        guard !isDisabled else { return false }
+        return keyCode == Self.capsLockKeyCode || modifiers.contains(.capsLock)
+    }
+
     var requiresExactModifierMatch: Bool {
         kind == .modifierKey || exactModifierKeyCodes != nil
     }

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -8,6 +8,7 @@ struct ShortcutModifiers: OptionSet, Hashable, Codable {
     static let option = ShortcutModifiers(rawValue: 1 << 2)
     static let shift = ShortcutModifiers(rawValue: 1 << 3)
     static let function = ShortcutModifiers(rawValue: 1 << 4)
+    static let capsLock = ShortcutModifiers(rawValue: 1 << 5)
 
     init(rawValue: Int) {
         self.rawValue = rawValue
@@ -30,6 +31,7 @@ struct ShortcutModifiers: OptionSet, Hashable, Codable {
         if contains(.option) { names.append("Option ⌥") }
         if contains(.shift) { names.append("Shift ⇧") }
         if contains(.function) { names.append("Fn 🌐") }
+        if contains(.capsLock) { names.append("Caps Lock ⇪") }
         return names
     }
 }
@@ -91,6 +93,7 @@ struct ShortcutConfiguration: Equatable {
 
 enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
     case fnKey = "fn"
+    case capsLock = "capsLock"
     case rightOption = "rightOption"
     case f5 = "f5"
 
@@ -99,6 +102,7 @@ enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
     var title: String {
         switch self {
         case .fnKey: return "Fn 🌐"
+        case .capsLock: return "Caps Lock ⇪"
         case .rightOption: return "Right Option ⌥"
         case .f5: return "F5"
         }
@@ -110,6 +114,14 @@ enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
             return ShortcutBinding(
                 keyCode: 63,
                 keyDisplay: "Fn",
+                modifiers: [],
+                kind: .modifierKey,
+                preset: self
+            )
+        case .capsLock:
+            return ShortcutBinding(
+                keyCode: ShortcutBinding.capsLockKeyCode,
+                keyDisplay: "Caps Lock",
                 modifiers: [],
                 kind: .modifierKey,
                 preset: self
@@ -338,12 +350,15 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     static let defaultHold = ShortcutPreset.fnKey.binding
     static let defaultToggle = ShortcutPreset.fnKey.binding.withAddedModifiers(.command)
 
-    static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
+    static let capsLockKeyCode: UInt16 = 57
+    static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
 
     static func logicalModifier(forKeyCode keyCode: UInt16) -> ShortcutModifiers? {
         switch keyCode {
         case 54, 55:
             return .command
+        case capsLockKeyCode:
+            return .capsLock
         case 59, 62:
             return .control
         case 58, 61:
@@ -389,6 +404,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         if modifiers.contains(.option) { keyCodes.insert(58) }
         if modifiers.contains(.shift) { keyCodes.insert(56) }
         if modifiers.contains(.function) { keyCodes.insert(63) }
+        if modifiers.contains(.capsLock) { keyCodes.insert(capsLockKeyCode) }
         return keyCodes
     }
 
@@ -399,6 +415,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         if modifiers.contains(.option) { keyCodes.formUnion([58, 61]) }
         if modifiers.contains(.shift) { keyCodes.formUnion([56, 60]) }
         if modifiers.contains(.function) { keyCodes.insert(63) }
+        if modifiers.contains(.capsLock) { keyCodes.insert(capsLockKeyCode) }
         return keyCodes
     }
 
@@ -420,6 +437,8 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             return "Shift"
         case 63:
             return "Fn"
+        case capsLockKeyCode:
+            return "Caps Lock"
         default:
             return "Modifier"
         }
@@ -456,6 +475,8 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
             return "Right Shift \u{21E7}"
         case 63:
             return "Fn"
+        case capsLockKeyCode:
+            return "Caps Lock ⇪"
         default:
             return nil
         }
@@ -530,14 +551,15 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         return names
     }
 
-    private static let modifierDisplayOrder: [UInt16] = [55, 54, 59, 62, 58, 61, 56, 60, 63]
+    private static let modifierDisplayOrder: [UInt16] = [55, 54, 59, 62, 58, 61, 56, 60, 63, capsLockKeyCode]
 
     private static let modifierKeyCodeMatchSpecs: [(logicalModifier: ShortcutModifiers, keyCodes: Set<UInt16>)] = [
         (.command, [54, 55]),
         (.control, [59, 62]),
         (.option, [58, 61]),
         (.shift, [56, 60]),
-        (.function, [63])
+        (.function, [63]),
+        (.capsLock, [capsLockKeyCode])
     ]
 
     private static let modifierDisplaySpecs: [(logicalModifier: ShortcutModifiers, genericDisplayName: String, exactDisplayNames: [(UInt16, String)])] = [
@@ -545,6 +567,7 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         (.control, "Ctrl ⌃", [(59, "Ctrl ⌃"), (62, "Right Ctrl ⌃")]),
         (.option, "Option ⌥", [(58, "Option ⌥"), (61, "Right Option ⌥")]),
         (.shift, "Shift ⇧", [(56, "Shift ⇧"), (60, "Right Shift ⇧")]),
-        (.function, "Fn 🌐", [(63, "Fn 🌐")])
+        (.function, "Fn 🌐", [(63, "Fn 🌐")]),
+        (.capsLock, "Caps Lock ⇪", [(capsLockKeyCode, "Caps Lock ⇪")])
     ]
 }


### PR DESCRIPTION
## Summary
- Adds Caps Lock as a built-in shortcut preset alongside Fn, Right Option, and F5.
- Wires Caps Lock key code 57 through shortcut display, preset bindings, modifier matching, and local/global shortcut capture.
- Tracks Caps Lock physical key state separately from the macOS latched Caps Lock flag so hold mode can stop on release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Caps Lock is now a first-class shortcut modifier with visible labels, an ordered display name, and a preset.
  * Optional physical Caps Lock monitoring can be enabled for more reliable detection.

* **Bug Fixes**
  * Improved Caps Lock state accuracy across modifier events and lifecycle (monitor stops on teardown/reset).
  * Physical monitor setup failures now surface explicit error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->