### PR TITLE
Set lastTranscript before post-processing so Paste Again survives errors

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2528,6 +2528,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
                     )
                     try Task.checkCancellation()
+                    // Capture the parsed raw transcript as lastTranscript before
+                    // post-processing runs. If anything after this throws or focus
+                    // shifts mid-paste, the Paste Again shortcut still has the raw
+                    // text instead of the previous dictation's stale value.
+                    let bootstrapTranscript = parsedTranscript.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !bootstrapTranscript.isEmpty {
+                        await MainActor.run { [weak self] in
+                            self?.lastTranscript = bootstrapTranscript
+                        }
+                    }
                     let appContext: AppContext
                     if let sessionContext {
                         appContext = sessionContext


### PR DESCRIPTION
## The problem

When other windows pop up during dictation — terminals, notifications, anything that grabs focus — Paste Again sometimes does nothing. The shortcut produces no paste, even though the dictation completed successfully and the transcript is visible in the Run Log entry. Recovery requires opening Settings, finding the dictation in the Run Log, copying the text out manually, and pasting it by hand.

Most dictations work. The broken ones always have something stealing focus mid-flow.

## The diagnosis

Walked the post-transcription flow in `Sources/AppState.swift`. Two storage paths for the transcript diverge at different points in the pipeline:

- `pipelineHistory` entry — written inside the main `MainActor.run` block on the success path, captures `trimmedFinalTranscript` and survives because the Run Log just renders what was written when it was written.
- `lastTranscript` — also written on the success path (line 2587 on `main`), but Paste Again reads from this property. If anything between raw-transcription-success and that line throws, `lastTranscript` keeps its previous-dictation value (or empty for the first failing dictation).

The existing `os_log` line `copyLastTranscriptToPasteboard: lastTranscript is EMPTY, nothing to copy` was the smoking gun — fires when Paste Again finds nothing to paste, which is exactly the symptom.

## The bug

`lastTranscript` is set too late. The success path runs:

1. `let rawTranscript = try await transcript` — raw transcription
2. `let parsedTranscript = Self.parseTranscriptCommands(...)` — strip "press enter" markers, etc.
3. `try Task.checkCancellation()`
4. ... appContext resolution, post-processing, status formatting ...
5. `self.lastTranscript = trimmedFinalTranscript` — only NOW

Anything that throws between steps 2 and 5 leaves `lastTranscript` untouched. Most throw sites are in post-processing (network, model errors), but the `MainActor.run` block also runs AX paste-verify and a few other side effects that can fail silently.

## The fix

Capture `lastTranscript` immediately after step 2 (raw transcription succeeds and parses), before any can-fail logic runs. The existing line 2587 still overwrites with the polished version when post-processing succeeds — that path is unchanged. Errors mid-pipeline now leave the raw transcript as a usable Paste Again fallback instead of nothing.

```swift
try Task.checkCancellation()
// Capture the parsed raw transcript as lastTranscript before
// post-processing runs. If anything after this throws or focus
// shifts mid-paste, the Paste Again shortcut still has the raw
// text instead of the previous dictation's stale value.
let bootstrapTranscript = parsedTranscript.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
if !bootstrapTranscript.isEmpty {
    await MainActor.run { [weak self] in
        self?.lastTranscript = bootstrapTranscript
    }
}
let appContext: AppContext
```

## Files

- `Sources/AppState.swift` — one 10-line insertion in the transcription completion `Task`. No deletions, no refactor.

## Behavior

- **Success path:** unchanged. Line 2587 still overwrites `lastTranscript` with the polished `trimmedFinalTranscript`.
- **Post-processing fails (network error, model error):** Paste Again now pastes the raw transcript instead of nothing. Strictly better than the current behavior.
- **Focus stolen mid-paste:** Paste Again now has the raw transcript ready when the user retries — instead of finding the empty/stale value from before.
- **Raw transcription fails:** unchanged. `bootstrapTranscript` is only assigned after `try await transcript` succeeds, so failures upstream of this point behave the same as before.

## Verified

By inspection only. The bug is timing-sensitive (focus-steal window is millisecond-level), so I do not have a clean keyboard repro that fires reliably. I do have the `lastTranscript is EMPTY` log lines from real user-encountered occurrences as evidence the failure path exists.

The fix runs before every existing throw site in the `do` block, and the existing success-path assignment is preserved unchanged — so the only behavior change is "transcripts that previously got dropped on the floor now land on `lastTranscript`."

If you want a stronger verification path, an `os_log` line around the new assignment under an existing `com.zachlatta.freeflow` category would surface the bootstrap-vs-overwrite path from the unified log without changing behavior. Out of scope for this fix, but a small follow-up if it would help.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transcript consistency during dictation operations to ensure accurate capture and retention of parsed transcripts in clipboard and paste workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->