### PR TITLE
Add in-pill error notifications

### DIFF
--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -10,6 +10,7 @@ final class RecordingOverlayState: ObservableObject {
     @Published var isCommandMode = false
     @Published var updateVersion: String = ""
     @Published var errorMessage: String?
+    @Published var toastID: UUID?
 }
 
 enum OverlayPhase {
@@ -164,17 +165,21 @@ final class RecordingOverlayManager {
             return String(message[..<cutoff]) + "…"
         }()
         DispatchQueue.main.async {
+            let toastID = UUID()
             self.overlayState.errorMessage = truncated
+            self.overlayState.toastID = toastID
             self.lockedOverlayWidth = nil
             self.overlayState.phase = .feedback
             self.showOverlayPanel(animatedResize: true)
             DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) { [weak self] in
                 guard let self else { return }
                 guard self.overlayState.phase == .feedback,
-                      self.overlayState.errorMessage == truncated else {
+                      self.overlayState.errorMessage == truncated,
+                      self.overlayState.toastID == toastID else {
                     return
                 }
                 self.overlayState.errorMessage = nil
+                self.overlayState.toastID = nil
                 self.dismissAll()
             }
         }

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -9,6 +9,7 @@ final class RecordingOverlayState: ObservableObject {
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
     @Published var isCommandMode = false
     @Published var updateVersion: String = ""
+    @Published var errorMessage: String?
 }
 
 enum OverlayPhase {
@@ -145,6 +146,40 @@ final class RecordingOverlayManager {
         }
     }
 
+    /// Maximum length of an in-pill error message. Anything longer is
+    /// truncated with an ellipsis to keep the pill from stretching across
+    /// the menu bar; the full text remains available in `os_log` for
+    /// forensic review.
+    private static let maxToastMessageLength = 90
+
+    /// Surface a transient error in the menu-bar pill. The pill resizes to
+    /// fit the message (subject to the truncation cap), holds for a few
+    /// seconds, then dismisses. Intended for non-fatal user-facing errors
+    /// that previously only landed in `os_log` — rate limits, network
+    /// failures, permission gaps, etc.
+    func showError(_ message: String) {
+        let truncated: String = {
+            if message.count <= Self.maxToastMessageLength { return message }
+            let cutoff = message.index(message.startIndex, offsetBy: Self.maxToastMessageLength - 1)
+            return String(message[..<cutoff]) + "…"
+        }()
+        DispatchQueue.main.async {
+            self.overlayState.errorMessage = truncated
+            self.lockedOverlayWidth = nil
+            self.overlayState.phase = .feedback
+            self.showOverlayPanel(animatedResize: true)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) { [weak self] in
+                guard let self else { return }
+                guard self.overlayState.phase == .feedback,
+                      self.overlayState.errorMessage == truncated else {
+                    return
+                }
+                self.overlayState.errorMessage = nil
+                self.dismissAll()
+            }
+        }
+    }
+
     func showUpdateAvailable(version: String) {
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
@@ -255,7 +290,19 @@ final class RecordingOverlayManager {
         }
 
         if overlayState.phase == .feedback {
-            let feedbackWidth: CGFloat = 92
+            // Error toasts size to the message length so short messages do
+            // not get the same wide pill as long ones. ~6.8pt per character
+            // plus 60pt of icon and padding chrome, clamped to 180-420pt so
+            // very short messages stay readable and very long ones do not
+            // stretch the pill across the menu bar. Bare failure-X marker
+            // (no message) keeps the original 92pt.
+            let feedbackWidth: CGFloat = {
+                guard let msg = overlayState.errorMessage, !msg.isEmpty else {
+                    return 92
+                }
+                let estimated = CGFloat(msg.count) * 6.8 + 60
+                return min(420, max(180, estimated))
+            }()
             guard screenHasNotch else { return feedbackWidth }
             return max(notchWidth, feedbackWidth)
         }
@@ -523,7 +570,9 @@ struct RecordingOverlayView: View {
 
     var body: some View {
         Group {
-            if state.phase == .feedback {
+            if state.phase == .feedback, let message = state.errorMessage {
+                ErrorOverlayView(message: message)
+            } else if state.phase == .feedback {
                 FailureIndicatorView()
             } else if state.phase == .updateAvailable {
                 UpdateAvailableOverlayView(onPress: onUpdateOverlayPressed)
@@ -602,6 +651,27 @@ struct FailureIndicatorView: View {
             .frame(width: 20, height: 20)
             .background(Circle().fill(Color.red.opacity(0.92)))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// In-pill error toast. Red exclamation icon plus the message text,
+/// rendered inside the standard menu-bar pill. Sized by the manager's
+/// `overlayWidth` based on message length.
+struct ErrorOverlayView: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(Color.red.opacity(0.92))
+            Text(message)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
 }
 


### PR DESCRIPTION
## What

Adds reusable in-pill error notification infrastructure. A new `showError(_:)` method on `RecordingOverlayManager` surfaces a transient error toast in the menu-bar pill instead of leaving the error buried in `os_log`.

## Why

Errors thrown from `Recording` and `PostProcessing` paths (rate limits, network drops, permission denials) only land in `os_log` today. The user has no UI signal — dictation appears to silently stop working, with the root cause hidden in Console.app.

Concrete example from a single hot dictation session:

```
15:05:35  Post-processing failed with status 429: ... tokens per day (TPD) ...
15:12:47  Post-processing failed with status 429: ... tokens per day (TPD) ...
15:13:10  Post-processing failed with status 429: ... tokens per day (TPD) ...
15:14:10  Post-processing failed with status 429: ... tokens per day (TPD) ...
15:16:48  Post-processing failed with status 429: ... tokens per day (TPD) ...
```

Five Edit Mode failures in 12 minutes. None visible to the user. Edit Mode silently returned the original selection unchanged each time.

## How

- `RecordingOverlayState` gains an `errorMessage: String?` slot.
- `RecordingOverlayManager.showError(_:)` truncates >90 chars, fires a feedback-phase pill, auto-dismisses after 6s.
- `ErrorOverlayView` renders a red exclamation icon plus the message text inside the standard pill chrome.
- Pill width auto-sizes to message length (clamped 180-420pt) so short toasts get a snug pill and long ones do not stretch the pill across the menu bar.

## Example

<img src="https://assets.themarketingshow.com/bugs/freeflow/in-pill-error-toast-2026-05-06.png" width="500">

(Example toast — the message text shown is illustrative; this PR ships the infrastructure only, no internal callers.)

## Scope

Pure infrastructure addition. No existing call sites are rewired in this PR — `showError` is added as a public API for future use. A follow-up PR will route specific failure paths (post-processing 429s, etc.) through it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recording overlay now shows transient in‑pill error toasts with a red exclamation icon and a single-line, tail‑truncated message.
  * Error toasts auto-dismiss after ~6 seconds and the pill resizes dynamically based on message length (within min/max bounds).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->