### PR TITLE
feat: easy drop down LLM model selection + add support for the qwen3-32b

### DIFF
--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -163,7 +163,7 @@ public struct ModelConfiguration {
         var cleaned = text
         
         // First, replace fully closed tags: <think>...</think>
-        let closedRegexPattern = "<think>[\\s\\S]*?</think>"
+        let closedRegexPattern = "^\\s*<think>[\\s\\S]*?</think>"
         if let regex = try? NSRegularExpression(pattern: closedRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")
@@ -171,7 +171,7 @@ public struct ModelConfiguration {
         
         // Next, if there is an unclosed <think> tag remaining (meaning it started thinking but got truncated),
         // we strip from the opening <think> tag to the very end of the string.
-        let openRegexPattern = "<think>[\\s\\S]*$"
+        let openRegexPattern = "^\\s*<think>[\\s\\S]*$"
         if let regex = try? NSRegularExpression(pattern: openRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -41,7 +41,7 @@ public struct ModelConfiguration {
         
         if cleanModel == "openai/gpt-oss-20b" {
             return ModelConfig(
-                maxCompletionTokens: 1024,
+                maxCompletionTokens: 4096,
                 reasoningEffort: "low",
                 includeReasoning: false,
                 shouldStripThinkTags: false

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -31,7 +31,13 @@ public struct ModelConfiguration {
     ]
 
     public static func config(for model: String) -> ModelConfig {
-        let cleanModel = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var cleanModel = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        
+        // Normalize providerless aliases
+        if cleanModel == "qwen3-32b" { cleanModel = "qwen/qwen3-32b" }
+        else if cleanModel == "gpt-oss-20b" { cleanModel = "openai/gpt-oss-20b" }
+        else if cleanModel == "gpt-oss-120b" { cleanModel = "openai/gpt-oss-120b" }
+        else if cleanModel == "gpt-oss-safeguard-20b" { cleanModel = "openai/gpt-oss-safeguard-20b" }
         
         if cleanModel == "openai/gpt-oss-20b" {
             return ModelConfig(
@@ -163,7 +169,8 @@ public struct ModelConfiguration {
         var cleaned = text
         
         // First, replace fully closed tags: <think>...</think>
-        let closedRegexPattern = "^\\s*<think>[\\s\\S]*?</think>"
+        // We use a group with + to catch multiple consecutive think blocks.
+        let closedRegexPattern = "^(?:\\s*<think>[\\s\\S]*?</think>)+"
         if let regex = try? NSRegularExpression(pattern: closedRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+public struct ModelConfig {
+    public let maxCompletionTokens: Int?
+    public let reasoningEffort: String?
+    public let includeReasoning: Bool?
+    public let shouldStripThinkTags: Bool
+}
+
+public struct ModelConfiguration {
+    public static let llmModels = [
+        "llama-3.3-70b-versatile",
+        "llama-3.1-8b-instant",
+        "meta-llama/llama-4-scout-17b-16e-instruct",
+        "openai/gpt-oss-20b",
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-safeguard-20b",
+        "qwen/qwen3-32b",
+        "allam-2-7b",
+        "groq/compound",
+        "groq/compound-mini",
+        "canopylabs/orpheus-arabic-saudi",
+        "canopylabs/orpheus-v1-english",
+        "meta-llama/llama-prompt-guard-2-22m",
+        "meta-llama/llama-prompt-guard-2-86m"
+    ]
+
+    public static let transcriptionModels = [
+        "whisper-large-v3",
+        "whisper-large-v3-turbo"
+    ]
+
+    public static func config(for model: String) -> ModelConfig {
+        let cleanModel = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        
+        if cleanModel == "openai/gpt-oss-20b" {
+            return ModelConfig(
+                maxCompletionTokens: 1024,
+                reasoningEffort: "low",
+                includeReasoning: false,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "openai/gpt-oss-120b" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "openai/gpt-oss-safeguard-20b" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "qwen/qwen3-32b" {
+ // Model that requires sanitization of thought tags
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: true
+            )
+        } else if cleanModel == "llama-3.1-8b-instant" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "llama-3.3-70b-versatile" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "meta-llama/llama-4-scout-17b-16e-instruct" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "meta-llama/llama-prompt-guard-2-22m" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "meta-llama/llama-prompt-guard-2-86m" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "allam-2-7b" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "canopylabs/orpheus-arabic-saudi" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "canopylabs/orpheus-v1-english" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "groq/compound" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "groq/compound-mini" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "whisper-large-v3" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "whisper-large-v3-turbo" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        }
+        
+        // Fallback genérico para qualquer outro modelo que não esteja na lista acima
+        return ModelConfig(
+            maxCompletionTokens: nil,
+            reasoningEffort: nil,
+            includeReasoning: nil,
+            shouldStripThinkTags: false
+        )
+    }
+    
+    /// Utility method to remove <think>...</think> tags and everything inside them.
+    /// This also handles unclosed tags gracefully (e.g. if the model runs out of tokens).
+    public static func stripThinkTags(_ text: String) -> String {
+        var cleaned = text
+        
+        // First, replace fully closed tags: <think>...</think>
+        let closedRegexPattern = "<think>[\\s\\S]*?</think>"
+        if let regex = try? NSRegularExpression(pattern: closedRegexPattern, options: []) {
+            let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
+            cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")
+        }
+        
+        // Next, if there is an unclosed <think> tag remaining (meaning it started thinking but got truncated),
+        // we strip from the opening <think> tag to the very end of the string.
+        let openRegexPattern = "<think>[\\s\\S]*$"
+        if let regex = try? NSRegularExpression(pattern: openRegexPattern, options: []) {
+            let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
+            cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")
+        }
+        
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/ModelDropdownView.swift
+++ b/Sources/ModelDropdownView.swift
@@ -86,5 +86,11 @@ struct ModelDropdownView: View {
                 isCustom = true
             }
         }
+        .onChange(of: textDraft) { newValue in
+            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                isCustom = !predefinedModels.contains(trimmed)
+            }
+        }
     }
 }

--- a/Sources/ModelDropdownView.swift
+++ b/Sources/ModelDropdownView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// A reusable dropdown for selecting a model from predefined options,
+/// or providing a custom model string if "Custom..." is chosen.
+struct ModelDropdownView: View {
+    let title: String
+    let subtitle: String?
+    let predefinedModels: [String]
+    let defaultModel: String
+    
+    @Binding var textDraft: String
+    let onCommit: () -> Void
+    let onReset: () -> Void
+    
+    @State private var isCustom: Bool = false
+    @FocusState private var isEditingCustom: Bool
+    
+    private var effectiveSelection: Binding<String> {
+        Binding(
+            get: {
+                if predefinedModels.contains(textDraft) && !isCustom {
+                    return textDraft
+                } else {
+                    return "Custom..."
+                }
+            },
+            set: { newValue in
+                if newValue == "Custom..." {
+                    isCustom = true
+                    if predefinedModels.contains(textDraft) {
+                        textDraft = ""
+                    }
+                } else {
+                    isCustom = false
+                    textDraft = newValue
+                    onCommit()
+                }
+            }
+        )
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+            
+            HStack(spacing: 8) {
+                Picker("", selection: effectiveSelection) {
+                    ForEach(predefinedModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                    Divider()
+                    Text("Custom...").tag("Custom...")
+                }
+                .labelsHidden()
+                
+                if effectiveSelection.wrappedValue == "Custom..." {
+                    TextField(defaultModel, text: $textDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($isEditingCustom)
+                        .onSubmit {
+                            onCommit()
+                        }
+                        .onChange(of: isEditingCustom) { isEditing in
+                            if !isEditing {
+                                onCommit()
+                            }
+                        }
+                }
+                
+                Button("Reset to Default") {
+                    isCustom = false
+                    onReset()
+                }
+                .font(.caption)
+            }
+            
+            if let subtitle = subtitle {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onAppear {
+            if !predefinedModels.contains(textDraft) && !textDraft.isEmpty {
+                isCustom = true
+            }
+        }
+    }
+}

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -422,9 +422,20 @@ Model: \(model)
                 ]
             ]
         ]
-        if model == defaultModel {
+        let config = ModelConfiguration.config(for: model)
+        if let maxTokens = config.maxCompletionTokens {
+            payload["max_completion_tokens"] = maxTokens
+        } else if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+        }
+        if let effort = config.reasoningEffort {
+            payload["reasoning_effort"] = effort
+        } else if model == defaultModel {
             payload["reasoning_effort"] = defaultModelReasoningEffort
+        }
+        if let include = config.includeReasoning {
+            payload["include_reasoning"] = include
+        } else if model == defaultModel {
             payload["include_reasoning"] = false
         }
 
@@ -444,8 +455,13 @@ Model: \(model)
               let choices = json["choices"] as? [[String: Any]],
               let firstChoice = choices.first,
               let message = firstChoice["message"] as? [String: Any],
-              let content = message["content"] as? String else {
+              let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
+        }
+        
+        var content = rawContent
+        if config.shouldStripThinkTags {
+            content = ModelConfiguration.stripThinkTags(content)
         }
 
         guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -530,9 +546,20 @@ Model: \(model)
                 ]
             ]
         ]
-        if model == defaultModel {
+        let config = ModelConfiguration.config(for: model)
+        if let maxTokens = config.maxCompletionTokens {
+            payload["max_completion_tokens"] = maxTokens
+        } else if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+        }
+        if let effort = config.reasoningEffort {
+            payload["reasoning_effort"] = effort
+        } else if model == defaultModel {
             payload["reasoning_effort"] = defaultModelReasoningEffort
+        }
+        if let include = config.includeReasoning {
+            payload["include_reasoning"] = include
+        } else if model == defaultModel {
             payload["include_reasoning"] = false
         }
 
@@ -552,8 +579,13 @@ Model: \(model)
               let choices = json["choices"] as? [[String: Any]],
               let firstChoice = choices.first,
               let message = firstChoice["message"] as? [String: Any],
-              let content = message["content"] as? String else {
+              let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
+        }
+        
+        var content = rawContent
+        if config.shouldStripThinkTags {
+            content = ModelConfiguration.stripThinkTags(content)
         }
 
         guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -151,109 +151,57 @@ struct ProviderSettingsFields: View {
                     .foregroundStyle(.secondary)
             }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Post-Processing Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingModel, text: $postProcessingModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingPostProcessingModel)
-                        .onSubmit {
-                            commitPostProcessingModel()
-                        }
-                        .onChange(of: isEditingPostProcessingModel) { isEditing in
-                            if !isEditing {
-                                commitPostProcessingModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        postProcessingModelDraft = AppState.defaultPostProcessingModel
-                        appState.postProcessingModel = AppState.defaultPostProcessingModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Post-Processing Model",
+                subtitle: "Used for transcript cleanup and Edit Mode transforms.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultPostProcessingModel,
+                textDraft: $postProcessingModelDraft,
+                onCommit: commitPostProcessingModel,
+                onReset: {
+                    postProcessingModelDraft = AppState.defaultPostProcessingModel
+                    appState.postProcessingModel = AppState.defaultPostProcessingModel
                 }
-                Text("Used for transcript cleanup and Edit Mode transforms.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Post-Processing Fallback Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingFallbackModel, text: $postProcessingFallbackModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingPostProcessingFallbackModel)
-                        .onSubmit {
-                            commitPostProcessingFallbackModel()
-                        }
-                        .onChange(of: isEditingPostProcessingFallbackModel) { isEditing in
-                            if !isEditing {
-                                commitPostProcessingFallbackModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        postProcessingFallbackModelDraft = AppState.defaultPostProcessingFallbackModel
-                        appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Post-Processing Fallback Model",
+                subtitle: "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultPostProcessingFallbackModel,
+                textDraft: $postProcessingFallbackModelDraft,
+                onCommit: commitPostProcessingFallbackModel,
+                onReset: {
+                    postProcessingFallbackModelDraft = AppState.defaultPostProcessingFallbackModel
+                    appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
                 }
-                Text("Used as the explicit retry model for transcript cleanup and Edit Mode transforms.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Context Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultContextModel, text: $contextModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingContextModel)
-                        .onSubmit {
-                            commitContextModel()
-                        }
-                        .onChange(of: isEditingContextModel) { isEditing in
-                            if !isEditing {
-                                commitContextModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        contextModelDraft = AppState.defaultContextModel
-                        appState.contextModel = AppState.defaultContextModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Context Model",
+                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultContextModel,
+                textDraft: $contextModelDraft,
+                onCommit: commitContextModel,
+                onReset: {
+                    contextModelDraft = AppState.defaultContextModel
+                    appState.contextModel = AppState.defaultContextModel
                 }
-                Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Transcription Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultTranscriptionModel, text: $transcriptionModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingTranscriptionModel)
-                        .onSubmit {
-                            commitTranscriptionModel()
-                        }
-                        .onChange(of: isEditingTranscriptionModel) { isEditing in
-                            if !isEditing {
-                                commitTranscriptionModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        transcriptionModelDraft = AppState.defaultTranscriptionModel
-                        appState.transcriptionModel = AppState.defaultTranscriptionModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Transcription Model",
+                subtitle: "Used for speech-to-text transcription.",
+                predefinedModels: ModelConfiguration.transcriptionModels,
+                defaultModel: AppState.defaultTranscriptionModel,
+                textDraft: $transcriptionModelDraft,
+                onCommit: commitTranscriptionModel,
+                onReset: {
+                    transcriptionModelDraft = AppState.defaultTranscriptionModel
+                    appState.transcriptionModel = AppState.defaultTranscriptionModel
                 }
-                Text("Used for speech-to-text transcription.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Transcription Language")


### PR DESCRIPTION
This PR introduces a smoother and easier way to select and switch between LLM models in the Advanced Provider Settings, while adding robust support for the `qwen3-32b` reasoning model.

### What's New?

- **Easy Drop-Down Model Selection**: We replaced the simple text fields with a native macOS dropdown menu (Picker) for all model settings (Post-Processing, Fallback, Context, and Transcription). 
  - *Custom Models*: The dropdown includes a "Custom..." option that dynamically reveals a text field, ensuring power users can still manually type any model string they want without losing backwards compatibility.
- **`qwen3-32b` Support**: Added full support for Qwen reasoning models, which are exceptional at following complex custom system prompts. Previously, they couldn't be effectively used because their chain-of-thought `<think>` tags would leak into the final output. The post-processing pipeline now natively detects and cleanly strips these tags before outputting the final text.
- **Centralized Model Configuration**: Introduced `ModelConfiguration.swift` to act as the single source of truth for model capabilities. It allows us to manually tune parameters for specific models, such as `max_completion_tokens` or `reasoning_effort`. More importantly, this sets a strong foundation to make future model management and API payload adjustments much easier.

### Screenshots
<img width="1560" height="1421" alt="SCR-20260601-orfm-2" src="https://github.com/user-attachments/assets/4eb35a12-6ed9-4025-8197-28322993e034" />
<img width="1391" height="931" alt="SCR-20260601-otdn" src="https://github.com/user-attachments/assets/ef50853a-5b67-4ae3-9718-815adbd2eafe" />
<img width="582" height="78" alt="SCR-20260601-osgu" src="https://github.com/user-attachments/assets/da3fb269-ee58-48ac-8e07-3dc32e059f03" />
<img width="780" height="661" alt="SCR-20260601-orya" src="https://github.com/user-attachments/assets/d449c19a-22ec-4c01-a5a1-e9bf2995395c" />



### Under the Hood

To implement this, we brought in `ModelConfiguration.swift` to act as our centralized hub for all model settings, including the new tag-stripping logic and reasoning effort configurations. Then, we created a brand new SwiftUI component called `ModelDropdownView.swift`, which serves as a highly reusable Picker that elegantly falls back to a text field for custom inputs. With those pieces in place, we updated the UI in `SettingsView.swift` to swap out the old text fields for our new dropdown component. Finally, we tied it all together by updating the `PostProcessingService.swift` to respect these new configurations, ensuring the API payloads are dynamically built and that any reasoning tags from models like Qwen are completely stripped out before reaching the final transcript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple LLM and transcription models with per-model settings and curated model lists
  * Dropdown model selector with a "Custom..." option and reset

* **Improvements**
  * Settings UI consolidated into streamlined model pickers for four model fields
  * Post-processing adapts behavior per selected model (completion tokens, reasoning options, optional stripping of <think> blocks)
  * Custom model entries commit on submit or when focus changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->