### PR TITLE
Add a Dictionary of deterministic transcript corrections

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -24,6 +24,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case prompts
     case macros
+    case dictionary
     case runLog
     case debug
 
@@ -40,6 +41,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return "General"
         case .prompts: return "Prompts"
         case .macros: return "Voice Macros"
+        case .dictionary: return "Dictionary"
         case .runLog: return "Run Log"
         case .debug: return "Debug"
         }
@@ -50,6 +52,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return "gearshape"
         case .prompts: return "text.bubble"
         case .macros: return "music.mic"
+        case .dictionary: return "character.book.closed"
         case .runLog: return "clock.arrow.circlepath"
         case .debug: return "wrench.and.screwdriver"
         }
@@ -226,6 +229,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
     private let voiceMacrosStorageKey = "voice_macros"
+    private let correctionsStorageKey = "dictionary_corrections"
     private let commandModeEnabledStorageKey = "command_mode_enabled"
     private let commandModeStyleStorageKey = "command_mode_style"
     private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
@@ -523,6 +527,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var corrections: [Correction] = [] {
+        didSet {
+            if let data = try? JSONEncoder().encode(corrections) {
+                UserDefaults.standard.set(data, forKey: correctionsStorageKey)
+            }
+        }
+    }
+
     @Published var isRecording = false {
         didSet {
             guard oldValue != isRecording else { return }
@@ -676,6 +688,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             initialMacros = []
         }
 
+        let initialCorrections: [Correction]
+        if let data = UserDefaults.standard.data(forKey: "dictionary_corrections"),
+           let decoded = try? JSONDecoder().decode([Correction].self, from: data) {
+            initialCorrections = decoded
+        } else {
+            initialCorrections = []
+        }
+
         let initialAccessibility = AXIsProcessTrusted()
         let initialScreenCapturePermission = CGPreflightScreenCaptureAccess()
         var removedAudioFileNames: [String] = []
@@ -733,6 +753,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
+        self.corrections = initialCorrections
         self.pipelineHistory = savedHistory
         self.hasAccessibility = initialAccessibility
         self.hasScreenRecordingPermission = initialScreenCapturePermission
@@ -1132,6 +1153,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
+        let capturedCorrections = corrections
 
         Task {
             do {
@@ -1156,6 +1178,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessingService: postProcessingService,
                     customVocabulary: capturedCustomVocabulary,
                     customSystemPrompt: capturedCustomSystemPrompt,
+                    corrections: capturedCorrections,
                     outputLanguage: self.outputLanguage
                 )
                 finalTranscript = result.finalTranscript
@@ -2362,6 +2385,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         postProcessingService: PostProcessingService,
         customVocabulary: String,
         customSystemPrompt: String,
+        corrections: [Correction],
         outputLanguage: String = ""
     ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
         let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2399,10 +2423,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 customSystemPrompt: customSystemPrompt,
                 outputLanguage: outputLanguage
             )
-            return (result.transcript, .postProcessingSucceeded, result.prompt)
+            return (DictionaryEngine.apply(result.transcript, corrections: corrections), .postProcessingSucceeded, result.prompt)
         } catch {
             os_log(.error, log: recordingLog, "Post-processing failed: %{public}@", error.localizedDescription)
-            return (trimmedRawTranscript, .postProcessingFailedFallback, "")
+            return (DictionaryEngine.apply(trimmedRawTranscript, corrections: corrections), .postProcessingFailedFallback, "")
         }
     }
 
@@ -2547,6 +2571,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         postProcessingService: postProcessingService,
                         customVocabulary: self.customVocabulary,
                         customSystemPrompt: self.customSystemPrompt,
+                        corrections: self.corrections,
                         outputLanguage: self.outputLanguage
                     )
                     try Task.checkCancellation()

--- a/Sources/Correction.swift
+++ b/Sources/Correction.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A single deterministic find-and-replace rule for the dictation Dictionary.
+/// `heard` is the phrase the transcription tends to produce; `replacement` is
+/// what the speaker actually meant. Applied as the last step before paste,
+/// after the LLM cleanup pass, so a correction can never be undone by
+/// post-processing.
+struct Correction: Codable, Identifiable, Equatable {
+    var id: UUID = UUID()
+    var heard: String
+    var replacement: String
+    var wholeWord: Bool = true
+    var caseSensitive: Bool = false
+    var enabled: Bool = true
+}
+
+/// Pure, isolation-free engine that applies a list of corrections to a string.
+/// Kept free of AppState so it can run on the background transcription task.
+enum DictionaryEngine {
+    static func apply(_ text: String, corrections: [Correction]) -> String {
+        guard !text.isEmpty, !corrections.isEmpty else { return text }
+
+        var result = text
+        for correction in corrections {
+            let heard = correction.heard.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard correction.enabled, !heard.isEmpty else { continue }
+
+            var options: NSRegularExpression.Options = []
+            if !correction.caseSensitive { options.insert(.caseInsensitive) }
+
+            var pattern = NSRegularExpression.escapedPattern(for: heard)
+            if correction.wholeWord {
+                // Unicode-aware word boundary: only match when the phrase is not
+                // flanked by a letter or digit. Keeps "cat" from rewriting the
+                // "cat" inside "category".
+                pattern = "(?<![\\p{L}\\p{N}])" + pattern + "(?![\\p{L}\\p{N}])"
+            }
+
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+                continue
+            }
+            let fullRange = NSRange(result.startIndex..., in: result)
+            let template = NSRegularExpression.escapedTemplate(for: correction.replacement)
+            result = regex.stringByReplacingMatches(
+                in: result,
+                options: [],
+                range: fullRange,
+                withTemplate: template
+            )
+        }
+        return result
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -434,6 +434,8 @@ struct SettingsView: View {
                     PromptsSettingsView()
                 case .macros:
                     VoiceMacrosSettingsView()
+                case .dictionary:
+                    DictionarySettingsView()
                 case .runLog:
                     RunLogView()
                 case .debug:
@@ -2713,6 +2715,312 @@ struct VoiceMacroEditorView: View {
             if let m = macro {
                 command = m.command
                 payload = m.payload
+            }
+        }
+    }
+}
+
+// MARK: - Dictionary
+
+struct DictionarySettingsView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var showingEditor = false
+    @State private var editingCorrection: Correction?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                SettingsCard("Corrections", icon: "arrow.left.arrow.right") {
+                    correctionsSection
+                }
+            }
+            .padding(24)
+        }
+        .sheet(isPresented: $showingEditor, onDismiss: { editingCorrection = nil }) {
+            CorrectionEditorView(isPresented: $showingEditor, correction: $editingCorrection)
+        }
+    }
+
+    private var correctionsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                Text("A guaranteed find-and-replace. When you know the exact wrong text the transcription produces, add it here with what you meant. FreeFlow swaps it on every dictation, even when AI cleanup is off. Best for specific mishears you can name exactly.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button(action: {
+                    editingCorrection = nil
+                    showingEditor = true
+                }) {
+                    Label("Add Word", systemImage: "plus")
+                }
+            }
+
+            if appState.corrections.isEmpty {
+                VStack {
+                    Image(systemName: "arrow.left.arrow.right")
+                        .font(.system(size: 30))
+                        .foregroundStyle(.tertiary)
+                        .padding(.bottom, 4)
+                    Text("No Corrections Yet")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    Text("Click 'Add Word' to teach FreeFlow your first correction.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 32)
+            } else {
+                VStack(spacing: 1) {
+                    ForEach(appState.corrections) { correction in
+                        correctionRow(correction)
+                    }
+                }
+                .cornerRadius(8)
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.primary.opacity(0.06), lineWidth: 1))
+            }
+        }
+    }
+
+    private func correctionRow(_ correction: Correction) -> some View {
+        HStack(spacing: 10) {
+            Toggle("", isOn: Binding(
+                get: { correction.enabled },
+                set: { newValue in
+                    if let index = appState.corrections.firstIndex(where: { $0.id == correction.id }) {
+                        appState.corrections[index].enabled = newValue
+                    }
+                }
+            ))
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(correction.heard.isEmpty ? "(empty)" : correction.heard)
+                        .font(.headline)
+                    Image(systemName: "arrow.right")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Text(correction.replacement.isEmpty ? "(empty)" : correction.replacement)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                }
+                Text(ruleSummary(correction))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .opacity(correction.enabled ? 1 : 0.4)
+
+            Spacer()
+
+            Button("Edit") {
+                editingCorrection = correction
+                showingEditor = true
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+
+            Button("Delete") {
+                appState.corrections.removeAll { $0.id == correction.id }
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+            .foregroundStyle(.red)
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.8))
+    }
+
+    private func ruleSummary(_ correction: Correction) -> String {
+        var parts: [String] = [correction.wholeWord ? "Whole word" : "Anywhere"]
+        if correction.caseSensitive { parts.append("Case-sensitive") }
+        return parts.joined(separator: "  ·  ")
+    }
+}
+
+struct CorrectionEditorView: View {
+    @EnvironmentObject var appState: AppState
+    @Binding var isPresented: Bool
+    @Binding var correction: Correction?
+
+    @State private var heard: String = ""
+    @State private var replacement: String = ""
+    @State private var wholeWord: Bool = true
+    @State private var caseSensitive: Bool = false
+
+    private var canSave: Bool {
+        !heard.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var showPreview: Bool {
+        !heard.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var heardTrimmed: String {
+        heard.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var replacementTrimmed: String {
+        replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // Three casings of the heard phrase so the case-sensitive card always has
+    // a spread to compare: typed, lowercase, UPPERCASE, then Title Case as a
+    // backup when one of the first three collapses into a duplicate.
+    private var caseSamples: [String] {
+        let h = heardTrimmed
+        guard !h.isEmpty else { return [] }
+        var samples: [String] = []
+        for candidate in [h, h.lowercased(), h.uppercased(), h.capitalized] {
+            if !candidate.isEmpty && !samples.contains(candidate) {
+                samples.append(candidate)
+            }
+        }
+        return Array(samples.prefix(3))
+    }
+
+    // Compact one-line example: the bare sample, an arrow, then the result or
+    // "unchanged". Used by both the whole-word card and the case-sensitive card.
+    @ViewBuilder
+    private func previewRow(_ sample: String) -> some View {
+        let rule = Correction(
+            heard: heardTrimmed,
+            replacement: replacementTrimmed,
+            wholeWord: wholeWord,
+            caseSensitive: caseSensitive,
+            enabled: true
+        )
+        let result = DictionaryEngine.apply(sample, corrections: [rule])
+        HStack(spacing: 6) {
+            Text(sample)
+                .font(.system(.caption, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Image(systemName: "arrow.right")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            if result == sample {
+                Text("unchanged")
+                    .font(.caption2)
+                    .italic()
+                    .foregroundStyle(.tertiary)
+            } else {
+                Text(result)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.green)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func settingCard<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text(correction == nil ? "Add Word" : "Edit Word")
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Heard (what the transcription produced)")
+                    .font(.caption.weight(.semibold))
+                TextField("e.g. next message", text: $heard)
+                    .textFieldStyle(.roundedBorder)
+
+                Text("Replacement (what you meant)")
+                    .font(.caption.weight(.semibold))
+                    .padding(.top, 8)
+                TextField("e.g. nextMessage", text: $replacement)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            settingCard {
+                Toggle("Match whole words only", isOn: $wholeWord)
+                Text("On: \"cat\" will not touch \"category\". Off: replaces every occurrence, even inside other words.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                if showPreview {
+                    Text("Examples")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 2)
+                    previewRow(heardTrimmed)
+                    previewRow(heardTrimmed + "s")
+                }
+            }
+
+            settingCard {
+                Toggle("Case-sensitive", isOn: $caseSensitive)
+                Text("Off: matches the heard phrase in any casing.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                if showPreview {
+                    Text("Examples")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 2)
+                    ForEach(caseSamples, id: \.self) { sample in
+                        previewRow(sample)
+                    }
+                }
+            }
+
+            HStack {
+                Button("Cancel") {
+                    isPresented = false
+                    correction = nil
+                }
+                Spacer()
+                Button("Save") {
+                    let updated = Correction(
+                        id: correction?.id ?? UUID(),
+                        heard: heardTrimmed,
+                        replacement: replacementTrimmed,
+                        wholeWord: wholeWord,
+                        caseSensitive: caseSensitive,
+                        enabled: correction?.enabled ?? true
+                    )
+                    if let index = appState.corrections.firstIndex(where: { $0.id == updated.id }) {
+                        appState.corrections[index] = updated
+                    } else {
+                        appState.corrections.append(updated)
+                    }
+                    isPresented = false
+                    correction = nil
+                }
+                .disabled(!canSave)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 440)
+        .onAppear {
+            if let c = correction {
+                heard = c.heard
+                replacement = c.replacement
+                wholeWord = c.wholeWord
+                caseSensitive = c.caseSensitive
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds a Dictionary — a list of user-defined `heard → replacement` rules applied to the final transcript as the last step of the dictation pipeline, after the LLM post-processing pass. A correction is a guaranteed find-and-replace: it fires every time, deterministically, and still applies when post-processing is disabled or the API is unavailable.

This is the same dictionary pattern found in other dictation tools such as WhisperFlow.

## Why, and how it differs from Custom Vocabulary

Custom Vocabulary feeds the cleanup model a soft spelling hint. It is probabilistic — the model may or may not act on it, and it does nothing when post-processing is off.

The Dictionary is a different mechanism: a deterministic find-and-replace on the final text. Not a hint to a model — a literal substitution rule. When the transcription gets a specific phrase wrong the same way every time, the user names exactly what came out and what they meant, and the rule fixes it on every dictation, guaranteed. The two are complementary: vocabulary for soft spelling guidance, the Dictionary for exact, known corrections.

## Screenshot

<img width="500" src="https://assets.themarketingshow.com/bugs/freeflow/freeflow-dictionary-corrections-2026-05-21.png" alt="The Dictionary tab in Settings, showing the Corrections card with two example heard-to-replacement rules">

## What's in it

- `Correction.swift` — a `Correction` model (heard, replacement, wholeWord, caseSensitive, enabled) and `DictionaryEngine`, a pure, dependency-free apply function. Whole-word matching uses a Unicode-aware boundary so a short rule like `cat → dog` does not rewrite `category`.
- `AppState` — a persisted `corrections` array and the pipeline hook: `DictionaryEngine.apply` runs on the final transcript inside `processTranscript`, on both the post-processing-success and raw-fallback paths.
- Settings — a new Dictionary tab with full add / edit / delete, a per-rule enable toggle, and a live preview in the editor.

No existing behavior changes when the corrections list is empty.

## Testing

Built and run first as a daily-driver feature in a personal fork, then re-implemented cleanly against v1.0.0 and validated again in a fresh build of that release as a feature patch.

Exercised by live dictation:
- Empty corrections list — pipeline unchanged, transcript passes through.
- Single correction, and multiple corrections within one utterance.
- Repeatability — the same utterance dictated repeatedly gives the same result every time.
- An arbitrary mapping (a phrase → an unrelated phrase) to confirm the transformation is the deterministic engine, not the cleanup model.
- Full add / edit / delete, including running with rules present, deleted, and re-added.
- The engine call site was temporarily instrumented to confirm it runs on every dictation with the expected rule count, then the instrumentation was removed once verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Dictionary settings tab for managing custom transcript corrections.
  * Users can create, edit, and delete corrections that automatically apply to transcriptions.
  * Supports whole-word and case-sensitive matching options with a live preview when editing.
  * Corrections are persistently saved and can be individually enabled or disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->