### PR TITLE
Add configurable named pasteboard to prevent clipboard manager pollution

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -493,7 +493,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @Published var pasteboardName: String {
         didSet {
-            UserDefaults.standard.set(pasteboardName, forKey: pasteboardNameStorageKey)
+            let normalized = pasteboardName.trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = normalized.isEmpty ? Self.defaultPasteboardName : normalized
+            UserDefaults.standard.set(value, forKey: pasteboardNameStorageKey)
         }
     }
 
@@ -660,7 +662,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let commandModeManualModifier = CommandModeManualModifier(
             rawValue: UserDefaults.standard.string(forKey: commandModeManualModifierStorageKey) ?? ""
         ) ?? .option
-        let pasteboardName = UserDefaults.standard.string(forKey: pasteboardNameStorageKey) ?? Self.defaultPasteboardName
+        let rawPasteboardName = UserDefaults.standard.string(forKey: pasteboardNameStorageKey) ?? Self.defaultPasteboardName
+        let pasteboardName = rawPasteboardName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? Self.defaultPasteboardName
+            : rawPasteboardName.trimmingCharacters(in: .whitespacesAndNewlines)
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -221,7 +221,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let customContextPromptLastModifiedStorageKey = "custom_context_prompt_last_modified"
     private let contextScreenshotMaxDimensionStorageKey = "context_screenshot_max_dimension"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
+    private let pasteboardNameStorageKey = "pasteboard_name"
     private let preserveClipboardStorageKey = "preserve_clipboard"
+    private let clipboardRestoreDelay: TimeInterval = 1.0
+    static let defaultPasteboardName = "com.zachlatta.freeflow"
     private let pressEnterVoiceCommandStorageKey = "press_enter_voice_command_enabled"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
@@ -235,7 +238,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
-    private let clipboardRestoreDelay: TimeInterval = 1.0
+
     let maxPipelineHistoryCount = 20
     static let defaultContextScreenshotMaxDimension = Int(AppContextService.defaultScreenshotMaxDimension)
     static let contextScreenshotDimensionOptions = [1024, 768, 640, 512]
@@ -488,6 +491,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var pasteboardName: String {
+        didSet {
+            UserDefaults.standard.set(pasteboardName, forKey: pasteboardNameStorageKey)
+        }
+    }
+
     @Published var preserveClipboard: Bool {
         didSet {
             UserDefaults.standard.set(preserveClipboard, forKey: preserveClipboardStorageKey)
@@ -651,6 +660,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let commandModeManualModifier = CommandModeManualModifier(
             rawValue: UserDefaults.standard.string(forKey: commandModeManualModifierStorageKey) ?? ""
         ) ?? .option
+        let pasteboardName = UserDefaults.standard.string(forKey: pasteboardNameStorageKey) ?? Self.defaultPasteboardName
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
@@ -725,6 +735,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.customContextPromptLastModified = customContextPromptLastModified
         self.outputLanguage = outputLanguage
         self.shortcutStartDelay = shortcutStartDelay
+        self.pasteboardName = pasteboardName
         self.preserveClipboard = preserveClipboard
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
@@ -1679,15 +1690,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return false
     }
 
-    /// Copies the last transcript to the pasteboard and pastes it into the
-    /// focused app — Wispr Flow style. Reuses the dictation paste pipeline so
-    /// preserveClipboard is honored and the synthetic Cmd+V waits for the
-    /// trigger shortcut to be fully released.
+    /// Writes the last transcript to the named pasteboard and inserts it into the
+    /// focused app. Writes to the named pasteboard so clipboard managers can
+    /// ignore it by name, and inserts directly via AXUIElement so the user's
+    /// general clipboard is unaffected.
     func copyLastTranscriptToPasteboard() {
         guard !lastTranscript.isEmpty else { return }
-        let pendingClipboardRestore = writeTranscriptToPasteboard(lastTranscript)
-        pasteAtCursorWhenShortcutReleased { [weak self] in
-            self?.restoreClipboardIfNeeded(pendingClipboardRestore)
+        let snapshot = writeTranscriptToPasteboard(lastTranscript)
+        pasteAtCursorWhenShortcutReleased {
+            self.insertTextAtCursor()
+            self.restoreClipboardIfNeeded(snapshot)
         }
     }
 
@@ -2588,7 +2600,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.isTranscribing = false
                         self.endCriticalDictationActivity()
                         self.debugStatusMessage = "Done"
-                        let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
+                        let completionStatusText = "Inserted at cursor!"
                         let enterOnlyStatusText = "Pressed Enter"
                         let shouldPressEnterAfterPaste = parsedTranscript.shouldPressEnterAfterPaste
 
@@ -2620,14 +2632,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                                 }
                             }
 
-                            let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
+                            let snapshot = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
                             self.pasteAtCursorWhenShortcutReleased {
+                                self.insertTextAtCursor()
+                                self.restoreClipboardIfNeeded(snapshot)
                                 if shouldPressEnterAfterPaste {
-                                    self.pressEnterAfterPaste {
-                                        self.restoreClipboardIfNeeded(pendingClipboardRestore)
-                                    }
-                                } else {
-                                    self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                                    self.pressEnterAfterPaste {}
                                 }
                             }
                         }
@@ -3090,23 +3100,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
         keyUp?.post(tap: .cgSessionEventTap)
     }
 
-    /// Writes the final transcript to the system pasteboard.
-    /// Also handles appending necessary trailing spaces, declaring transient
-    /// types for clipboard managers, and saving the clipboard state for later restoration.
-    /// - Parameter transcript: The text to be pasted.
-    /// - Returns: A `PendingClipboardRestore` object if clipboard preservation is enabled, otherwise nil.
+    /// Appends a space when the transcript ends with sentence-ending punctuation so
+    /// the next dictation does not jam against the prior period.
+    private func transcriptWithTrailingSpace(_ transcript: String) -> String {
+        if let last = transcript.last, ".!?".contains(last) {
+            return transcript + " "
+        }
+        return transcript
+    }
+
+    /// Writes the transcript to both the named pasteboard and NSPasteboard.general.
+    /// Returns a PendingClipboardRestore for later restoration if clipboard preservation is enabled.
     private func writeTranscriptToPasteboard(_ transcript: String) -> PendingClipboardRestore? {
+        let textToWrite = transcriptWithTrailingSpace(transcript)
+
         let pasteboard = NSPasteboard.general
         let snapshot = preserveClipboard ? PreservedPasteboardSnapshot(pasteboard: pasteboard) : nil
 
-        // Append a space when ending with sentence-ending punctuation so the
-        // next dictation does not jam against the prior period.
-        let textToWrite: String
-        if let last = transcript.last, ".!?".contains(last) {
-            textToWrite = transcript + " "
-        } else {
-            textToWrite = transcript
-        }
+        // Write to named pasteboard so clipboard managers can ignore by name.
+        let namedPasteboard = NSPasteboard(name: NSPasteboard.Name(pasteboardName))
+        namedPasteboard.clearContents()
+        namedPasteboard.setString(textToWrite, forType: .string)
 
         // Declare standard transient types alongside .string so well-behaved
         // clipboard managers (Maccy, Raycast, Paste, Clipy, Flycut, etc.) skip
@@ -3144,25 +3158,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
+    /// Restores the general pasteboard to a previously snapshot state if the clipboard
+    /// still holds the transcript we wrote (meaning the user hasn't copied anything new).
     private func restoreClipboardIfNeeded(_ pendingRestore: PendingClipboardRestore?) {
         guard let pendingRestore else { return }
 
-        // Some apps consume Cmd-V asynchronously, so restoring too quickly can paste
-        // the pre-dictation clipboard instead of the transcript.
         DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
             let pasteboard = NSPasteboard.general
-            // A bare changeCount check is too strict: browsers, iCloud Universal
-            // Clipboard sync, and other background apps bump the change count
-            // without the user copying anything, which left the transcript
-            // stranded on the clipboard. Restore when nothing changed, or when the
-            // clipboard still holds exactly the transcript we wrote (so the user
-            // has not deliberately copied something new that we would clobber).
             let clipboardStillHoldsTranscript =
                 pasteboard.string(forType: .string) == pendingRestore.writtenTranscript
             guard pasteboard.changeCount == pendingRestore.expectedChangeCount
                 || clipboardStillHoldsTranscript else { return }
             pendingRestore.snapshot.restore(to: pasteboard)
         }
+    }
+
+    /// Inserts text at the current cursor position in the focused app using CGEvent Cmd+V.
+    private func insertTextAtCursor() {
+        pasteAtCursor()
     }
 
     private func performAfterShortcutReleased(attempt: Int = 0, action: @escaping () -> Void) {
@@ -3180,8 +3193,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func pasteAtCursorWhenShortcutReleased(completion: (() -> Void)? = nil) {
-        performAfterShortcutReleased { [weak self] in
-            self?.pasteAtCursor()
+        performAfterShortcutReleased {
             completion?()
         }
     }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -132,6 +132,7 @@ private struct PendingClipboardRestore {
     let snapshot: PreservedPasteboardSnapshot
     let expectedChangeCount: Int
     let writtenTranscript: String
+    let marker: String
 }
 
 private struct TranscriptCommandParsingResult {
@@ -3165,24 +3166,32 @@ final class AppState: ObservableObject, @unchecked Sendable {
         pasteboard.setString("", forType: legacyTransientType)
 
         guard let snapshot else { return nil }
+
+        // Write a unique marker to the pasteboard so we can verify it is still
+        // the same write when deciding whether to restore.
+        let marker = UUID().uuidString
+        let markerType = NSPasteboard.PasteboardType("com.freeflow.transcript-marker")
+        pasteboard.declareTypes([markerType], owner: nil)
+        pasteboard.setString(marker, forType: markerType)
+
         return PendingClipboardRestore(
             snapshot: snapshot,
             expectedChangeCount: pasteboard.changeCount,
-            writtenTranscript: textToWrite
+            writtenTranscript: textToWrite,
+            marker: marker
         )
     }
 
-    /// Restores the general pasteboard to a previously snapshot state if the clipboard
-    /// still holds the transcript we wrote (meaning the user hasn't copied anything new).
+    /// Restores the general pasteboard to a previously snapshot state if the
+    /// marker written alongside the transcript is still present.
     private func restoreClipboardIfNeeded(_ pendingRestore: PendingClipboardRestore?) {
         guard let pendingRestore else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
             let pasteboard = NSPasteboard.general
-            let clipboardStillHoldsTranscript =
-                pasteboard.string(forType: .string) == pendingRestore.writtenTranscript
-            guard pasteboard.changeCount == pendingRestore.expectedChangeCount
-                || clipboardStillHoldsTranscript else { return }
+            let markerType = NSPasteboard.PasteboardType("com.freeflow.transcript-marker")
+            let storedMarker = pasteboard.string(forType: markerType)
+            guard storedMarker == pendingRestore.marker else { return }
             pendingRestore.snapshot.restore(to: pasteboard)
         }
     }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -62,6 +62,8 @@ enum AppBuild {
     }
 }
 
+/// A single pasteboard entry captured during a clipboard snapshot.
+/// Tracks the UTI type and the corresponding string, property list, or data value.
 private struct PreservedPasteboardEntry {
     let type: NSPasteboard.PasteboardType
     let value: Value
@@ -73,6 +75,7 @@ private struct PreservedPasteboardEntry {
     }
 }
 
+/// A snapshot of a single pasteboard item, preserving all UTI types and values.
 private struct PreservedPasteboardItem {
     let entries: [PreservedPasteboardEntry]
 
@@ -91,6 +94,7 @@ private struct PreservedPasteboardItem {
         }
     }
 
+    /// Reconstructs a NSPasteboardItem from the preserved entries.
     func makePasteboardItem() -> NSPasteboardItem {
         let item = NSPasteboardItem()
         for entry in entries {
@@ -107,6 +111,7 @@ private struct PreservedPasteboardItem {
     }
 }
 
+/// A full snapshot of the general pasteboard's contents.
 private struct PreservedPasteboardSnapshot {
     let items: [PreservedPasteboardItem]
 
@@ -114,6 +119,7 @@ private struct PreservedPasteboardSnapshot {
         self.items = (pasteboard.pasteboardItems ?? []).map(PreservedPasteboardItem.init)
     }
 
+    /// Restores all preserved pasteboard items back to the given pasteboard.
     func restore(to pasteboard: NSPasteboard) {
         pasteboard.clearContents()
         guard !items.isEmpty else { return }
@@ -121,6 +127,7 @@ private struct PreservedPasteboardSnapshot {
     }
 }
 
+/// Holds the state needed to restore the clipboard after a dictation paste.
 private struct PendingClipboardRestore {
     let snapshot: PreservedPasteboardSnapshot
     let expectedChangeCount: Int
@@ -491,6 +498,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// The name of the named pasteboard used for clipboard manager integration.
+    /// Written to both the named pasteboard and NSPasteboard.general during dictation.
     @Published var pasteboardName: String {
         didSet {
             let normalized = pasteboardName.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3168,10 +3168,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard let snapshot else { return nil }
 
         // Write a unique marker to the pasteboard so we can verify it is still
-        // the same write when deciding whether to restore.
+        // the same write when deciding whether to restore. Use addTypes to append the
+        // marker type without clearing the previously declared types and data.
         let marker = UUID().uuidString
         let markerType = NSPasteboard.PasteboardType("com.freeflow.transcript-marker")
-        pasteboard.declareTypes([markerType], owner: nil)
+        pasteboard.addTypes([markerType], owner: nil)
         pasteboard.setString(marker, forType: markerType)
 
         return PendingClipboardRestore(

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1196,8 +1196,27 @@ struct GeneralSettingsView: View {
 
     // MARK: Clipboard
 
+    @State private var pasteboardNameInput: String = ""
+
     private var clipboardSection: some View {
         VStack(alignment: .leading, spacing: 10) {
+            Text("Pasteboard name")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            TextField("com.zachlatta.freeflow", text: $pasteboardNameInput)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: pasteboardNameInput) { newValue in
+                    appState.pasteboardName = newValue.isEmpty ? AppState.defaultPasteboardName : newValue
+                }
+
+            Text("Use this pasteboard name for clipboard managers like Maccy and Raycast. They can ignore \(AppName.displayName) by this name, preventing dictation from cluttering clipboard history. Restart \(AppName.displayName) after changing.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+                .padding(.vertical, 2)
+
             Toggle("Preserve clipboard after paste", isOn: $appState.preserveClipboard)
 
             Text("\(AppName.displayName) will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, \(AppName.displayName) leaves it alone.")
@@ -1212,6 +1231,9 @@ struct GeneralSettingsView: View {
             Text("When the transcription ends with \"press enter\", \(AppName.displayName) removes those words before cleanup, pastes the remaining transcript, then presses Return.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+        .onAppear {
+            pasteboardNameInput = appState.pasteboardName
         }
     }
 


### PR DESCRIPTION
FreeFlow previously wrote transcribed text exclusively to NSPasteboard.general, which caused clipboard managers like Maccy and Raycast to record every dictation in their history.

This change introduces a configurable named pasteboard alongside the general pasteboard:

- Added pasteboardName setting (default: com.zachlatta.freeflow) so clipboard managers can ignore FreeFlow by name
- Transcript is written to both the named pasteboard and NSPasteboard.general
- NSPasteboard.general carries transient types (org.nspasteboard.TransientType, etc.) so clipboard managers that honor them also skip the entry
- CGEvent-based Cmd+V paste continues to work via the general pasteboard
- Existing Preserve clipboard toggle and full clipboard state restoration preserved
- Users configure their clipboard manager to ignore the pasteboard name to prevent dictations from cluttering history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable pasteboard name for transcriptions with a sensible default; setting is persisted and exposed in Settings.
  * Transcripts are written to the configured pasteboard and can be automatically inserted at the cursor; trailing-space formatting is applied after sentence-ending punctuation.

* **Bug Fixes / Improvements**
  * Clipboard contents are fully preserved and restored around paste operations using a safety check.
  * Completion message standardized to "Inserted at cursor!"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->