### PR TITLE
Retry success places transcript on the clipboard

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1196,6 +1196,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     } catch {
                         errorMessage = "Failed to save retry result: \(error.localizedDescription)"
                     }
+                    let trimmedRetryTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmedRetryTranscript.isEmpty {
+                        lastTranscript = trimmedRetryTranscript
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(trimmedRetryTranscript, forType: .string)
+                    }
                     retryingItemIDs.remove(item.id)
                 }
             } catch {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1193,14 +1193,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     do {
                         try pipelineHistoryStore.update(updatedItem)
                         pipelineHistory = pipelineHistoryStore.loadAllHistory()
+                        let trimmedRetryTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmedRetryTranscript.isEmpty {
+                            lastTranscript = trimmedRetryTranscript
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(trimmedRetryTranscript, forType: .string)
+                        }
                     } catch {
                         errorMessage = "Failed to save retry result: \(error.localizedDescription)"
-                    }
-                    let trimmedRetryTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !trimmedRetryTranscript.isEmpty {
-                        lastTranscript = trimmedRetryTranscript
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(trimmedRetryTranscript, forType: .string)
                     }
                     retryingItemIDs.remove(item.id)
                 }


### PR DESCRIPTION
## Summary
- When a history row errors out and the user clicks the retry icon, a successful retry now writes the regenerated transcript to `NSPasteboard.general` and updates `lastTranscript`.
- Previously the regenerated text only updated the row stored fields — recovering it required manually right-clicking the row and copying from the context menu.
- No synthetic `Cmd+V` keystroke. The user paste-controls when the text lands. The Paste Again shortcut also surfaces the retried transcript since `lastTranscript` is now in sync.

## The errored history row

<img src="https://assets.themarketingshow.com/bugs/freeflow/retry-error-history-row-v2-2026-05-27.png" width="600" alt="Errored history row in the pipeline list — the orange circular refresh icon appears at the left of the row action button group">

When a transcript errors, an orange circular refresh icon appears at the left of the row action buttons. Clicking it re-runs transcription against the saved audio file.

## Why
The retry button is most useful when a transient transcription or post-processing error wipes a recording the user actually needs. Forcing them to dig through the menu to recover the result undercuts the recovery flow. Putting the text on the clipboard restores the dictate-then-paste loop without changing the explicit-paste semantics.

## Scope
One block in the success branch of `AppState.retryTranscription(item:)`. Six new lines. The failure branch is unchanged.

## Test plan
- [ ] Force a transcription error (toggle wifi off mid-recording, or block the transcription API endpoint).
- [ ] Confirm the errored row shows the orange retry icon.
- [ ] Click the retry icon and wait for the spinner to clear.
- [ ] `Cmd+V` into a text field — retried transcript should land.
- [ ] Trigger the Paste Again shortcut — same retried transcript should land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription retry: retried results are now trimmed of extra whitespace, the displayed transcript is updated, and the cleaned text is automatically placed on the system clipboard for easy pasting. This ensures retried transcriptions are immediately visible and readily usable without manual copying.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->