### PR TITLE
Fix clipboard not being restored after dictation

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -124,6 +124,7 @@ private struct PreservedPasteboardSnapshot {
 private struct PendingClipboardRestore {
     let snapshot: PreservedPasteboardSnapshot
     let expectedChangeCount: Int
+    let writtenTranscript: String
 }
 
 private struct TranscriptCommandParsingResult {
@@ -3002,7 +3003,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         pasteboard.setString(textToWrite, forType: .string)
 
         guard let snapshot else { return nil }
-        return PendingClipboardRestore(snapshot: snapshot, expectedChangeCount: pasteboard.changeCount)
+        return PendingClipboardRestore(
+            snapshot: snapshot,
+            expectedChangeCount: pasteboard.changeCount,
+            writtenTranscript: textToWrite
+        )
     }
 
     private func restoreClipboardIfNeeded(_ pendingRestore: PendingClipboardRestore?) {
@@ -3012,7 +3017,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         // the pre-dictation clipboard instead of the transcript.
         DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
             let pasteboard = NSPasteboard.general
-            guard pasteboard.changeCount == pendingRestore.expectedChangeCount else { return }
+            // A bare changeCount check is too strict: browsers, iCloud Universal
+            // Clipboard sync, and other background apps bump the change count
+            // without the user copying anything, which left the transcript
+            // stranded on the clipboard. Restore when nothing changed, or when the
+            // clipboard still holds exactly the transcript we wrote (so the user
+            // has not deliberately copied something new that we would clobber).
+            let clipboardStillHoldsTranscript =
+                pasteboard.string(forType: .string) == pendingRestore.writtenTranscript
+            guard pasteboard.changeCount == pendingRestore.expectedChangeCount
+                || clipboardStillHoldsTranscript else { return }
             pendingRestore.snapshot.restore(to: pasteboard)
         }
     }


### PR DESCRIPTION
When I copy a URL (or anything) and then dictate something, my clipboard gets stuck with the dictated text instead of what I copied. So later when I hit Cmd+V it pastes my last dictation instead of the URL. Pretty annoying.

FreeFlow already tries to restore the clipboard after pasting, but it only does it when the pasteboard `changeCount` is exactly what it expects. The problem is other apps (browsers, iCloud Universal Clipboard, etc.) bump that count in the background, so the restore just gets skipped and my original clipboard is gone.

Fix: also restore when the clipboard still holds the exact transcript FreeFlow wrote. That way background apps bumping the count don't break it, but if I actually copied something new myself it won't get overwritten.

Builds and typechecks clean. To verify by hand: copy a URL, dictate into a field, wait a couple seconds, then Cmd+V somewhere else - you should get the URL back, not the dictation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced clipboard preservation reliability. Transcripts are now more reliably preserved when background applications or iCloud clipboard synchronization modify clipboard state. Improved detection and preservation mechanisms prevent your transcript content from being unexpectedly lost or replaced when external systems interact with the clipboard during background operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->