### PR TITLE
Add Groq backup-key auto-rotation for free-tier survivability

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -198,6 +198,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private let apiKeyStorageKey = "groq_api_key"
+    // Backup Groq key for free-tier survivability — when the active key
+    // returns a 429 with `tokens per day` (per-org daily cap exhausted),
+    // the post-processing path swaps to the other key and retries once.
+    // Per-minute throttling does NOT trigger rotation; the existing model
+    // fallback handles that.
+    private let apiKeyBackupStorageKey = "groq_api_key_backup"
+    private let activeKeyIsBackupStorageKey = "groq_active_key_is_backup"
     private let apiBaseURLStorageKey = "api_base_url"
     private let transcriptionModelStorageKey = "transcription_model"
     private let transcriptionAPIURLStorageKey = "transcription_api_url"
@@ -287,6 +294,33 @@ final class AppState: ObservableObject, @unchecked Sendable {
             persistAPIKey(apiKey)
             rebuildContextService()
         }
+    }
+
+    @Published var apiKeyBackup: String {
+        didSet {
+            persistOptionalAPIValue(apiKeyBackup, account: apiKeyBackupStorageKey)
+        }
+    }
+
+    /// When true, the backup key is the live one. Flipped automatically by
+    /// `rotateAPIKeyIfDailyExhausted` when the active key returns a TPD 429.
+    /// Persists across launches so an exhausted key is not retried after
+    /// a restart.
+    @Published var activeKeyIsBackup: Bool {
+        didSet {
+            UserDefaults.standard.set(activeKeyIsBackup, forKey: activeKeyIsBackupStorageKey)
+            rebuildContextService()
+        }
+    }
+
+    /// Resolves to whichever key is currently live. Backup wins only when
+    /// activeKeyIsBackup is true AND the backup field has a value.
+    var activeAPIKey: String {
+        let trimmedBackup = apiKeyBackup.trimmingCharacters(in: .whitespacesAndNewlines)
+        if activeKeyIsBackup, !trimmedBackup.isEmpty {
+            return apiKeyBackup
+        }
+        return apiKey
     }
 
     @Published var apiBaseURL: String {
@@ -588,6 +622,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
         let hasCompletedSetup = UserDefaults.standard.bool(forKey: "hasCompletedSetup")
         let apiKey = Self.loadStoredAPIKey(account: apiKeyStorageKey)
+        let apiKeyBackup = Self.loadStoredAPIKey(account: apiKeyBackupStorageKey)
+        let activeKeyIsBackup = UserDefaults.standard.bool(forKey: activeKeyIsBackupStorageKey)
         let apiBaseURL = Self.loadStoredAPIBaseURL(account: "api_base_url")
         let transcriptionModel = UserDefaults.standard.string(forKey: transcriptionModelStorageKey) ?? Self.defaultTranscriptionModel
         let transcriptionAPIURL = Self.loadOptionalStoredAPIValue(account: transcriptionAPIURLStorageKey)
@@ -670,8 +706,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
 
+        // Honour persisted rotation state at launch — if the backup was the
+        // live key when the app last quit, contextService must boot with it
+        // so on-startup requests use the working key rather than the
+        // exhausted one.
+        let initialActiveKey: String = {
+            let trimmedBackup = apiKeyBackup.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (activeKeyIsBackup && !trimmedBackup.isEmpty) ? apiKeyBackup : apiKey
+        }()
         self.contextService = Self.makeAppContextService(
-            apiKey: apiKey,
+            apiKey: initialActiveKey,
             baseURL: apiBaseURL,
             customContextPrompt: customContextPrompt,
             contextModel: contextModel,
@@ -679,6 +723,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         self.hasCompletedSetup = hasCompletedSetup
         self.apiKey = apiKey
+        self.apiKeyBackup = apiKeyBackup
+        self.activeKeyIsBackup = activeKeyIsBackup
         self.apiBaseURL = apiBaseURL
         self.transcriptionAPIURL = transcriptionAPIURL
         self.transcriptionAPIKey = transcriptionAPIKey
@@ -774,6 +820,40 @@ final class AppState: ObservableObject, @unchecked Sendable {
             AppSettingsStorage.delete(account: apiKeyStorageKey)
         } else {
             AppSettingsStorage.save(trimmed, account: apiKeyStorageKey)
+        }
+    }
+
+    /// Inspect a thrown error from PostProcessingService. If it is a 429
+    /// whose body mentions a daily-token cap AND the other key slot has
+    /// a value, flip the active key, surface the change in the pill, and
+    /// return true so the caller can retry once with the new key.
+    /// Returns false if the error is unrelated, the other slot is empty,
+    /// or both keys are exhausted.
+    func rotateAPIKeyIfDailyExhausted(error: Error) -> Bool {
+        let message = error.localizedDescription
+        guard message.contains("429"), message.contains("tokens per day") else {
+            return false
+        }
+
+        let trimmedBackup = apiKeyBackup.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPrimary = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if activeKeyIsBackup {
+            guard !trimmedPrimary.isEmpty else {
+                overlayManager.showError("Both Groq keys hit daily caps. Try again tomorrow.")
+                return false
+            }
+            activeKeyIsBackup = false
+            overlayManager.showError("Backup Groq key daily cap hit. Switched back to primary.")
+            return true
+        } else {
+            guard !trimmedBackup.isEmpty else {
+                overlayManager.showError("Groq daily cap hit. Set a Backup API Key in Settings to auto-rotate.")
+                return false
+            }
+            activeKeyIsBackup = true
+            overlayManager.showError("Primary Groq key daily cap hit. Switched to backup.")
+            return true
         }
     }
 
@@ -874,7 +954,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     func makeAppContextService() -> AppContextService {
         Self.makeAppContextService(
-            apiKey: apiKey,
+            apiKey: activeAPIKey,
             baseURL: apiBaseURL,
             customContextPrompt: customContextPrompt,
             contextModel: contextModel,
@@ -1087,7 +1167,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
 
         let postProcessingService = PostProcessingService(
-            apiKey: apiKey,
+            apiKey: activeAPIKey,
             baseURL: apiBaseURL,
             preferredModel: postProcessingModel,
             preferredFallbackModel: postProcessingFallbackModel
@@ -2277,6 +2357,29 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return (result.transcript, .commandModeSucceeded(invocation: invocation), result.prompt)
             } catch {
                 os_log(.error, log: recordingLog, "Edit mode failed: %{public}@", error.localizedDescription)
+                if rotateAPIKeyIfDailyExhausted(error: error) {
+                    // Active key flipped — build a fresh service so the
+                    // retry hits Groq with the new key, then attempt the
+                    // transform once more.
+                    let retryService = PostProcessingService(
+                        apiKey: activeAPIKey,
+                        baseURL: apiBaseURL,
+                        preferredModel: postProcessingModel,
+                        preferredFallbackModel: postProcessingFallbackModel
+                    )
+                    do {
+                        let retried = try await retryService.commandTransform(
+                            selectedText: selectedText,
+                            voiceCommand: rawTranscript,
+                            context: context,
+                            customVocabulary: customVocabulary,
+                            outputLanguage: outputLanguage
+                        )
+                        return (retried.transcript, .commandModeSucceeded(invocation: invocation), retried.prompt)
+                    } catch {
+                        os_log(.error, log: recordingLog, "Edit mode retry after key rotation failed: %{public}@", error.localizedDescription)
+                    }
+                }
                 return (selectedText, .commandModeFailedFallback(invocation: invocation), "")
             }
         }
@@ -2297,6 +2400,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return (result.transcript, .postProcessingSucceeded, result.prompt)
         } catch {
             os_log(.error, log: recordingLog, "Post-processing failed: %{public}@", error.localizedDescription)
+            if rotateAPIKeyIfDailyExhausted(error: error) {
+                let retryService = PostProcessingService(
+                    apiKey: activeAPIKey,
+                    baseURL: apiBaseURL,
+                    preferredModel: postProcessingModel,
+                    preferredFallbackModel: postProcessingFallbackModel
+                )
+                do {
+                    let retried = try await retryService.postProcess(
+                        transcript: trimmedRawTranscript,
+                        context: context,
+                        customVocabulary: customVocabulary,
+                        customSystemPrompt: customSystemPrompt,
+                        outputLanguage: outputLanguage
+                    )
+                    return (retried.transcript, .postProcessingSucceeded, retried.prompt)
+                } catch {
+                    os_log(.error, log: recordingLog, "Post-processing retry after key rotation failed: %{public}@", error.localizedDescription)
+                }
+            }
             return (trimmedRawTranscript, .postProcessingFailedFallback, "")
         }
     }
@@ -2385,7 +2508,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.debugStatusMessage = "Transcribing audio"
 
         let postProcessingService = PostProcessingService(
-            apiKey: apiKey,
+            apiKey: activeAPIKey,
             baseURL: apiBaseURL,
             preferredModel: postProcessingModel,
             preferredFallbackModel: postProcessingFallbackModel

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -517,6 +517,7 @@ struct GeneralSettingsView: View {
     @Environment(\.openURL) private var openURL
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
     @State private var apiKeyInput: String = ""
+    @State private var apiKeyBackupInput: String = ""
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
@@ -697,6 +698,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("API Key", icon: "key.fill") {
                     apiKeySection
                 }
+                SettingsCard("Backup API Key", icon: "key") {
+                    apiKeyBackupSection
+                }
                 SettingsCard("Output Language", icon: "globe") {
                     outputLanguageSection
                 }
@@ -732,6 +736,7 @@ struct GeneralSettingsView: View {
         }
         .onAppear {
             apiKeyInput = appState.apiKey
+            apiKeyBackupInput = appState.apiKeyBackup
             apiBaseURLInput = appState.apiBaseURL
             transcriptionAPIURLInput = appState.transcriptionAPIURL
             transcriptionAPIKeyInput = appState.transcriptionAPIKey
@@ -1021,6 +1026,49 @@ struct GeneralSettingsView: View {
                     keyValidationSuccess = true
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
+                }
+            }
+        }
+    }
+
+    // MARK: Backup API Key
+
+    private var apiKeyBackupSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Used automatically when the primary key hits its daily token cap. Leave blank to disable rotation.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                SecureField("Paste backup API key", text: $apiKeyBackupInput)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+
+                Button("Save") {
+                    let trimmed = apiKeyBackupInput.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if appState.apiKeyBackup != trimmed {
+                        appState.apiKeyBackup = trimmed
+                    }
+                    apiKeyBackupInput = trimmed
+                }
+                .disabled(apiKeyBackupInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+
+            // Surface the active-key indicator only when the backup is live —
+            // the default state (primary active) is the common case and
+            // would be visual noise.
+            if appState.activeKeyIsBackup {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .foregroundStyle(.orange)
+                    Text("Currently using backup key")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Switch back to primary") {
+                        appState.activeKeyIsBackup = false
+                    }
+                    .controlSize(.small)
                 }
             }
         }


### PR DESCRIPTION
## What

Adds an optional Backup API Key field. When the active Groq key returns a 429 with `tokens per day` (the per-org daily cap), the post-processing path swaps to the other key, retries the failed request once, and surfaces the rotation in the menu-bar pill.

## Why

Groq's free tier exhausts quickly under heavy command-mode use — once the per-day token cap on the active org is hit, every subsequent post-processing request 429s for the rest of the day. Today the user sees dictation silently stop working with no rotation path. This PR lets users keep going by configuring a key from a second Groq account as a backup; rotation is automatic when the daily cap fires.

Per-minute throttling does NOT trigger rotation. The existing model fallback chain (primary model → fallback model on 429) already handles that case well.

## How

- `apiKeyBackup` and `activeKeyIsBackup` added to `AppState`.
- `activeAPIKey` computed property resolves to whichever key is live.
- `rotateAPIKeyIfDailyExhausted(error:)` inspects the error, flips the active key when the other slot has a value, fires a pill toast, and returns `true` so the caller can retry.
- Both `processTranscript` catch blocks (Edit Mode and post-processing) invoke rotation and retry once with a freshly-constructed `PostProcessingService` so the new key takes effect mid-flight.
- `SettingsView` gains a "Backup API Key" card directly below the primary. Active-key indicator and manual "Switch back to primary" button surface only when the backup is the live key.

## UI

<img src="https://assets.themarketingshow.com/bugs/freeflow/groq-backup-key-settings-2026-05-06.png" width="500">

(Screenshot is from a downstream variant that uses a masked-with-peek field for both keys; the upstream version in this PR uses `SecureField` matching the existing primary API Key pattern. Structural placement and the active-key indicator are identical.)

## Behaviour notes

- Active-key state persists across launches — an exhausted key is not retried after restart.
- Empty backup field disables rotation entirely; behaviour is unchanged for users who do not configure one.
- Same Groq account on both slots provides no rotation benefit (daily caps are per-org, not per-key); the documentation copy notes this implicitly by saying "leave blank to disable rotation."

## Dependency

Depends on #190 (in-pill error notifications) for the `showError(_:)` surfacing mechanism. Once #190 lands, this PR rebases onto main and the calls resolve. Code is presented assuming `showError` exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configure backup API key in settings for failover protection
  * Automatic key rotation when daily usage limit is reached
  * Manual switching between primary and backup API keys available
  * Visual indicator displays currently active API key

<!-- end of auto-generated comment: release notes by coderabbit.ai -->