### PR TITLE
Dictation: migrate legacy “audio interruption mode” to mute toggle storage

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -229,7 +229,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let outputLanguageStorageKey = "output_language"
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
-    private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
+    private static let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
+    /// Migrates users who stored the picker `mute`/`pause`/`disabled` variant.
+    private static let dictationAudioInterruptionModeStorageKey = "dictation_audio_interruption_mode"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
     private let clipboardRestoreDelay: TimeInterval = 1.0
@@ -465,10 +467,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @Published var dictationAudioInterruptionEnabled: Bool {
         didSet {
-            UserDefaults.standard.set(
-                dictationAudioInterruptionEnabled,
-                forKey: dictationAudioInterruptionEnabledStorageKey
-            )
+            UserDefaults.standard.set(dictationAudioInterruptionEnabled, forKey: Self.dictationAudioInterruptionEnabledStorageKey)
+            UserDefaults.standard.removeObject(forKey: Self.dictationAudioInterruptionModeStorageKey)
         }
     }
 
@@ -635,9 +635,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
-        let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
-            forKey: dictationAudioInterruptionEnabledStorageKey
-        )
+        let dictationAudioInterruptionEnabled = Self.loadDictationAudioInterruptionEnabled()
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -848,6 +846,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
             binding: fallback,
             didUpdateStoredValue: stored.hadStoredValue || fallback != nil
         )
+    }
+
+    private static func loadDictationAudioInterruptionEnabled() -> Bool {
+        if UserDefaults.standard.object(forKey: dictationAudioInterruptionEnabledStorageKey) != nil {
+            return UserDefaults.standard.bool(forKey: dictationAudioInterruptionEnabledStorageKey)
+        }
+        if let raw = UserDefaults.standard.string(forKey: dictationAudioInterruptionModeStorageKey) {
+            let enabled = (raw == "mute")
+            UserDefaults.standard.set(enabled, forKey: dictationAudioInterruptionEnabledStorageKey)
+            UserDefaults.standard.removeObject(forKey: dictationAudioInterruptionModeStorageKey)
+            return enabled
+        }
+        return false
     }
 
     static func normalizedContextScreenshotMaxDimension(_ value: Int) -> Int {


### PR DESCRIPTION
## What problem this solves

While you dictate, sound from the Mac’s **default output** (music, calls, notification chimes, etc.) can still play. That is distracting, can bleed into the microphone, and makes it harder to hear yourself think. FreeFlow can **temporarily mute that default output for the duration of a dictation session** and **return it to how it was afterward** (Settings → **Mute audio when dictation starts**).

This is **output mute** via Core Audio, not a global “media play/pause” control for third-party players.

## High-level summary

- **User-facing behavior:** Same as today on `main` when the toggle is on: mute default output for active dictation, restore prior mute state when dictation ends.
- **What this PR changes:** Makes **saved preferences reliable** for installs that still have the older `dictation_audio_interruption_mode` string (from when the app stored a `mute` / `pause` / `off` style mode) by migrating once to the current boolean `dictation_audio_interruption_enabled`, then dropping the legacy key.

## Code details

- If `dictation_audio_interruption_enabled` is already present, its value is used as today.
- Otherwise, if `dictation_audio_interruption_mode` exists: `mute` → enabled, any other value → disabled; persist the bool and remove the mode key.
- When the user toggles the checkbox, also remove `dictation_audio_interruption_mode` so stale values cannot linger.
