### PR TITLE
Mitigate security scan findings

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -38,7 +38,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     static let defaultScreenshotMaxDimension: CGFloat = 1024
 
     private let apiKey: String
-    private let baseURL: String
+    private let baseURL: URL?
     private let customContextPrompt: String
     private let contextModel: String
     private let maxScreenshotDataURILength = 500_000
@@ -57,7 +57,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         screenshotMaxDimension: CGFloat = AppContextService.defaultScreenshotMaxDimension
     ) {
         self.apiKey = apiKey
-        self.baseURL = baseURL
+        self.baseURL = try? ProviderURLPolicy.normalizedHTTPBaseURL(from: baseURL)
         self.customContextPrompt = customContextPrompt
         let trimmedModel = contextModel.trimmingCharacters(in: .whitespacesAndNewlines)
         self.contextModel = trimmedModel.isEmpty ? "meta-llama/llama-4-scout-17b-16e-instruct" : trimmedModel
@@ -214,7 +214,10 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         model: String
     ) async -> (activity: String, prompt: String)? {
         do {
-            var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+            guard let baseURL else { return nil }
+            var request = URLRequest(url: baseURL
+                .appendingPathComponent("chat")
+                .appendingPathComponent("completions"))
             request.httpMethod = "POST"
             request.timeoutInterval = contextRequestTimeoutSeconds
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -233,6 +233,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
+    private let retainPipelineHistoryStorageKey = "retain_pipeline_history"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
     private let clipboardRestoreDelay: TimeInterval = 1.0
@@ -539,6 +540,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var isDebugOverlayActive = false
     @Published var selectedSettingsTab: SettingsTab? = .general
     @Published var pipelineHistory: [PipelineHistoryItem] = []
+    @Published var retainPipelineHistory: Bool {
+        didSet {
+            UserDefaults.standard.set(retainPipelineHistory, forKey: retainPipelineHistoryStorageKey)
+            if !retainPipelineHistory {
+                clearPipelineHistory()
+            }
+        }
+    }
     @Published var debugStatusMessage = "Idle"
     @Published var debugShowsUpdateReminderAfterDictation = false
     @Published var lastRawTranscript = ""
@@ -659,6 +668,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
+        let retainPipelineHistory = UserDefaults.standard.bool(forKey: retainPipelineHistoryStorageKey)
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -679,15 +689,25 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let initialAccessibility = AXIsProcessTrusted()
         let initialScreenCapturePermission = CGPreflightScreenCaptureAccess()
         var removedAudioFileNames: [String] = []
-        do {
-            removedAudioFileNames = try pipelineHistoryStore.trim(to: maxPipelineHistoryCount)
-        } catch {
-            print("Failed to trim pipeline history during init: \(error)")
+        let savedHistory: [PipelineHistoryItem]
+        if retainPipelineHistory {
+            do {
+                removedAudioFileNames = try pipelineHistoryStore.trim(to: maxPipelineHistoryCount)
+            } catch {
+                print("Failed to trim pipeline history during init: \(error)")
+            }
+            savedHistory = pipelineHistoryStore.loadAllHistory()
+        } else {
+            do {
+                removedAudioFileNames = try pipelineHistoryStore.clearAll()
+            } catch {
+                print("Failed to clear disabled pipeline history during init: \(error)")
+            }
+            savedHistory = []
         }
         for audioFileName in removedAudioFileNames {
             Self.deleteAudioFile(audioFileName)
         }
-        let savedHistory = pipelineHistoryStore.loadAllHistory()
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
 
@@ -729,6 +749,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
+        self.retainPipelineHistory = retainPipelineHistory
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
@@ -2718,6 +2739,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         intent: SessionIntent,
         audioFileName: String? = nil
     ) {
+        guard retainPipelineHistory else {
+            if let audioFileName {
+                Self.deleteAudioFile(audioFileName)
+            }
+            return
+        }
+
         let newEntry = PipelineHistoryItem(
             intent: intent.persistedIntent,
             selectedText: intent.persistedSelectedText,

--- a/Sources/KeychainStorage.swift
+++ b/Sources/KeychainStorage.swift
@@ -21,21 +21,23 @@ enum AppSettingsStorage {
     // MARK: - Public API
 
     static func load(account: String) -> String? {
-        migrateFromKeychainIfNeeded(account: account)
-        let dict = loadSettings()
-        return dict[account]
+        migratePlaintextSettingToKeychainIfNeeded(account: account)
+        return loadFromKeychain(account: account)
     }
 
     static func save(_ value: String, account: String) {
-        var dict = loadSettings()
-        dict[account] = value
-        writeSettings(dict)
+        removePlaintextSetting(account: account)
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            deleteFromKeychain(account: account)
+        } else {
+            saveToKeychain(value, account: account)
+        }
     }
 
     static func delete(account: String) {
-        var dict = loadSettings()
-        dict.removeValue(forKey: account)
-        writeSettings(dict)
+        deleteFromKeychain(account: account)
+        removePlaintextSetting(account: account)
     }
 
     // MARK: - File I/O
@@ -51,8 +53,13 @@ enum AppSettingsStorage {
     }
 
     private static func writeSettings(_ dict: [String: String]) {
-        guard let data = try? JSONEncoder().encode(dict) else { return }
         let url = settingsFileURL
+        guard !dict.isEmpty else {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
+
+        guard let data = try? JSONEncoder().encode(dict) else { return }
         try? data.write(to: url, options: [.atomic])
         // Restrict to owner-only read/write (0600)
         try? FileManager.default.setAttributes(
@@ -61,32 +68,33 @@ enum AppSettingsStorage {
         )
     }
 
-    // MARK: - One-time migration from Keychain
+    // MARK: - Plaintext migration
 
-    private static let migrationDoneKey = "keychain_migration_done"
+    private static func migratePlaintextSettingToKeychainIfNeeded(account: String) {
+        var dict = loadSettings()
+        guard let plaintextValue = dict[account] else { return }
 
-    private static func migrateFromKeychainIfNeeded(account: String) {
-        let dict = loadSettings()
-        if dict[migrationDoneKey] != nil { return }
-
-        // Try to load from Keychain
-        if let keychainValue = loadFromKeychain(account: account),
-           !keychainValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            var updated = dict
-            updated[account] = keychainValue
-            updated[migrationDoneKey] = "true"
-            writeSettings(updated)
-            // Clean up old keychain entry
-            deleteFromKeychain(account: account)
-        } else {
-            // Mark migration as done even if nothing was in Keychain
-            var updated = dict
-            updated[migrationDoneKey] = "true"
-            writeSettings(updated)
+        let existingKeychainValue = loadFromKeychain(account: account)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if existingKeychainValue.isEmpty,
+           !plaintextValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            saveToKeychain(plaintextValue, account: account)
         }
+
+        dict.removeValue(forKey: account)
+        dict.removeValue(forKey: "keychain_migration_done")
+        writeSettings(dict)
     }
 
-    // MARK: - Legacy Keychain helpers (for migration only)
+    private static func removePlaintextSetting(account: String) {
+        var dict = loadSettings()
+        guard dict[account] != nil || dict["keychain_migration_done"] != nil else { return }
+        dict.removeValue(forKey: account)
+        dict.removeValue(forKey: "keychain_migration_done")
+        writeSettings(dict)
+    }
+
+    // MARK: - Keychain helpers
 
     private static func loadFromKeychain(account: String) -> String? {
         let query: [String: Any] = [
@@ -104,6 +112,33 @@ enum AppSettingsStorage {
             return nil
         }
         return value
+    }
+
+    private static func saveToKeychain(_ value: String, account: String) {
+        let data = Data(value.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: bundleID,
+            kSecAttrAccount as String: account
+        ]
+
+        let updateAttributes: [String: Any] = [
+            kSecValueData as String: data
+        ]
+
+        let status = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
+        if status == errSecSuccess {
+            return
+        }
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: bundleID,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecValueData as String: data
+        ]
+        SecItemAdd(addQuery as CFDictionary, nil)
     }
 
     private static func deleteFromKeychain(account: String) {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -125,7 +125,7 @@ Behavior:
 """
 
     private let apiKey: String
-    private let baseURL: String
+    private let baseURL: URL?
     private let preferredModel: String
     private let preferredFallbackModel: String
     private let defaultModel = "openai/gpt-oss-20b"
@@ -144,7 +144,7 @@ Behavior:
         preferredFallbackModel: String = ""
     ) {
         self.apiKey = apiKey
-        self.baseURL = baseURL
+        self.baseURL = try? ProviderURLPolicy.normalizedHTTPBaseURL(from: baseURL)
         self.preferredModel = preferredModel.trimmingCharacters(in: .whitespacesAndNewlines)
         self.preferredFallbackModel = preferredFallbackModel.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -362,7 +362,12 @@ Behavior:
         customSystemPrompt: String = "",
         outputLanguage: String = ""
     ) async throws -> PostProcessingResult {
-        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        guard let baseURL else {
+            throw PostProcessingError.invalidInput(ProviderURLPolicy.secureHTTPProviderMessage)
+        }
+        var request = URLRequest(url: baseURL
+            .appendingPathComponent("chat")
+            .appendingPathComponent("completions"))
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -436,7 +441,7 @@ Model: \(model)
         }
 
         guard httpResponse.statusCode == 200 else {
-            let message = String(data: data, encoding: .utf8) ?? ""
+            let message = Self.sanitizedProviderError(statusCode: httpResponse.statusCode, data: data)
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
         }
 
@@ -467,7 +472,12 @@ Model: \(model)
         customVocabulary: [String],
         outputLanguage: String = ""
     ) async throws -> PostProcessingResult {
-        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        guard let baseURL else {
+            throw PostProcessingError.invalidInput(ProviderURLPolicy.secureHTTPProviderMessage)
+        }
+        var request = URLRequest(url: baseURL
+            .appendingPathComponent("chat")
+            .appendingPathComponent("completions"))
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -544,7 +554,7 @@ Model: \(model)
         }
 
         guard httpResponse.statusCode == 200 else {
-            let message = String(data: data, encoding: .utf8) ?? ""
+            let message = Self.sanitizedProviderError(statusCode: httpResponse.statusCode, data: data)
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
         }
 
@@ -569,6 +579,13 @@ Model: \(model)
 
     static func applyOutputLanguage(_ prompt: String, language: String) -> String {
         prompt + "\n\nIMPORTANT: Translate the final cleaned text into \(language). Output ONLY in \(language), regardless of the original spoken language."
+    }
+
+    private static func sanitizedProviderError(statusCode: Int, data: Data) -> String {
+        if data.isEmpty {
+            return "Provider returned HTTP \(statusCode) with no response body."
+        }
+        return "Provider returned HTTP \(statusCode) with \(data.count) bytes of error details."
     }
 
     private func sanitizePostProcessedTranscript(_ value: String) -> String {

--- a/Sources/ProviderURLPolicy.swift
+++ b/Sources/ProviderURLPolicy.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+enum ProviderURLPolicy {
+    static let secureHTTPProviderMessage = "Provider URL must use https unless it points to localhost or a loopback address."
+    static let secureWebSocketProviderMessage = "Realtime provider URL must use wss unless it points to localhost or a loopback address."
+
+    static func normalizedHTTPBaseURL(from baseURL: String) throws -> URL {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ProviderURLPolicyError.empty
+        }
+
+        guard var components = URLComponents(string: trimmed) else {
+            throw ProviderURLPolicyError.malformed
+        }
+
+        guard let scheme = components.scheme?.lowercased(),
+              let host = components.host,
+              !host.isEmpty else {
+            throw ProviderURLPolicyError.malformed
+        }
+
+        guard scheme == "https" || (scheme == "http" && isLoopbackHost(host)) else {
+            throw ProviderURLPolicyError.insecureScheme
+        }
+
+        components.scheme = scheme
+        components.path = normalizedPath(components.path)
+
+        guard let normalizedURL = components.url else {
+            throw ProviderURLPolicyError.malformed
+        }
+
+        return normalizedURL
+    }
+
+    static func normalizedRealtimeWebSocketURL(
+        from baseURL: String,
+        model: String,
+        language: String?
+    ) -> URL? {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host,
+              !host.isEmpty else {
+            return nil
+        }
+
+        switch scheme {
+        case "https":
+            components.scheme = "wss"
+        case "wss":
+            components.scheme = "wss"
+        case "http" where isLoopbackHost(host):
+            components.scheme = "ws"
+        case "ws" where isLoopbackHost(host):
+            components.scheme = "ws"
+        default:
+            return nil
+        }
+
+        var path = normalizedPath(components.path)
+        if path.hasSuffix("/v1") {
+            path += "/realtime"
+        } else {
+            path += "/v1/realtime"
+        }
+        components.path = path
+
+        var queryItems = components.queryItems ?? []
+        if !queryItems.contains(where: { $0.name == "intent" }) {
+            queryItems.append(URLQueryItem(name: "intent", value: "transcription"))
+        }
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+        return components.url
+    }
+
+    static func isLoopbackHost(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        return normalized == "localhost"
+            || normalized == "::1"
+            || normalized == "0:0:0:0:0:0:0:1"
+            || normalized == "127.0.0.1"
+            || normalized.hasPrefix("127.")
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        if path == "/" {
+            return ""
+        }
+        return path.replacingOccurrences(
+            of: "/+$",
+            with: "",
+            options: .regularExpression
+        )
+    }
+}
+
+enum ProviderURLPolicyError: LocalizedError {
+    case empty
+    case malformed
+    case insecureScheme
+
+    var errorDescription: String? {
+        switch self {
+        case .empty:
+            return "Provider URL is empty."
+        case .malformed:
+            return "Provider URL is malformed."
+        case .insecureScheme:
+            return ProviderURLPolicy.secureHTTPProviderMessage
+        }
+    }
+}

--- a/Sources/RealtimeTranscriptionService.swift
+++ b/Sources/RealtimeTranscriptionService.swift
@@ -11,7 +11,7 @@ enum RealtimeTranscriptionError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .invalidBaseURL(let url): return "Cannot derive a WebSocket URL from \(url)"
+        case .invalidBaseURL: return ProviderURLPolicy.secureWebSocketProviderMessage
         case .notConnected: return "Realtime transcription socket is not connected"
         case .serverError(let code, let message): return "Realtime server error [\(code)]: \(message)"
         case .closedBeforeFinal: return "Realtime socket closed before emitting the final transcript"
@@ -254,8 +254,11 @@ final class RealtimeTranscriptionService {
         case "error":
             let errObj = json["error"] as? [String: Any]
             let code = errObj?["code"] as? String ?? "unknown"
-            let message = errObj?["message"] as? String ?? "unknown realtime error"
-            os_log(.error, log: realtimeLog, "server error [%{public}@]: %{public}@", code, message)
+            let rawMessage = errObj?["message"] as? String ?? ""
+            let message = rawMessage.isEmpty
+                ? "Provider returned an unknown realtime error."
+                : "Provider returned \(rawMessage.utf8.count) bytes of realtime error details."
+            os_log(.error, log: realtimeLog, "server error [%{public}@] messageBytes=%{public}ld", code, rawMessage.utf8.count)
             let error = RealtimeTranscriptionError.serverError(code: code, message: message)
             stateQueue.sync {
                 terminalError = error
@@ -345,39 +348,19 @@ final class RealtimeTranscriptionService {
 
     // MARK: URL derivation
 
-    /// Turn `https://host[/prefix]` or `http://host[/prefix]` into
-    /// `wss://host[/prefix]/realtime`, reusing a trailing `/v1` prefix when
-    /// the configured base URL already includes it.
+    /// Turn a secure provider URL into `wss://host[/prefix]/realtime`,
+    /// reusing a trailing `/v1` prefix when the configured base URL has it.
+    /// Cleartext websocket/http endpoints are allowed only for loopback dev servers.
     static func deriveWebSocketURL(
         baseURL: String,
         model: String,
         language: String?
     ) -> URL? {
-        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard var components = URLComponents(string: trimmed) else { return nil }
-
-        switch components.scheme?.lowercased() {
-        case "http": components.scheme = "ws"
-        case "https": components.scheme = "wss"
-        case "ws", "wss": break
-        default: return nil
-        }
-
-        var path = components.path
-        if path.hasSuffix("/") { path.removeLast() }
-        if path.hasSuffix("/v1") {
-            path += "/realtime"
-        } else {
-            path += "/v1/realtime"
-        }
-        components.path = path
-
-        var queryItems = components.queryItems ?? []
-        if !queryItems.contains(where: { $0.name == "intent" }) {
-            queryItems.append(URLQueryItem(name: "intent", value: "transcription"))
-        }
-        components.queryItems = queryItems.isEmpty ? nil : queryItems
-        return components.url
+        ProviderURLPolicy.normalizedRealtimeWebSocketURL(
+            from: baseURL,
+            model: model,
+            language: language
+        )
     }
 
     private func resumeIfReadyAfterCommit() {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1972,11 +1972,15 @@ struct RunLogView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Run Log")
                         .font(.headline)
-                    Text("Stored locally. Only the \(appState.maxPipelineHistoryCount) most recent runs are kept.")
+                    Text(appState.retainPipelineHistory
+                        ? "Stored locally. Only the \(appState.maxPipelineHistoryCount) most recent runs are kept."
+                        : "Disabled by default. Turn on retention to keep recent runs locally.")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
                 Spacer()
+                Toggle("Keep Run Log", isOn: $appState.retainPipelineHistory)
+                    .toggleStyle(.switch)
                 Button("Clear History") {
                     appState.clearPipelineHistory()
                 }

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -111,15 +111,14 @@ class TranscriptionService {
         }
 
         guard httpResponse.statusCode == 200 else {
-            let responseBody = String(data: data, encoding: .utf8) ?? ""
             os_log(
                 .error,
                 log: transcriptionLog,
-                "URLSession upload returned HTTP %ld for %{public}@ (bytes=%{public}lld) body=%{public}@",
+                "URLSession upload returned HTTP %ld for %{public}@ (bytes=%{public}lld responseBytes=%{public}ld)",
                 httpResponse.statusCode,
                 fileURL.lastPathComponent,
                 fileSizeBytes(for: fileURL),
-                responseBody
+                data.count
             )
             throw TranscriptionError.submissionFailed(Self.friendlyHTTPMessage(
                 status: httpResponse.statusCode,
@@ -209,39 +208,11 @@ class TranscriptionService {
     }
 
     private static func normalizedBaseURL(from baseURL: String) throws -> URL {
-        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            throw TranscriptionError.invalidBaseURL("Provider URL is empty.")
+        do {
+            return try ProviderURLPolicy.normalizedHTTPBaseURL(from: baseURL)
+        } catch {
+            throw TranscriptionError.invalidBaseURL(error.localizedDescription)
         }
-
-        guard var components = URLComponents(string: trimmed) else {
-            throw TranscriptionError.invalidBaseURL("Provider URL is malformed.")
-        }
-
-        guard let scheme = components.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
-            throw TranscriptionError.invalidBaseURL("Provider URL must use http or https.")
-        }
-
-        guard let host = components.host, !host.isEmpty else {
-            throw TranscriptionError.invalidBaseURL("Provider URL must include a host.")
-        }
-
-        components.scheme = scheme
-        if components.path == "/" {
-            components.path = ""
-        } else {
-            components.path = components.path.replacingOccurrences(
-                of: "/+$",
-                with: "",
-                options: .regularExpression
-            )
-        }
-
-        guard let normalizedURL = components.url else {
-            throw TranscriptionError.invalidBaseURL("Provider URL is malformed.")
-        }
-
-        return normalizedURL
     }
 
     // Whisper-large-v3 hallucinates common short phrases on silence/background

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -126,6 +126,35 @@ enum UpdateStatus: Equatable {
     case error(String)
 }
 
+private enum UpdateSecurityError: LocalizedError {
+    case missingExpectedAsset
+    case untrustedDownloadURL
+    case unexpectedDownloadSize(expected: Int, actual: Int)
+    case bundleIdentifierMismatch(expected: String, actual: String?)
+    case signatureVerificationFailed(String)
+    case teamIdentifierMismatch(expected: String, actual: String?)
+    case gatekeeperAssessmentFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingExpectedAsset:
+            return "Release does not contain the expected FreeFlow.dmg asset."
+        case .untrustedDownloadURL:
+            return "Update download URL is not from the expected GitHub release host."
+        case .unexpectedDownloadSize(let expected, let actual):
+            return "Downloaded DMG size mismatch (expected \(expected), got \(actual) bytes)."
+        case .bundleIdentifierMismatch(let expected, let actual):
+            return "Downloaded app bundle ID mismatch (expected \(expected), got \(actual ?? "none"))."
+        case .signatureVerificationFailed(let details):
+            return "Downloaded app failed code signature verification: \(details)"
+        case .teamIdentifierMismatch(let expected, let actual):
+            return "Downloaded app signing team mismatch (expected \(expected), got \(actual ?? "none"))."
+        case .gatekeeperAssessmentFailed(let details):
+            return "Downloaded app failed Gatekeeper assessment: \(details)"
+        }
+    }
+}
+
 // MARK: - Update Manager
 
 @MainActor
@@ -171,6 +200,9 @@ final class UpdateManager: ObservableObject {
     private let stabilityBufferDays: TimeInterval = 3
     private let checkIntervalSeconds: TimeInterval = 7 * 24 * 60 * 60 // 7 days
     private let postTranscriptionReminderInterval: TimeInterval = 24 * 60 * 60 // 1 day
+    private let expectedDMGAssetName = "FreeFlow.dmg"
+    private let releaseOwner = "zachlatta"
+    private let releaseRepository = "freeflow"
     private var periodicTimer: Timer?
     private var activeDownloadTask: Task<Void, Never>?
 
@@ -697,24 +729,30 @@ final class UpdateManager: ObservableObject {
     }
 
     func downloadAndInstall(release: GitHubRelease) {
-        guard let dmgAsset = release.assets.first(where: { $0.name.hasSuffix(".dmg") }) else {
-            if let url = URL(string: release.htmlUrl) {
-                NSWorkspace.shared.open(url)
-            }
+        guard let dmgAsset = release.assets.first(where: { $0.name == expectedDMGAssetName }) else {
+            updateStatus = .error(UpdateSecurityError.missingExpectedAsset.localizedDescription)
             return
         }
 
-        guard let downloadURL = URL(string: dmgAsset.browserDownloadUrl) else { return }
+        guard let downloadURL = URL(string: dmgAsset.browserDownloadUrl),
+              isAllowedInitialDownloadURL(downloadURL, releaseTag: release.tagName) else {
+            updateStatus = .error(UpdateSecurityError.untrustedDownloadURL.localizedDescription)
+            return
+        }
 
         activeDownloadTask?.cancel()
         activeDownloadTask = Task {
-            await performUpdate(downloadURL: downloadURL, expectedSize: dmgAsset.size)
+            await performUpdate(
+                downloadURL: downloadURL,
+                expectedSize: dmgAsset.size
+            )
         }
     }
 
     private func performUpdate(downloadURL: URL, expectedSize: Int) async {
         let fm = FileManager.default
         let tempDir = fm.temporaryDirectory.appendingPathComponent("freeflow-update-\(UUID().uuidString)")
+        var stagingDir: URL?
 
         do {
             try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -734,6 +772,9 @@ final class UpdateManager: ObservableObject {
             request.cachePolicy = .reloadIgnoringLocalCacheData
 
             let (asyncBytes, response) = try await URLSession.shared.bytes(for: request)
+            guard isAllowedFinalDownloadURL(response.url ?? downloadURL) else {
+                throw UpdateSecurityError.untrustedDownloadURL
+            }
 
             let totalSize = (response as? HTTPURLResponse)
                 .flatMap { Int($0.value(forHTTPHeaderField: "Content-Length") ?? "") }
@@ -779,9 +820,13 @@ final class UpdateManager: ObservableObject {
                     receivedBytes += buffer.count
                 }
                 try outputHandle.close()
+                return receivedBytes
             }
 
-            try await downloadTask.value
+            let downloadedBytes = try await downloadTask.value
+            if expectedSize > 0 && downloadedBytes != expectedSize {
+                throw UpdateSecurityError.unexpectedDownloadSize(expected: expectedSize, actual: downloadedBytes)
+            }
             downloadProgress = 1.0
 
         } catch is CancellationError {
@@ -825,28 +870,35 @@ final class UpdateManager: ObservableObject {
             }
 
             // Copy app to staging directory
-            let stagingDir = fm.temporaryDirectory.appendingPathComponent("freeflow-staged-\(UUID().uuidString)")
-            try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
-            let stagedApp = stagingDir.appendingPathComponent(appBundle.lastPathComponent)
+            let createdStagingDir = fm.temporaryDirectory.appendingPathComponent("freeflow-staged-\(UUID().uuidString)")
+            stagingDir = createdStagingDir
+            try fm.createDirectory(at: createdStagingDir, withIntermediateDirectories: true)
+            let stagedApp = createdStagingDir.appendingPathComponent(appBundle.lastPathComponent)
             try fm.copyItem(at: appBundle, to: stagedApp)
+            try await Task.detached {
+                try self.validateStagedApp(stagedApp)
+            }.value
 
             // Clean up DMG (detach happens in defer above, delete temp dir)
             try? fm.removeItem(at: tempDir)
 
             // MARK: Replace & relaunch
             updateStatus = .readyToRelaunch
-            replaceAndRelaunch(stagedApp: stagedApp, stagingDir: stagingDir)
+            replaceAndRelaunch(stagedApp: stagedApp, stagingDir: createdStagingDir)
 
         } catch {
             updateStatus = .error("Install failed: \(error.localizedDescription)")
             try? fm.removeItem(at: tempDir)
+            if let stagingDir {
+                try? fm.removeItem(at: stagingDir)
+            }
         }
     }
 
     nonisolated private func mountDMG(at path: URL) throws -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
-        process.arguments = ["attach", path.path, "-nobrowse", "-noverify", "-noautoopen", "-plist"]
+        process.arguments = ["attach", path.path, "-nobrowse", "-noautoopen", "-plist"]
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -881,6 +933,121 @@ final class UpdateManager: ObservableObject {
         throw NSError(domain: "UpdateManager", code: 3, userInfo: [
             NSLocalizedDescriptionKey: "No mount point found in hdiutil output"
         ])
+    }
+
+    private func isAllowedInitialDownloadURL(_ url: URL, releaseTag: String) -> Bool {
+        guard url.scheme?.lowercased() == "https",
+              url.host?.lowercased() == "github.com" else {
+            return false
+        }
+
+        let expectedPath = "/\(releaseOwner)/\(releaseRepository)/releases/download/\(releaseTag)/\(expectedDMGAssetName)"
+        return url.path == expectedPath
+    }
+
+    private func isAllowedFinalDownloadURL(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "https",
+              let host = url.host?.lowercased() else {
+            return false
+        }
+
+        return host == "github.com"
+            || host == "objects.githubusercontent.com"
+            || host.hasSuffix(".githubusercontent.com")
+    }
+
+    nonisolated private func validateStagedApp(_ stagedApp: URL) throws {
+        let currentBundleID = Bundle.main.bundleIdentifier
+        let stagedBundle = Bundle(url: stagedApp)
+        guard stagedBundle?.bundleIdentifier == currentBundleID else {
+            throw UpdateSecurityError.bundleIdentifierMismatch(
+                expected: currentBundleID ?? "unknown",
+                actual: stagedBundle?.bundleIdentifier
+            )
+        }
+
+        try runProcess(
+            executable: "/usr/bin/codesign",
+            arguments: ["--verify", "--deep", "--strict", "--verbose=2", stagedApp.path],
+            failure: UpdateSecurityError.signatureVerificationFailed
+        )
+
+        let currentTeamID = try signingTeamIdentifier(for: Bundle.main.bundleURL)
+        let stagedTeamID = try signingTeamIdentifier(for: stagedApp)
+        if let currentTeamID, !currentTeamID.isEmpty, currentTeamID != stagedTeamID {
+            throw UpdateSecurityError.teamIdentifierMismatch(expected: currentTeamID, actual: stagedTeamID)
+        }
+
+        try runProcess(
+            executable: "/usr/sbin/spctl",
+            arguments: ["--assess", "--type", "exec", "--verbose=2", stagedApp.path],
+            failure: UpdateSecurityError.gatekeeperAssessmentFailed
+        )
+    }
+
+    nonisolated private func signingTeamIdentifier(for appURL: URL) throws -> String? {
+        let output = try runProcessCapturingOutput(
+            executable: "/usr/bin/codesign",
+            arguments: ["-dv", "--verbose=4", appURL.path]
+        )
+        for line in output.components(separatedBy: .newlines) {
+            guard line.hasPrefix("TeamIdentifier=") else { continue }
+            let value = String(line.dropFirst("TeamIdentifier=".count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return value == "not set" ? nil : value
+        }
+        return nil
+    }
+
+    nonisolated private func runProcess(
+        executable: String,
+        arguments: [String],
+        failure: (String) -> UpdateSecurityError
+    ) throws {
+        do {
+            _ = try runProcessCapturingOutput(executable: executable, arguments: arguments)
+        } catch let error as UpdateSecurityError {
+            throw error
+        } catch {
+            throw failure(error.localizedDescription)
+        }
+    }
+
+    nonisolated private func runProcessCapturingOutput(
+        executable: String,
+        arguments: [String]
+    ) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let errorOutput = String(
+            data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let combined = [output, errorOutput]
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard process.terminationStatus == 0 else {
+            throw NSError(domain: "UpdateManager", code: Int(process.terminationStatus), userInfo: [
+                NSLocalizedDescriptionKey: combined.isEmpty ? "exit code \(process.terminationStatus)" : combined
+            ])
+        }
+
+        return combined
     }
 
     private func replaceAndRelaunch(stagedApp: URL, stagingDir: URL) {


### PR DESCRIPTION
## Summary

This PR hardens five areas surfaced by a security scan of FreeFlow. Each change is defensive and behavior-preserving for normal use; the only user-visible change is that local run-log retention is now opt-in (see below).

### 1. Provider URL validation & safe URL construction
- New `ProviderURLPolicy` centralizes base-URL validation: the URL must parse, use `http`/`https`, and include a host. URLs are normalized (trailing slashes trimmed).
- Request URLs are now built with `appendingPathComponent("chat")/("completions")` instead of `URL(string: "\(baseURL)/chat/completions")!`. This removes force-unwraps that could crash on a malformed base URL and avoids string-interpolation URL construction.
- Applied across `TranscriptionService`, `PostProcessingService`, `AppContextService`, and `RealtimeTranscriptionService`.

### 2. Store API keys in the Keychain instead of plaintext
- Secrets now live in the macOS Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` rather than in a plaintext JSON settings file.
- Existing plaintext values are migrated into the Keychain and then removed from disk.

### 3. Stop leaking raw provider responses into errors/logs
- Provider error responses are no longer echoed verbatim into error messages or `os_log` output. Only the HTTP status code and response byte count are surfaced, avoiding accidental disclosure of sensitive response contents and log injection.

### 4. Local history retention is now opt-in
- Run-log / pipeline-history retention defaults to **off**. A "Keep Run Log" toggle in Settings enables it.
- When disabled, stored history entries and their associated audio files are cleared and not persisted, reducing local retention of potentially sensitive transcripts and audio.

### 5. Harden the auto-update path
Before installing a downloaded update, `UpdateManager` now verifies:
- the release contains the exact expected asset (`FreeFlow.dmg`);
- the download URL (initial **and** post-redirect) is on the expected GitHub release host;
- the downloaded size matches the asset's advertised size exactly;
- the app bundle identifier matches;
- the code signature is valid and the signing **team identifier** matches;
- the app passes a Gatekeeper assessment.

This prevents installing a tampered or spoofed update.

## Notes
- This branch is a single, focused commit on top of current `main`.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Keep Run Log" setting to control pipeline history retention.

* **Bug Fixes**
  * Enhanced security validation for provider URLs and app updates.
  * Improved error messages for invalid provider configurations.
  * Strengthened update installation with code signing and Gatekeeper verification.

* **Improvements**
  * Better handling of provider URL normalization.
  * Refined error reporting for transcription and processing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->