### PR TITLE
Fix verbose_json incompatibility with OpenAI transcribe models

### DIFF
--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -8,7 +8,12 @@ class TranscriptionService {
     private let baseURL: URL
     private let transcriptionModel: String
     private let language: String?
-    private let transcriptionResponseFormat = "verbose_json"
+    private var transcriptionResponseFormat: String {
+        // OpenAI's *-transcribe model family rejects "verbose_json" with a 400 error;
+        // other providers (Groq whisper-large-v3, etc.) need it for no_speech_prob segments.
+        // The hallucination filter degrades gracefully when segments are absent.
+        transcriptionModel.lowercased().contains("transcribe") ? "json" : "verbose_json"
+    }
     private var transcriptionTimeoutSeconds: TimeInterval {
         let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
         return override > 0 ? override : 20
@@ -199,6 +204,8 @@ class TranscriptionService {
             return "Endpoint not found at \(provider) (HTTP 404). Base URL is likely wrong for this provider."
         case 413:
             return "Audio file too large for \(provider) (HTTP 413). Try a shorter recording."
+        case 400:
+            return "Provider rejected the request (HTTP 400). Check your model name and Base URL in Settings."
         case 429:
             return "Rate limit reached at \(provider) (HTTP 429). Wait a moment and try again."
         case 500..<600:

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -4,15 +4,22 @@ import os.log
 private let transcriptionLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Transcription")
 
 class TranscriptionService {
+    private static let modelsSupportingVerboseJSON: Set<String> = [
+        // OpenAI's Whisper model supports segment metadata. The newer
+        // gpt-4o-transcribe family only supports the plain JSON format.
+        "whisper-1",
+        // Groq's hosted Whisper models support verbose_json and expose the
+        // segment metadata used by the hallucination filter below.
+        "whisper-large-v3",
+        "whisper-large-v3-turbo"
+    ]
+
     private let apiKey: String
     private let baseURL: URL
     private let transcriptionModel: String
     private let language: String?
     private var transcriptionResponseFormat: String {
-        // OpenAI's *-transcribe model family rejects "verbose_json" with a 400 error;
-        // other providers (Groq whisper-large-v3, etc.) need it for no_speech_prob segments.
-        // The hallucination filter degrades gracefully when segments are absent.
-        transcriptionModel.lowercased().contains("transcribe") ? "json" : "verbose_json"
+        Self.responseFormat(forModel: transcriptionModel)
     }
     private var transcriptionTimeoutSeconds: TimeInterval {
         let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
@@ -31,6 +38,11 @@ class TranscriptionService {
         self.transcriptionModel = trimmedModel.isEmpty ? "whisper-large-v3" : trimmedModel
         let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.language = (trimmedLanguage?.isEmpty == false) ? trimmedLanguage : nil
+    }
+
+    static func responseFormat(forModel model: String) -> String {
+        let normalizedModel = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return modelsSupportingVerboseJSON.contains(normalizedModel) ? "verbose_json" : "json"
     }
 
     // Validate API key by hitting a lightweight endpoint


### PR DESCRIPTION
## What happened

When setting up FreeFlow with an OpenAI `*-transcribe` model (e.g. `gpt-4o-mini-transcribe`), the setup test fails immediately and the onboarding screen shows a raw API error body:

<img src="https://assets.themarketingshow.com/bugs/freeflow/verbose-json-error-2026-05-29-v3.png" width="500" alt="FreeFlow setup error showing Status 400 response_format incompatibility">

```
Submission failed: Status 400: {
  "error": {
    "message": "response_format 'verbose_json' is not compatible with model 'gpt-4o-mini-transcribe-api-ev3'. Use 'json' or 'text' instead.",
    "type": "invalid_request_error",
    "param": "response_format",
    "code": "unsupported_value"
  }
}
```

Two separate problems compound here: the wrong `response_format` value is being sent, and HTTP 400 had no friendly case in the error handler so the raw body surfaced.

## The diagnosis

`TranscriptionService` hard-codes `response_format = "verbose_json"`. OpenAI's Whisper-based models (`whisper-1`) accept this. OpenAI's newer `*-transcribe` model family explicitly rejects it — their API only accepts `"json"` or `"text"`.

`verbose_json` is needed for Groq/Whisper users because it returns per-segment `no_speech_prob` values, which the hallucination filter relies on. Switching to `"json"` globally would break that. But `"json"` is the right default for any model whose name contains `"transcribe"`.

The hallucination filter already degrades gracefully when segments are absent (`parseTranscript` checks for `json["segments"]` and returns `false` — skipping the filter — when none are present), so `"json"` responses from transcribe models flow through cleanly.

## The fix

**1. Model-aware `response_format`** — changed from a stored constant to a computed property:

```swift
private var transcriptionResponseFormat: String {
    transcriptionModel.lowercased().contains("transcribe") ? "json" : "verbose_json"
}
```

This preserves `verbose_json` for Groq and Whisper users while routing any `*-transcribe` model to the `json` format the provider expects.

**2. Explicit HTTP 400 case** — added to `friendlyHTTPMessage`:

```swift
case 400:
    return "Provider rejected the request (HTTP 400). Check your model name and Base URL in Settings."
```

Previously 400 fell through to the generic default. The new message points directly at the two most common 400 causes: wrong model name and wrong Base URL.

## Files changed

- `Sources/TranscriptionService.swift` — two changes: computed `transcriptionResponseFormat`, `case 400` in `friendlyHTTPMessage`

## Behavior unchanged

- Groq users (`whisper-large-v3`, etc.): still receive `verbose_json`, hallucination filter works as before.
- Any model not containing `"transcribe"` in its name: unchanged.
- 401, 403, 404, 413, 429, 5xx: unchanged.

## Verified

- `gpt-4o-mini-transcribe` path: reasoned through — `response_format` becomes `"json"`, API accepts the request, transcript returned; hallucination filter skips gracefully with no segments.
- Groq path: `"whisper-large-v3"` does not contain `"transcribe"`, format stays `"verbose_json"`, no change.
- 400 friendly message: confirmed the string is what the user sees in the setup error view.

## Notes / Considered

- **Why not use `"json"` for all models?** The hallucination filter needs `no_speech_prob` from `verbose_json` segments. Removing it for Whisper users would silently stop filtering common hallucinations on silence.
- **Naming-convention bet:** the `contains("transcribe")` check assumes OpenAI keeps `"transcribe"` in future model names. If a provider uses a different naming scheme, this falls back to `verbose_json` and they would see the same 400 again. A settings override for `response_format` would be a more robust long-term fix, but that is a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for transcription service failures, now providing model name and configuration details when HTTP 400 errors occur.

* **Improvements**
  * Enhanced transcription service compatibility by selecting the response format based on the configured transcription model (verbose output for supported whisper variants; JSON otherwise).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->