### PR TITLE
Make network timeouts overridable via UserDefaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,38 @@ Then your response would be ONLY the cleaned up text, so here your response is O
 "Hey, I just wanted to follow up on the meeting from yesterday. I think we should definitely move the deadline to next Friday because the design team still needs more time to finish the mockups. Let me know if that works for you. Thanks."</code></pre>
 </details>
 
-## FAQ
+## Using a Local Model
 
-**Why does this use Groq instead of a local transcription model?**
+FreeFlow can use OpenAI-compatible local or self-hosted providers instead of Groq. In settings, configure the API base URL and model IDs for your local LLM provider, such as Ollama, LM Studio, or another OpenAI-compatible server. If your transcription backend uses a different endpoint from your LLM backend, set the transcription API URL separately.
 
-I love this idea, and originally planned to build FreeFlow using local models, but to have post-processing (that's where you get correctly spelled names when replying to emails / etc), you need to have a local LLM too.
+Local models are often slower than hosted providers, especially on cold start, long recordings, or busy hardware.
 
-If you do that, the total pipeline takes too long for the UX to be good (5-10 seconds per transcription instead of <1s). I also had concerns around battery life.
+<details>
+  <summary>Configure longer timeouts for local models</summary>
 
-Some day!
+  FreeFlow keeps the default network timeout at 20 seconds, but you can extend it with macOS defaults:
 
-**Update:** You can now use a custom model with FreeFlow by configuring the LLM API URL in the FreeFlow settings to use Ollama. Thank you @taciturnaxolotl!
+```bash
+defaults write com.zachlatta.freeflow transcription_timeout_seconds -float 120
+defaults write com.zachlatta.freeflow post_processing_timeout_seconds -float 120
+defaults write com.zachlatta.freeflow context_request_timeout_seconds -float 120
+```
+
+The timeout keys are:
+
+- `transcription_timeout_seconds`: audio transcription requests
+- `post_processing_timeout_seconds`: transcript cleanup and edit mode requests
+- `context_request_timeout_seconds`: nearby app context requests
+
+Only positive values are used. Remove a custom timeout to return to the 20-second default:
+
+```bash
+defaults delete com.zachlatta.freeflow transcription_timeout_seconds
+defaults delete com.zachlatta.freeflow post_processing_timeout_seconds
+defaults delete com.zachlatta.freeflow context_request_timeout_seconds
+```
+
+</details>
 
 ## License
 

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -44,7 +44,10 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     private let maxScreenshotDataURILength = 500_000
     private let screenshotCompressionPrimary = 0.5
     private let screenshotMaxDimension: CGFloat
-    private let contextRequestTimeoutSeconds: TimeInterval = 20
+    private var contextRequestTimeoutSeconds: TimeInterval {
+        let override = UserDefaults.standard.double(forKey: "context_request_timeout_seconds")
+        return override > 0 ? override : 20
+    }
 
     init(
         apiKey: String,

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -132,7 +132,10 @@ Behavior:
     private let defaultFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private let defaultModelReasoningEffort = "low"
     private let postProcessingMaxCompletionTokens = 4096
-    private let postProcessingTimeoutSeconds: TimeInterval = 20
+    private var postProcessingTimeoutSeconds: TimeInterval {
+        let override = UserDefaults.standard.double(forKey: "post_processing_timeout_seconds")
+        return override > 0 ? override : 20
+    }
 
     init(
         apiKey: String,

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -9,7 +9,10 @@ class TranscriptionService {
     private let transcriptionModel: String
     private let language: String?
     private let transcriptionResponseFormat = "verbose_json"
-    private let transcriptionTimeoutSeconds: TimeInterval = 20
+    private var transcriptionTimeoutSeconds: TimeInterval {
+        let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
+        return override > 0 ? override : 20
+    }
 
     init(
         apiKey: String,


### PR DESCRIPTION
## Summary

The transcription, post-processing, and context-request HTTP timeouts are currently hardcoded to 20 seconds:

- `Sources/TranscriptionService.swift:12`
- `Sources/PostProcessingService.swift:135`
- `Sources/AppContextService.swift:47`

For users running self-hosted transcription backends, 20 seconds is often too short — Granite Speech / Whisper running on local hardware can take noticeably longer than Groq to return a result for the same audio, especially on a cold start or while the GPU is busy. There is no way to extend these timeouts today without recompiling the app.

## Change

Each timeout becomes a computed property that prefers a positive `Double` value from `UserDefaults.standard` if present, otherwise returns the existing `20` default. No UI changes; no behavior change for anyone who doesn't set the keys.

Keys (matching the codebase's existing `snake_case` `@AppStorage` convention in `SettingsView.swift`):

- `transcription_timeout_seconds`
- `post_processing_timeout_seconds`
- `context_request_timeout_seconds`

Example:

```bash
defaults write com.zachlatta.freeflow transcription_timeout_seconds -float 120
```

## Test plan

- [x] `make all` compiles cleanly with the patch applied
- [x] No behavior change when the keys are unset — `UserDefaults.standard.double(forKey:)` returns 0 for missing keys, the `> 0` guard preserves the original 20s default
- [x] End-to-end verified by building locally with `make all APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY=-` and running against a self-hosted backend:
  - With `transcription_timeout_seconds = 0.25`, even trivial dictation fails with `Transcription timed out after 0 seconds`
  - With `transcription_timeout_seconds = 60`, a 7+ minute dictation that previously failed at 20s now completes
  - Confirms the override value reaches `request.timeoutInterval` and the error formatter

## Notes

This is an opt-in escape hatch for power users. If a future iteration wants to surface these in the Settings UI, the keys are already in place to bind a SwiftUI control to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request timeouts for transcription, post-processing, and nearby context operations are now user-configurable through system settings instead of fixed values, with backward-compatible 20-second defaults.

* **Documentation**
  * Added comprehensive support and configuration guidance for local or self-hosted OpenAI-compatible models, including instructions for adjusting operation timeouts to accommodate slower processing environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachlatta/freeflow/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->