### PR TITLE
Avoid false screen recording alerts

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -530,7 +530,7 @@ Selected text: \(selectedText ?? "None")
             kCGNullWindowID,
             [.bestResolution]
         ) else {
-            return (nil, nil, "Could not capture screenshot (screen recording permission or window access issue)")
+            return (nil, nil, "Could not capture screenshot from the active window")
         }
 
         if let croppedImage = croppedWhitespaceImage(from: fullScreenImage),

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2777,7 +2777,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func isScreenCapturePermissionError(_ message: String) -> Bool {
         let lowered = message.lowercased()
-        return lowered.contains("permission") || lowered.contains("screen recording")
+        return lowered.contains("screen recording permission not granted")
+            || lowered.contains("requires screen recording permission")
     }
 
     private func showScreenshotPermissionAlert(message: String) {


### PR DESCRIPTION
## Summary
- Avoid treating generic active-window screenshot failures as Screen Recording permission failures.
- Keep the Screen Recording alert reserved for explicit permission-denied messages.

## Why
FreeFlow could show "Screen Recording Permission Required" even when macOS already showed the app enabled in Privacy & Security. The generic capture fallback message included the word "permission", and the alert guard matched any message containing "permission" or "screen recording".

## Validation
- Built locally with `make APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY=-`.
- Installed the rebuilt app at `/Applications/FreeFlow.app` and relaunched it.
- Verified FreeFlow remains enabled in both Accessibility and Screen & System Audio Recording in System Settings.

## Caveats
- This does not change the real Screen Recording preflight check. If macOS actually denies Screen Recording, FreeFlow still shows the permission alert.
- No automated TCC test is included because macOS privacy state is user/system scoped and not reliable in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when screenshot capture fails for better diagnostics.
  * Enhanced screen recording permission detection for more accurate issue identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->