### PR TITLE
Add opt-out for sending screenshots to the context model

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ApplicationServices
 import AppKit
+import os.log
 
 struct AppSelectionSnapshot {
     let appName: String?
@@ -36,6 +37,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
 """
     static let defaultContextPromptDate = "2026-02-24"
     static let defaultScreenshotMaxDimension: CGFloat = 1024
+    fileprivate static let contextLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Context")
 
     private let apiKey: String
     private let baseURL: String
@@ -409,7 +411,19 @@ Selected text: \(selectedText ?? "None")
         appElement: AXUIElement,
         focusedWindowTitle: String?
     ) -> (dataURL: String?, mimeType: String?, error: String?) {
+        let useScreenshotContext = UserDefaults.standard.object(forKey: "use_screenshot_context") == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: "use_screenshot_context")
+        if !useScreenshotContext {
+            os_log(.info, log: Self.contextLog, "screenshot skipped — disabled in settings (Use screen context for smarter dictation = off)")
+            return (
+                nil,
+                nil,
+                "Screen context disabled in settings. Toggle it on in Settings → Prompts → Context Prompt to use screenshots."
+            )
+        }
         if !CGPreflightScreenCaptureAccess() {
+            os_log(.info, log: Self.contextLog, "screenshot blocked — Screen Recording permission not granted")
             return (
                 nil,
                 nil,
@@ -485,6 +499,7 @@ Selected text: \(selectedText ?? "None")
                     compression: screenshotCompressionPrimary,
                     maxDimension: screenshotMaxDimension
                 ) {
+                    os_log(.info, log: Self.contextLog, "screenshot captured via active-window match (%{public}d bytes)", dataURL.count)
                     return (dataURL, "image/jpeg", nil)
                 }
             }
@@ -519,6 +534,7 @@ Selected text: \(selectedText ?? "None")
                     compression: screenshotCompressionPrimary,
                     maxDimension: screenshotMaxDimension
                 ) {
+                    os_log(.info, log: Self.contextLog, "screenshot captured via focused-title match (%{public}d bytes)", dataURL.count)
                     return (dataURL, "image/jpeg", nil)
                 }
             }
@@ -530,6 +546,7 @@ Selected text: \(selectedText ?? "None")
             kCGNullWindowID,
             [.bestResolution]
         ) else {
+            os_log(.error, log: Self.contextLog, "screenshot failed — CGWindowListCreateImage returned nil")
             return (nil, nil, "Could not capture screenshot (screen recording permission or window access issue)")
         }
 
@@ -541,9 +558,11 @@ Selected text: \(selectedText ?? "None")
             compression: screenshotCompressionPrimary,
             maxDimension: screenshotMaxDimension
         ) {
+            os_log(.info, log: Self.contextLog, "screenshot captured via full-screen fallback (%{public}d bytes)", dataURL.count)
             return (dataURL, "image/jpeg", nil)
         }
 
+        os_log(.error, log: Self.contextLog, "screenshot failed — image could not be encoded within size limits")
         return (nil, nil, "Could not capture screenshot within size limits")
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -222,6 +222,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let contextScreenshotMaxDimensionStorageKey = "context_screenshot_max_dimension"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
+    private let useScreenshotContextStorageKey = "use_screenshot_context"
     private let pressEnterVoiceCommandStorageKey = "press_enter_voice_command_enabled"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
@@ -494,6 +495,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var useScreenshotContext: Bool {
+        didSet {
+            UserDefaults.standard.set(useScreenshotContext, forKey: useScreenshotContextStorageKey)
+        }
+    }
+
     @Published var isPressEnterVoiceCommandEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isPressEnterVoiceCommandEnabled, forKey: pressEnterVoiceCommandStorageKey)
@@ -654,6 +661,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
+        let useScreenshotContext = UserDefaults.standard.object(forKey: useScreenshotContextStorageKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: useScreenshotContextStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
@@ -726,6 +736,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.outputLanguage = outputLanguage
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
+        self.useScreenshotContext = useScreenshotContext
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1693,6 +1693,16 @@ struct PromptsSettingsView: View {
             && appState.customContextPromptLastModified < AppContextService.defaultContextPromptDate
 
         return VStack(alignment: .leading, spacing: 10) {
+            SettingsSubcard {
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Use screen context for smarter dictation", isOn: $appState.useScreenshotContext)
+
+                    Text("When on, \(AppName.displayName) captures a screenshot of the active window with each dictation so the model can read what you are looking at. Off keeps dictation working with just the app name, window title, and selected text — better privacy, slightly less context-aware in browsers and Electron apps.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Text("Controls how \(AppName.displayName) infers your current activity from app metadata and screenshots.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -1896,6 +1906,12 @@ struct PromptsSettingsView: View {
         contextTestOutput = nil
         contextTestError = nil
         contextTestPrompt = nil
+
+        if !appState.useScreenshotContext {
+            contextTestError = "Screen context is disabled. Toggle \"Use screen context for smarter dictation\" on above to run this test."
+            contextTestRunning = false
+            return
+        }
 
         let service = appState.makeAppContextService()
 
@@ -2163,6 +2179,20 @@ struct RunLogEntryView: View {
                                             .aspectRatio(contentMode: .fit)
                                             .frame(maxHeight: 120)
                                             .cornerRadius(4)
+                                    } else if !item.contextScreenshotStatus.isEmpty {
+                                        HStack(alignment: .top, spacing: 6) {
+                                            Image(systemName: "camera.viewfinder")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                            Text(item.contextScreenshotStatus)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                                .fixedSize(horizontal: false, vertical: true)
+                                        }
+                                        .padding(8)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .background(Color(nsColor: .controlBackgroundColor))
+                                        .cornerRadius(4)
                                     }
 
                                     if let prompt = item.contextPrompt, !prompt.isEmpty {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -152,6 +152,25 @@ struct SetupView: View {
                                     saveCustomVocabularyAndContinue()
                                 }
                                 .keyboardShortcut(.defaultAction)
+                            } else if currentStep == .screenRecording {
+                                HStack(spacing: 10) {
+                                    Button("Skip") {
+                                        appState.useScreenshotContext = false
+                                        withAnimation {
+                                            currentStep = nextStep(currentStep)
+                                        }
+                                    }
+                                    .buttonStyle(.plain)
+                                    .foregroundStyle(.secondary)
+
+                                    Button("Continue") {
+                                        withAnimation {
+                                            currentStep = nextStep(currentStep)
+                                        }
+                                    }
+                                    .keyboardShortcut(.defaultAction)
+                                    .disabled(!canContinueFromCurrentStep)
+                                }
                             } else if currentStep == .testTranscription {
                                 HStack(spacing: 10) {
                                     Button("Skip") {


### PR DESCRIPTION
## Summary

Adds a **"Use screen context for smarter dictation"** toggle in Settings → Prompts → Context Prompt, plus a **Skip** button on the Setup wizard's Screen Recording step. Both default to **on**, so existing users see zero behavior change.

## Why

The context inference is genuinely useful, but it requires the Screen Recording permission — and every dictation captures a JPEG of the active window and ships it to whatever inference endpoint the user has configured. There is currently no way to disable just the screenshot without revoking the OS permission entirely (which also kills the grant, so flipping it back on means re-granting through System Settings).

This PR adds a clean opt-out:

- Existing user who is happy with how things work: do nothing, defaults are unchanged.
- Privacy-conscious user who wants the screenshot off: one toggle in Settings.
- New user who does not want to grant the permission at all: Skip the step in Setup.

## How it works

`AppContextService.captureActiveWindowScreenshot` gates on a new `use_screenshot_context` UserDefaults flag (default `true`). When off, it returns the same `(nil, nil, error)` tuple shape as the existing permission-denied path — so the existing `screenshotDataURL == nil` fallback throughout the codebase keeps working without modification. No new code paths, just a clean early return with a user-facing error string that points back at the toggle.

The Run Log's "Capture Context" step (Step 1) gets a small no-image caption when `contextScreenshotDataURL` is nil but `contextScreenshotStatus` is non-empty — so the user can see at a glance why a given dictation has no screenshot attached.

Test button in the Context Prompt section refuses to run when the toggle is off, with a clear message pointing back at the toggle, instead of silently running a degraded test.

## Observability

Adds an `os_log` subsystem `com.zachlatta.freeflow` category `Context` that emits one line per capture outcome:

| Outcome | Log line |
|---|---|
| Toggle off | `screenshot skipped — disabled in settings (Use screen context for smarter dictation = off)` |
| Permission denied | `screenshot blocked — Screen Recording permission not granted` |
| Captured (active window) | `screenshot captured via active-window match (N bytes)` |
| Captured (focused title match) | `screenshot captured via focused-title match (N bytes)` |
| Captured (full-screen fallback) | `screenshot captured via full-screen fallback (N bytes)` |
| CGWindowListCreateImage nil | `screenshot failed — CGWindowListCreateImage returned nil` |
| Could not encode | `screenshot failed — image could not be encoded within size limits` |

Useful for verifying gate behavior from outside the app:

```
log show --predicate 'subsystem == "com.zachlatta.freeflow" AND category == "Context"' --info --last 10m --style compact
```

## What changed

- `Sources/AppState.swift` — new `useScreenshotContext` `@Published` Bool, persisted at UserDefaults key `use_screenshot_context`, default `true`.
- `Sources/AppContextService.swift` — `import os.log`, OSLog declaration, gate in `captureActiveWindowScreenshot`, and one `os_log` line on every outcome path.
- `Sources/SettingsView.swift` — adds the toggle subcard at the top of `contextPromptSection`, the test-button refusal, and the no-image caption in the Run Log's Capture Context step.
- `Sources/SetupView.swift` — adds a Skip button to the Screen Recording step that sets `useScreenshotContext = false` and advances without granting the permission.

**+79 / -0.** Purely additive, no upstream logic modified.

## Testing

Verified locally on a downstream build:

- **Default-on behavior is unchanged.** `log show --predicate 'subsystem == "com.zachlatta.freeflow" AND category == "Context"'` shows `screenshot captured via active-window match (N bytes)` per dictation, same as `main` today.
- **Toggle off skips the capture.** Same log shows `screenshot skipped — disabled in settings` instead, dictation still completes using the existing fallback context (app + window + selection), and the Run Log's Capture Context step displays the new "Screen context disabled in settings..." caption in place of the missing image.
- **Test button refuses with friendly error when the toggle is off.** Clicking Test Context Prompt with the toggle off renders `Screen context is disabled. Toggle "Use screen context for smarter dictation" on above to run this test.` instead of running a degraded test.

## Screenshots

The Settings toggle in Prompts → Context Prompt:

<img width="500" alt="Use screen context for smarter dictation toggle in Settings" src="https://assets.themarketingshow.com/bugs/freeflow/screen-context-toggle-2026-05-23.png" />

The Run Log's Capture Context step when the toggle is off (new no-image caption in this PR):

<img width="500" alt="Run Log shows Screen context disabled in settings caption" src="https://assets.themarketingshow.com/bugs/freeflow/run-log-disabled-caption-2026-05-23.png" />

The Test Context Prompt button refusal when the toggle is off:

<img width="500" alt="Test Context Prompt refuses when screen context is disabled" src="https://assets.themarketingshow.com/bugs/freeflow/test-button-refusal-2026-05-23.png" />

## Notes

Default-on means zero regression for existing users. Defaults can flip later in a separate PR if that becomes desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added toggle in settings to enable or disable screen context functionality
  * Added Skip option in setup flow for screen recording permissions
  * Added fallback status indicator when context capture is unavailable

* **Improvements**
  * Settings now persist across app sessions
  * Enhanced explanatory text for context capture behavior in settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->