### PR TITLE
Add opt-out for sending app and window info to the context model

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ApplicationServices
 import AppKit
+import os.log
 
 struct AppSelectionSnapshot {
     let appName: String?
@@ -36,6 +37,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
 """
     static let defaultContextPromptDate = "2026-02-24"
     static let defaultScreenshotMaxDimension: CGFloat = 1024
+    fileprivate static let contextLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Context")
 
     private let apiKey: String
     private let baseURL: String
@@ -409,7 +411,19 @@ Selected text: \(selectedText ?? "None")
         appElement: AXUIElement,
         focusedWindowTitle: String?
     ) -> (dataURL: String?, mimeType: String?, error: String?) {
+        let useScreenshotContext = UserDefaults.standard.object(forKey: "use_screenshot_context") == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: "use_screenshot_context")
+        if !useScreenshotContext {
+            os_log(.info, log: Self.contextLog, "screenshot skipped — disabled in settings (Use screen context for smarter dictation = off)")
+            return (
+                nil,
+                nil,
+                "Screen context disabled in settings. Toggle it on in Settings → Prompts → Context Prompt to use screenshots."
+            )
+        }
         if !CGPreflightScreenCaptureAccess() {
+            os_log(.info, log: Self.contextLog, "screenshot blocked — Screen Recording permission not granted")
             return (
                 nil,
                 nil,
@@ -485,6 +499,7 @@ Selected text: \(selectedText ?? "None")
                     compression: screenshotCompressionPrimary,
                     maxDimension: screenshotMaxDimension
                 ) {
+                    os_log(.info, log: Self.contextLog, "screenshot captured via active-window match (%{public}d bytes)", dataURL.count)
                     return (dataURL, "image/jpeg", nil)
                 }
             }
@@ -519,6 +534,7 @@ Selected text: \(selectedText ?? "None")
                     compression: screenshotCompressionPrimary,
                     maxDimension: screenshotMaxDimension
                 ) {
+                    os_log(.info, log: Self.contextLog, "screenshot captured via focused-title match (%{public}d bytes)", dataURL.count)
                     return (dataURL, "image/jpeg", nil)
                 }
             }
@@ -530,6 +546,7 @@ Selected text: \(selectedText ?? "None")
             kCGNullWindowID,
             [.bestResolution]
         ) else {
+            os_log(.error, log: Self.contextLog, "screenshot failed — CGWindowListCreateImage returned nil")
             return (nil, nil, "Could not capture screenshot (screen recording permission or window access issue)")
         }
 
@@ -541,9 +558,11 @@ Selected text: \(selectedText ?? "None")
             compression: screenshotCompressionPrimary,
             maxDimension: screenshotMaxDimension
         ) {
+            os_log(.info, log: Self.contextLog, "screenshot captured via full-screen fallback (%{public}d bytes)", dataURL.count)
             return (dataURL, "image/jpeg", nil)
         }
 
+        os_log(.error, log: Self.contextLog, "screenshot failed — image could not be encoded within size limits")
         return (nil, nil, "Could not capture screenshot within size limits")
     }
 

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -107,20 +107,40 @@ Return only two sentences, no labels, no markdown, no extra commentary.
             )
         }
 
-        let appName = frontmostApp.localizedName
-        let bundleIdentifier = frontmostApp.bundleIdentifier
-        let appElement = AXUIElementCreateApplication(frontmostApp.processIdentifier)
+        let sendAppAndWindowContext = UserDefaults.standard.object(forKey: "send_app_and_window_context") == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: "send_app_and_window_context")
 
-        let windowTitle = focusedWindowTitle(from: appElement) ?? appName
-        let selectedText = selectedText(from: appElement)
+        let appElement = AXUIElementCreateApplication(frontmostApp.processIdentifier)
+        let internalWindowTitle = focusedWindowTitle(from: appElement) ?? frontmostApp.localizedName
+
         let screenshot = captureActiveWindowScreenshot(
             processIdentifier: frontmostApp.processIdentifier,
             appElement: appElement,
-            focusedWindowTitle: windowTitle
+            focusedWindowTitle: internalWindowTitle
         )
+
+        let appName: String?
+        let bundleIdentifier: String?
+        let windowTitle: String?
+        let selectedText: String?
+        if sendAppAndWindowContext {
+            appName = frontmostApp.localizedName
+            bundleIdentifier = frontmostApp.bundleIdentifier
+            windowTitle = internalWindowTitle
+            selectedText = self.selectedText(from: appElement)
+        } else {
+            os_log(.info, log: Self.contextLog, "app/window context skipped — disabled in settings (Send app and window info = off)")
+            appName = nil
+            bundleIdentifier = nil
+            windowTitle = nil
+            selectedText = nil
+        }
+
         let currentActivity: String
         let contextPrompt: String?
-        if !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (sendAppAndWindowContext || screenshot.dataURL != nil) {
             if let result = await inferActivityWithLLM(
                 appName: appName,
                 bundleIdentifier: bundleIdentifier,
@@ -141,6 +161,9 @@ Return only two sentences, no labels, no markdown, no extra commentary.
                 )
                 contextPrompt = nil
             }
+        } else if !sendAppAndWindowContext && screenshot.dataURL == nil {
+            currentActivity = "You are dictating. App and window context are disabled in settings, and no screenshot was captured."
+            contextPrompt = nil
         } else {
             currentActivity = fallbackCurrentActivity(
                 appName: appName,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -222,6 +222,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let contextScreenshotMaxDimensionStorageKey = "context_screenshot_max_dimension"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
+    private let useScreenshotContextStorageKey = "use_screenshot_context"
     private let pressEnterVoiceCommandStorageKey = "press_enter_voice_command_enabled"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
@@ -494,6 +495,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var useScreenshotContext: Bool {
+        didSet {
+            UserDefaults.standard.set(useScreenshotContext, forKey: useScreenshotContextStorageKey)
+        }
+    }
+
     @Published var isPressEnterVoiceCommandEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isPressEnterVoiceCommandEnabled, forKey: pressEnterVoiceCommandStorageKey)
@@ -654,6 +661,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
+        let useScreenshotContext = UserDefaults.standard.object(forKey: useScreenshotContextStorageKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: useScreenshotContextStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
@@ -726,6 +736,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.outputLanguage = outputLanguage
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
+        self.useScreenshotContext = useScreenshotContext
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -223,6 +223,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
     private let useScreenshotContextStorageKey = "use_screenshot_context"
+    private let sendAppAndWindowContextStorageKey = "send_app_and_window_context"
     private let pressEnterVoiceCommandStorageKey = "press_enter_voice_command_enabled"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
@@ -501,6 +502,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var sendAppAndWindowContext: Bool {
+        didSet {
+            UserDefaults.standard.set(sendAppAndWindowContext, forKey: sendAppAndWindowContextStorageKey)
+        }
+    }
+
     @Published var isPressEnterVoiceCommandEnabled: Bool {
         didSet {
             UserDefaults.standard.set(isPressEnterVoiceCommandEnabled, forKey: pressEnterVoiceCommandStorageKey)
@@ -664,6 +671,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let useScreenshotContext = UserDefaults.standard.object(forKey: useScreenshotContextStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: useScreenshotContextStorageKey)
+        let sendAppAndWindowContext = UserDefaults.standard.object(forKey: sendAppAndWindowContextStorageKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: sendAppAndWindowContextStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
@@ -737,6 +747,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
         self.useScreenshotContext = useScreenshotContext
+        self.sendAppAndWindowContext = sendAppAndWindowContext
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1693,6 +1693,16 @@ struct PromptsSettingsView: View {
             && appState.customContextPromptLastModified < AppContextService.defaultContextPromptDate
 
         return VStack(alignment: .leading, spacing: 10) {
+            SettingsSubcard {
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Use screen context for smarter dictation", isOn: $appState.useScreenshotContext)
+
+                    Text("When on, \(AppName.displayName) captures a screenshot of the active window with each dictation so the model can read what you are looking at. Off keeps dictation working with just the app name, window title, and selected text — better privacy, slightly less context-aware in browsers and Electron apps.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Text("Controls how \(AppName.displayName) infers your current activity from app metadata and screenshots.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -1896,6 +1906,12 @@ struct PromptsSettingsView: View {
         contextTestOutput = nil
         contextTestError = nil
         contextTestPrompt = nil
+
+        if !appState.useScreenshotContext {
+            contextTestError = "Screen context is disabled. Toggle \"Use screen context for smarter dictation\" on above to run this test."
+            contextTestRunning = false
+            return
+        }
 
         let service = appState.makeAppContextService()
 
@@ -2163,6 +2179,20 @@ struct RunLogEntryView: View {
                                             .aspectRatio(contentMode: .fit)
                                             .frame(maxHeight: 120)
                                             .cornerRadius(4)
+                                    } else if !item.contextScreenshotStatus.isEmpty {
+                                        HStack(alignment: .top, spacing: 6) {
+                                            Image(systemName: "camera.viewfinder")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                            Text(item.contextScreenshotStatus)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                                .fixedSize(horizontal: false, vertical: true)
+                                        }
+                                        .padding(8)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .background(Color(nsColor: .controlBackgroundColor))
+                                        .cornerRadius(4)
                                     }
 
                                     if let prompt = item.contextPrompt, !prompt.isEmpty {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1703,6 +1703,16 @@ struct PromptsSettingsView: View {
                 }
             }
 
+            SettingsSubcard {
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Send app and window info", isOn: $appState.sendAppAndWindowContext)
+
+                    Text("When on, \(AppName.displayName) sends the active app name, window title, and any selected text to the model so it can tailor the transcript. Off keeps the model blind to which app or window you are in — strongest privacy, but cleanup tone and proper-noun spelling lose context. Turn off both this and the screenshot toggle for fully blind dictation.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Text("Controls how \(AppName.displayName) infers your current activity from app metadata and screenshots.")
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -152,6 +152,25 @@ struct SetupView: View {
                                     saveCustomVocabularyAndContinue()
                                 }
                                 .keyboardShortcut(.defaultAction)
+                            } else if currentStep == .screenRecording {
+                                HStack(spacing: 10) {
+                                    Button("Skip") {
+                                        appState.useScreenshotContext = false
+                                        withAnimation {
+                                            currentStep = nextStep(currentStep)
+                                        }
+                                    }
+                                    .buttonStyle(.plain)
+                                    .foregroundStyle(.secondary)
+
+                                    Button("Continue") {
+                                        withAnimation {
+                                            currentStep = nextStep(currentStep)
+                                        }
+                                    }
+                                    .keyboardShortcut(.defaultAction)
+                                    .disabled(!canContinueFromCurrentStep)
+                                }
                             } else if currentStep == .testTranscription {
                                 HStack(spacing: 10) {
                                     Button("Skip") {


### PR DESCRIPTION
## Summary

Adds a second toggle in Settings → Prompts → Context Prompt: **"Send app and window info"**. Pairs with the screenshot-context toggle in #208 so users can independently control both kinds of context the model sees — pixels (screenshot) and text strings (app name, window title, selected text). Default on, no behavior change for existing users.

## Why

Even with the screenshot toggle off, the context inference still sends the active app's name, bundle identifier, window title, and any selected text to the model. That string set alone is often enough to leak meaningful information — a browser window title contains the Gmail thread subject and the user's email address, a code editor's title bar reveals the active file, a SaaS dashboard's title gives away the account being viewed.

Some users would rather the model see none of that — accepting weaker context-aware cleanup in exchange for the strongest privacy posture. This toggle gives them that option, and pairs with #208 to make the privacy story complete:

| Screenshot toggle | App/window toggle | Model sees |
|---|---|---|
| ON | ON | screenshot + app + window + selection (today's behavior) |
| OFF | ON | app + window + selection only |
| ON | OFF | screenshot only (visual reading, no metadata) |
| OFF | OFF | nothing but the audio (fully blind dictation) |

## How it works

`AppContextService.collectContext` still performs the AX reads internally so the screenshot capture path can find the active window. But when the new `send_app_and_window_context` UserDefaults flag is off, `appName`, `bundleIdentifier`, `windowTitle`, and `selectedText` are scrubbed to `nil` before being passed to the LLM inference call OR stored on the returned `AppContext`. The downstream `pipelineHistory` and run-log display honor the `nil`s naturally.

When BOTH toggles are off, the LLM inference call is skipped entirely (no signal, no API call), and `currentActivity` is set to a stable string: `"You are dictating. App and window context are disabled in settings, and no screenshot was captured."` — so the run log makes the configuration explicit instead of silently producing nothing.

## Observability

One new `os_log` line under the existing `Context` category (added in #208):

```
app/window context skipped — disabled in settings (Send app and window info = off)
```

Pairs with the screenshot skip line. When both fire on the same dictation, the unified log shows two skip entries on the same thread at the same millisecond — the verifiable signature of fully blind dictation.

## What changed

- `Sources/AppState.swift` — new `sendAppAndWindowContext` `@Published` Bool, persisted at UserDefaults key `send_app_and_window_context`, default `true`.
- `Sources/AppContextService.swift` — adds the gate in `collectContext`; AX reads still happen internally (the screenshot path needs them), but the values are scrubbed before going to the LLM or to the returned `AppContext` when the toggle is off. Also short-circuits the LLM inference call when both toggles are off, since there is no signal worth spending an API call on.
- `Sources/SettingsView.swift` — adds the second toggle subcard right below the screenshot toggle.

**+50 / -6.** The -6 lines are a small refactor in `collectContext` to move the AX reads into local variables that get conditionally scrubbed.

## Testing

Verified locally:

- **Toggle off, screenshot on.** Unified log shows `app/window context skipped — disabled in settings` per dictation; screenshot still fires as expected. Inferred activity from the model becomes generic ("a coding environment", "an email application") instead of naming the specific app or thread.
- **Both toggles off.** Unified log shows BOTH skip lines on the same dictation, same thread, same millisecond. Run log's Capture Context step shows `"You are dictating. App and window context are disabled in settings, and no screenshot was captured."`

## Screenshots

The second toggle in Prompts → Context Prompt (sits directly below the screenshot toggle from #208):

<img width="500" alt="Send app and window info toggle in Settings" src="https://assets.themarketingshow.com/bugs/freeflow/send-app-window-info-toggle-2026-05-23.png" />

## Notes

- Depends on #208 (this branch is stacked on `feat/optional-screenshot-context`). When #208 lands, this rebases to `main` cleanly. If #208 stalls, this stays a dependent and can be re-targeted.
- Default-on means zero regression for existing users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy settings to control screenshot usage in dictation and app/window context sharing
  * Users can now skip screen recording permission during setup

* **UI/UX**
  * Settings view expanded with two new toggles explaining privacy tradeoffs
  * Setup flow now provides clear skip option for screenshot permissions, with disabled continue button until recording access is granted

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->