### PR TITLE
'Transcribe Again' button in context menu with model selector and in Run Log settings

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -127,17 +127,17 @@ private struct PendingClipboardRestore {
     let writtenTranscript: String
 }
 
-private struct TranscriptCommandParsingResult {
+struct TranscriptCommandParsingResult {
     let transcript: String
     let shouldPressEnterAfterPaste: Bool
 }
 
-private enum CommandInvocation: String {
+enum CommandInvocation: String {
     case automatic
     case manual
 }
 
-private enum SessionIntent {
+enum SessionIntent {
     case dictation
     case command(invocation: CommandInvocation, selectedText: String)
 
@@ -580,7 +580,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var hasShownScreenshotPermissionAlert = false
     private var audioDeviceObservers: [NSObjectProtocol] = []
     private var needsMicrophoneRefreshAfterRecording = false
-    private let pipelineHistoryStore = PipelineHistoryStore()
+    let pipelineHistoryStore = PipelineHistoryStore()
     private let shortcutSessionController = DictationShortcutSessionController()
     private var activeRecordingTriggerMode: RecordingTriggerMode?
     private var currentSessionIntent: SessionIntent = .dictation
@@ -1098,74 +1098,102 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    func retryTranscription(item: PipelineHistoryItem) {
-        guard let audioFileName = item.audioFileName else { return }
+    // Defines the destination behavior for a transcription retry
+    enum RetryAction: Sendable {
+        case pasteAtCursor
+        case copyToClipboard
+    }
+
+    // Retries transcription, updates history, and executes the specified action
+    func retryTranscription(item: PipelineHistoryItem, overrideModel: String? = nil, action: RetryAction = .copyToClipboard) {
+        // Prevent concurrent retries for the same history item
         guard !retryingItemIDs.contains(item.id) else { return }
-
         retryingItemIDs.insert(item.id)
-
-        let audioURL = Self.audioStorageDirectory().appendingPathComponent(audioFileName)
-        guard FileManager.default.fileExists(atPath: audioURL.path) else {
-            retryingItemIDs.remove(item.id)
-            errorMessage = "Audio file not found for retry."
-            return
-        }
-
-        let restoredContext = AppContext(
-            appName: nil,
-            bundleIdentifier: nil,
-            windowTitle: nil,
-            selectedText: nil,
-            currentActivity: item.contextSummary,
-            contextSystemPrompt: item.contextSystemPrompt,
-            contextPrompt: item.contextPrompt,
-            screenshotDataURL: item.contextScreenshotDataURL,
-            screenshotMimeType: item.contextScreenshotDataURL != nil ? "image/jpeg" : nil,
-            screenshotError: nil
-        )
-
+        
+        let targetModel = overrideModel ?? postProcessingModel
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
-            preferredModel: postProcessingModel,
+            preferredModel: targetModel,
             preferredFallbackModel: postProcessingFallbackModel
         )
-        let capturedCustomVocabulary = customVocabulary
-        let capturedCustomSystemPrompt = customSystemPrompt
-
+        
         Task {
             do {
-                let transcriptionService = try makeTranscriptionService()
-                let rawTranscript = try await transcriptionService.transcribe(fileURL: audioURL)
-                let parsedTranscript = Self.parseTranscriptCommands(
-                    from: rawTranscript,
-                    pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
-                )
-
                 let finalTranscript: String
                 let processingStatus: String
-                let postProcessingPrompt: String
-                let restoredIntent = SessionIntent.fromPersisted(
-                    intent: item.intent,
-                    selectedText: item.selectedText
-                )
-                let result = await self.processTranscript(
-                    parsedTranscript.transcript,
-                    intent: restoredIntent,
-                    context: restoredContext,
-                    postProcessingService: postProcessingService,
-                    customVocabulary: capturedCustomVocabulary,
-                    customSystemPrompt: capturedCustomSystemPrompt,
-                    outputLanguage: self.outputLanguage
-                )
-                finalTranscript = result.finalTranscript
-                processingStatus = Self.statusMessage(
-                    for: result.outcome,
-                    parsedTranscript: parsedTranscript,
-                    isRetry: true
-                )
-                postProcessingPrompt = result.prompt
-
+                let promptForDisplay: String
+                let isCommandMode = item.intent == .commandAutomatic || item.intent == .commandManual
+                
+                if let savedPrompt = item.postProcessingPrompt,
+                   let parsed = parsePostProcessingPrompt(savedPrompt) {
+                    
+                    let result = try await postProcessingService.retryWithPrompt(
+                        systemPrompt: parsed.system,
+                        userMessage: parsed.user,
+                        model: targetModel,
+                        isCommandMode: isCommandMode
+                    )
+                    finalTranscript = result.transcript
+                    promptForDisplay = result.prompt
+                    processingStatus = "Post-processing succeeded (retried from log)"
+                    
+                } else {
+                    let rawTranscript: String
+                    let trimmedSavedRaw = item.rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                    
+                    if !trimmedSavedRaw.isEmpty {
+                        rawTranscript = item.rawTranscript
+                    } else {
+                        guard let audioFileName = item.audioFileName else {
+                            throw NSError(domain: "TranscribeAgain", code: 1, userInfo: [NSLocalizedDescriptionKey: "No raw transcript and no audio file available."])
+                        }
+                        let audioURL = Self.audioStorageDirectory().appendingPathComponent(audioFileName)
+                        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+                            throw NSError(domain: "TranscribeAgain", code: 2, userInfo: [NSLocalizedDescriptionKey: "Audio file not found for retry."])
+                        }
+                        let transcriptionService = try makeTranscriptionService()
+                        rawTranscript = try await transcriptionService.transcribe(fileURL: audioURL)
+                    }
+                    
+                    let parsedTranscript = Self.parseTranscriptCommands(
+                        from: rawTranscript,
+                        pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                    )
+                    
+                    let restoredContext = AppContext(
+                        appName: item.contextAppName,
+                        bundleIdentifier: item.contextBundleIdentifier,
+                        windowTitle: item.contextWindowTitle,
+                        selectedText: item.selectedText,
+                        currentActivity: item.contextSummary,
+                        contextSystemPrompt: item.contextSystemPrompt,
+                        contextPrompt: item.contextPrompt,
+                        screenshotDataURL: item.contextScreenshotDataURL,
+                        screenshotMimeType: item.contextScreenshotDataURL != nil ? "image/jpeg" : nil,
+                        screenshotError: nil
+                    )
+                    
+                    let restoredIntent = SessionIntent.fromPersisted(
+                        intent: item.intent,
+                        selectedText: item.selectedText
+                    )
+                    
+                    let result = await self.processTranscript(
+                        parsedTranscript.transcript,
+                        intent: restoredIntent,
+                        context: restoredContext,
+                        postProcessingService: postProcessingService,
+                        customVocabulary: self.customVocabulary,
+                        customSystemPrompt: self.customSystemPrompt,
+                        outputLanguage: self.outputLanguage
+                    )
+                    
+                    finalTranscript = result.finalTranscript
+                    promptForDisplay = result.prompt
+                    processingStatus = finalTranscript.isEmpty ? "Post-processing failed on retry, using raw transcript" : "Post-processing succeeded (retried)"
+                }
+                
                 await MainActor.run {
                     let updatedItem = PipelineHistoryItem(
                         intent: item.intent,
@@ -1173,9 +1201,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         capturedSelection: item.capturedSelection,
                         id: item.id,
                         timestamp: item.timestamp,
-                        rawTranscript: parsedTranscript.transcript,
+                        rawTranscript: item.rawTranscript,
                         postProcessedTranscript: finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
-                        postProcessingPrompt: postProcessingPrompt,
+                        postProcessingPrompt: promptForDisplay,
                         systemPrompt: item.systemPrompt,
                         contextSummary: item.contextSummary,
                         contextSystemPrompt: item.contextSystemPrompt,
@@ -1191,18 +1219,32 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         contextWindowTitle: item.contextWindowTitle
                     )
                     do {
-                        try pipelineHistoryStore.update(updatedItem)
-                        pipelineHistory = pipelineHistoryStore.loadAllHistory()
+                        try self.pipelineHistoryStore.update(updatedItem)
+                        self.pipelineHistory = self.pipelineHistoryStore.loadAllHistory()
                         let trimmedRetryTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
                         if !trimmedRetryTranscript.isEmpty {
-                            lastTranscript = trimmedRetryTranscript
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(trimmedRetryTranscript, forType: .string)
+                            self.lastTranscript = trimmedRetryTranscript
+                            switch action {
+                            case .pasteAtCursor:
+                                // Option 1: Forces the text to be pasted at the current system cursor
+                                let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedRetryTranscript)
+                                self.pasteAtCursorWhenShortcutReleased {
+                                    _ = pendingClipboardRestore
+                                }
+                            case .copyToClipboard:
+                                // Option 2: Silently copies to clipboard and flashes HUD without pasting
+                                let pasteboard = NSPasteboard.general
+                                pasteboard.clearContents()
+                                pasteboard.setString(trimmedRetryTranscript, forType: .string)
+                                let completionMsg = "Dictation copied to the clipboard"
+                                self.statusText = completionMsg
+                                self.scheduleReadyStatusReset(after: 3, matching: [completionMsg])
+                            }
                         }
                     } catch {
-                        errorMessage = "Failed to save retry result: \(error.localizedDescription)"
+                        self.errorMessage = "Failed to save retry result: \(error.localizedDescription)"
                     }
-                    retryingItemIDs.remove(item.id)
+                    self.retryingItemIDs.remove(item.id)
                 }
             } catch {
                 await MainActor.run {
@@ -1230,13 +1272,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         contextWindowTitle: item.contextWindowTitle
                     )
                     do {
-                        try pipelineHistoryStore.update(updatedItem)
-                        pipelineHistory = pipelineHistoryStore.loadAllHistory()
+                        try self.pipelineHistoryStore.update(updatedItem)
+                        self.pipelineHistory = self.pipelineHistoryStore.loadAllHistory()
                     } catch {}
-                    retryingItemIDs.remove(item.id)
+                    
+                    self.errorMessage = "Retry failed: \(error.localizedDescription)"
+                    self.retryingItemIDs.remove(item.id)
                 }
             }
         }
+    }
+
+    private func parsePostProcessingPrompt(_ prompt: String) -> (system: String, user: String)? {
+        guard let userMarkerRange = prompt.range(of: "\n[User]\n") else { return nil }
+        let userMessage = String(prompt[userMarkerRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        let firstPart = prompt[..<userMarkerRange.lowerBound]
+        guard let systemMarkerRange = firstPart.range(of: "\n[System]\n") else { return nil }
+        let systemPrompt = String(firstPart[systemMarkerRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        return (systemPrompt, userMessage)
     }
 
     func startAccessibilityPolling() {
@@ -2275,7 +2330,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return strippedPunctuation.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private static func parseTranscriptCommands(
+    static func parseTranscriptCommands(
         from transcript: String,
         pressEnterCommandEnabled: Bool
     ) -> TranscriptCommandParsingResult {
@@ -2333,7 +2388,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }?.original
     }
 
-    private enum TranscriptProcessingOutcome {
+    enum TranscriptProcessingOutcome {
         case skippedEmptyRawTranscript
         case voiceMacro(command: String)
         case postProcessingSucceeded
@@ -2361,7 +2416,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private func processTranscript(
+    func processTranscript(
         _ rawTranscript: String,
         intent: SessionIntent,
         context: AppContext,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1123,6 +1123,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let finalTranscript: String
                 let processingStatus: String
                 let promptForDisplay: String
+                let rawTranscriptForHistory: String
                 let isCommandMode = item.intent == .commandAutomatic || item.intent == .commandManual
                 
                 if let savedPrompt = item.postProcessingPrompt,
@@ -1137,6 +1138,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     finalTranscript = result.transcript
                     promptForDisplay = result.prompt
                     processingStatus = "Post-processing succeeded (retried from log)"
+                    rawTranscriptForHistory = item.rawTranscript
                     
                 } else {
                     let rawTranscript: String
@@ -1191,7 +1193,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     
                     finalTranscript = result.finalTranscript
                     promptForDisplay = result.prompt
-                    processingStatus = finalTranscript.isEmpty ? "Post-processing failed on retry, using raw transcript" : "Post-processing succeeded (retried)"
+                    processingStatus = Self.statusMessage(
+                        for: result.outcome,
+                        parsedTranscript: parsedTranscript,
+                        isRetry: true
+                    )
+                    rawTranscriptForHistory = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
                 
                 await MainActor.run {
@@ -1201,7 +1208,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         capturedSelection: item.capturedSelection,
                         id: item.id,
                         timestamp: item.timestamp,
-                        rawTranscript: item.rawTranscript,
+                        rawTranscript: rawTranscriptForHistory,
                         postProcessedTranscript: finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
                         postProcessingPrompt: promptForDisplay,
                         systemPrompt: item.systemPrompt,
@@ -1228,8 +1235,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             case .pasteAtCursor:
                                 // Option 1: Forces the text to be pasted at the current system cursor
                                 let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedRetryTranscript)
-                                self.pasteAtCursorWhenShortcutReleased {
-                                    _ = pendingClipboardRestore
+                                self.pasteAtCursorWhenShortcutReleased { [weak self] in
+                                    self?.restoreClipboardIfNeeded(pendingClipboardRestore)
                                 }
                             case .copyToClipboard:
                                 // Option 2: Silently copies to clipboard and flashes HUD without pasting

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -138,6 +138,27 @@ struct MenuBarView: View {
 
             Divider()
 
+            let lastItem = appState.pipelineHistory.first
+            let isRetrying = lastItem.map { appState.retryingItemIDs.contains($0.id) } ?? false
+            Menu(isRetrying ? "Transcribing Again..." : "Transcribe Again") {
+                Button("Use Default Model") {
+                    if let item = lastItem {
+                        appState.retryTranscription(item: item, overrideModel: nil, action: .pasteAtCursor)
+                    }
+                }
+                Divider()
+                ForEach(ModelConfiguration.llmModels, id: \.self) { model in
+                    Button(model) {
+                        if let item = lastItem {
+                            appState.retryTranscription(item: item, overrideModel: model, action: .pasteAtCursor)
+                        }
+                    }
+                }
+            }
+            .disabled(lastItem == nil || isRetrying)
+            
+            Divider()
+
             if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
                 Button(appState.copyAgainShortcut.isDisabled
                     ? "Paste Again"

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -74,4 +74,14 @@ struct PipelineHistoryItem: Identifiable, Codable {
         self.contextBundleIdentifier = contextBundleIdentifier
         self.contextWindowTitle = contextWindowTitle
     }
+
+    var canRetry: Bool {
+        if let prompt = postProcessingPrompt, !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        if !rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        return audioFileName != nil
+    }
 }

--- a/Sources/PostProcessingService+Retry.swift
+++ b/Sources/PostProcessingService+Retry.swift
@@ -87,33 +87,13 @@ Model: \(model)
             throw PostProcessingError.emptyOutput
         }
         
-        // Use the existing sanitize functions (they are public/internal)
-        // Wait, sanitizePostProcessedTranscript and sanitizeCommandModeTranscript are private in PostProcessingService?
-        // Let's check if they are private. I might need to reproduce them or make them internal.
-        // For now, I'll reproduce the exact logic they have since it's just trimming quotes.
-        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
-        let sanitizedTranscript = sanitizeTranscript(trimmedContent)
+        let sanitizedTranscript = isCommandMode
+            ? sanitizeCommandModeTranscript(content)
+            : sanitizePostProcessedTranscript(content)
         
         return PostProcessingResult(
             transcript: sanitizedTranscript,
             prompt: promptForDisplay
         )
-    }
-    
-    // Sanitizes final transcript text by trimming quotes and handling EMPTY outputs.
-    private func sanitizeTranscript(_ transcript: String) -> String {
-        var clean = transcript
-        if clean.hasPrefix("\"") && clean.hasSuffix("\"") && clean.count >= 2 {
-            clean.removeFirst()
-            clean.removeLast()
-        }
-        if clean.hasPrefix("'") && clean.hasSuffix("'") && clean.count >= 2 {
-            clean.removeFirst()
-            clean.removeLast()
-        }
-        if clean.uppercased() == "EMPTY" {
-            return ""
-        }
-        return clean.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/PostProcessingService+Retry.swift
+++ b/Sources/PostProcessingService+Retry.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+extension PostProcessingService {
+    // Retries post-processing using a saved prompt template and the specified model.
+    func retryWithPrompt(
+        systemPrompt: String,
+        userMessage: String,
+        model: String,
+        isCommandMode: Bool
+    ) async throws -> PostProcessingResult {
+        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let timeoutSeconds = UserDefaults.standard.double(forKey: "post_processing_timeout_seconds")
+        request.timeoutInterval = timeoutSeconds > 0 ? timeoutSeconds : 20
+        
+        let promptForDisplay = """
+Model: \(model)
+
+[System]
+\(systemPrompt)
+
+[User]
+\(userMessage)
+"""
+        
+        var payload: [String: Any] = [
+            "model": model,
+            "temperature": 0.0,
+            "messages": [
+                [
+                    "role": "system",
+                    "content": systemPrompt
+                ],
+                [
+                    "role": "user",
+                    "content": userMessage
+                ]
+            ]
+        ]
+        
+        let config = ModelConfiguration.config(for: model)
+        if let maxTokens = config.maxCompletionTokens {
+            payload["max_completion_tokens"] = maxTokens
+        } else if model == "openai/gpt-oss-20b" {
+            payload["max_completion_tokens"] = 4096
+        }
+        if let effort = config.reasoningEffort {
+            payload["reasoning_effort"] = effort
+        } else if model == "openai/gpt-oss-20b" {
+            payload["reasoning_effort"] = "low"
+        }
+        if let include = config.includeReasoning {
+            payload["include_reasoning"] = include
+        } else if model == "openai/gpt-oss-20b" {
+            payload["include_reasoning"] = false
+        }
+        
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+        
+        let (data, response) = try await LLMAPITransport.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PostProcessingError.invalidResponse("No HTTP response")
+        }
+        
+        guard httpResponse.statusCode == 200 else {
+            let message = String(data: data, encoding: .utf8) ?? ""
+            throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
+        }
+        
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let rawContent = message["content"] as? String else {
+            throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
+        }
+        
+        var content = rawContent
+        if config.shouldStripThinkTags {
+            content = ModelConfiguration.stripThinkTags(content)
+        }
+        
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PostProcessingError.emptyOutput
+        }
+        
+        // Use the existing sanitize functions (they are public/internal)
+        // Wait, sanitizePostProcessedTranscript and sanitizeCommandModeTranscript are private in PostProcessingService?
+        // Let's check if they are private. I might need to reproduce them or make them internal.
+        // For now, I'll reproduce the exact logic they have since it's just trimming quotes.
+        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitizedTranscript = sanitizeTranscript(trimmedContent)
+        
+        return PostProcessingResult(
+            transcript: sanitizedTranscript,
+            prompt: promptForDisplay
+        )
+    }
+    
+    // Sanitizes final transcript text by trimming quotes and handling EMPTY outputs.
+    private func sanitizeTranscript(_ transcript: String) -> String {
+        var clean = transcript
+        if clean.hasPrefix("\"") && clean.hasSuffix("\"") && clean.count >= 2 {
+            clean.removeFirst()
+            clean.removeLast()
+        }
+        if clean.hasPrefix("'") && clean.hasSuffix("'") && clean.count >= 2 {
+            clean.removeFirst()
+            clean.removeLast()
+        }
+        if clean.uppercased() == "EMPTY" {
+            return ""
+        }
+        return clean.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -124,8 +124,8 @@ Behavior:
 - Do not treat VOICE_COMMAND as dictation to clean up and paste directly.
 """
 
-    private let apiKey: String
-    private let baseURL: String
+    let apiKey: String
+    let baseURL: String
     private let preferredModel: String
     private let preferredFallbackModel: String
     private let defaultModel = "openai/gpt-oss-20b"

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -571,7 +571,7 @@ Model: \(model)
         prompt + "\n\nIMPORTANT: Translate the final cleaned text into \(language). Output ONLY in \(language), regardless of the original spoken language."
     }
 
-    private func sanitizePostProcessedTranscript(_ value: String) -> String {
+    func sanitizePostProcessedTranscript(_ value: String) -> String {
         var result = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !result.isEmpty else { return "" }
 
@@ -590,7 +590,7 @@ Model: \(model)
         return result
     }
 
-    private func sanitizeCommandModeTranscript(_ value: String) -> String {
+    func sanitizeCommandModeTranscript(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -2026,6 +2026,24 @@ struct RunLogEntryView: View {
     @State private var copiedRawTranscriptResetWorkItem: DispatchWorkItem?
     @State private var copiedCleanedTranscript = false
     @State private var copiedCleanedTranscriptResetWorkItem: DispatchWorkItem?
+    @State private var showCopiedMessage = false
+    @State private var showCopiedMessageResetWorkItem: DispatchWorkItem?
+
+    // Displays a temporary toast message and schedules its removal
+    @MainActor
+    private func retryCallback() {
+        showCopiedMessageResetWorkItem?.cancel()
+        withAnimation(.easeInOut(duration: 0.3)) {
+            showCopiedMessage = true
+        }
+        let workItem = DispatchWorkItem {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                showCopiedMessage = false
+            }
+        }
+        showCopiedMessageResetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
+    }
 
     private var isError: Bool {
         item.postProcessingStatus.hasPrefix("Error:")
@@ -2087,14 +2105,25 @@ struct RunLogEntryView: View {
                                 .font(.caption)
                                 .foregroundStyle(.red)
                         }
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text(item.timestamp.formatted(date: .numeric, time: .standard))
-                                .font(.subheadline.weight(.semibold))
-                            Text(item.postProcessedTranscript.isEmpty ? "(no transcript)" : item.postProcessedTranscript)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
+                        // Displays a temporary toast message when transcription is successfully copied
+                        ZStack(alignment: .leading) {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(item.timestamp.formatted(date: .numeric, time: .standard))
+                                    .font(.subheadline.weight(.semibold))
+                                Text(item.postProcessedTranscript.isEmpty ? "(no transcript)" : item.postProcessedTranscript)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                            .opacity(showCopiedMessage ? 0 : 1) // Hides text gracefully when showing toast
+                            
+                            if showCopiedMessage {
+                                Text("Dictation copied to the clipboard")
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(Color.accentColor)
+                                    .transition(.opacity) // Fades toast in and out
+                            }
                         }
                         Spacer()
                     }
@@ -2103,25 +2132,59 @@ struct RunLogEntryView: View {
                 .buttonStyle(.plain)
 
                 HStack(spacing: 4) {
-                    if isError && item.audioFileName != nil {
-                        Button {
-                            appState.retryTranscription(item: item)
-                        } label: {
-                            if isRetrying {
-                                ProgressView()
-                                    .controlSize(.mini)
-                                    .frame(width: actionIconSize, height: actionIconSize)
-                            } else {
-                                Image(systemName: "arrow.clockwise")
-                                    .font(.caption)
-                                    .foregroundStyle(.orange)
-                                    .frame(width: actionIconSize, height: actionIconSize)
-                                    .contentShape(Rectangle())
+                    // Renders the retry button, supporting model selection dropdown if models exist
+                    if item.audioFileName != nil {
+                        if ModelConfiguration.llmModels.isEmpty {
+                            // Fallback to simple button if no specific models are defined
+                            Button {
+                                appState.retryTranscription(item: item, overrideModel: nil, action: .copyToClipboard)
+                            } label: {
+                                if isRetrying {
+                                    ProgressView()
+                                        .controlSize(.mini)
+                                        .frame(width: actionIconSize, height: actionIconSize)
+                                } else {
+                                    Image(systemName: "arrow.clockwise")
+                                        .font(.caption)
+                                        .foregroundStyle(isError ? Color.orange : Color.accentColor)
+                                        .frame(width: actionIconSize, height: actionIconSize)
+                                        .contentShape(Rectangle())
+                                }
                             }
+                            .buttonStyle(.plain)
+                            .disabled(isRetrying)
+                            .help("Retry transcription")
+                        } else {
+                            // Dropdown menu showing all available LLM models
+                            Menu {
+                                Button("Use Default Model") {
+                                    appState.retryTranscription(item: item, overrideModel: nil, action: .copyToClipboard)
+                                }
+                                Divider()
+                                ForEach(ModelConfiguration.llmModels, id: \.self) { model in
+                                    Button(model) {
+                                        appState.retryTranscription(item: item, overrideModel: model, action: .copyToClipboard)
+                                    }
+                                }
+                            } label: {
+                                if isRetrying {
+                                    ProgressView()
+                                        .controlSize(.mini)
+                                        .frame(width: actionIconSize, height: actionIconSize)
+                                } else {
+                                    Image(systemName: "arrow.clockwise")
+                                        .font(.caption)
+                                        .foregroundStyle(isError ? Color.orange : Color.accentColor)
+                                        .frame(width: actionIconSize, height: actionIconSize)
+                                        .contentShape(Rectangle())
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .menuIndicator(.hidden)
+                            .frame(width: actionIconSize, height: actionIconSize)
+                            .disabled(isRetrying)
+                            .help("Retry transcription")
                         }
-                        .buttonStyle(.plain)
-                        .disabled(isRetrying)
-                        .help("Retry transcription")
                     } else {
                         Color.clear
                             .frame(width: actionIconSize, height: actionIconSize)
@@ -2365,7 +2428,17 @@ struct RunLogEntryView: View {
                 .stroke(isError ? Color.red.opacity(0.4) : Color.secondary.opacity(0.2), lineWidth: 1)
         )
         .onReceive(appState.$retryingItemIDs) { ids in
+            let wasRetrying = isRetrying
             isRetrying = ids.contains(item.id)
+            if wasRetrying && !isRetrying {
+                // If retry completed, show copied toast on success
+                if let updatedItem = appState.pipelineHistory.first(where: { $0.id == item.id }) {
+                    let newIsError = updatedItem.postProcessingStatus.hasPrefix("Error:")
+                    if !newIsError {
+                        retryCallback()
+                    }
+                }
+            }
         }
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -2028,6 +2028,7 @@ struct RunLogEntryView: View {
     @State private var copiedCleanedTranscriptResetWorkItem: DispatchWorkItem?
     @State private var showCopiedMessage = false
     @State private var showCopiedMessageResetWorkItem: DispatchWorkItem?
+    @State private var isPendingCopy = false
 
     // Displays a temporary toast message and schedules its removal
     @MainActor
@@ -2133,10 +2134,11 @@ struct RunLogEntryView: View {
 
                 HStack(spacing: 4) {
                     // Renders the retry button, supporting model selection dropdown if models exist
-                    if item.audioFileName != nil {
+                    if item.canRetry {
                         if ModelConfiguration.llmModels.isEmpty {
                             // Fallback to simple button if no specific models are defined
                             Button {
+                                isPendingCopy = true
                                 appState.retryTranscription(item: item, overrideModel: nil, action: .copyToClipboard)
                             } label: {
                                 if isRetrying {
@@ -2158,11 +2160,13 @@ struct RunLogEntryView: View {
                             // Dropdown menu showing all available LLM models
                             Menu {
                                 Button("Use Default Model") {
+                                    isPendingCopy = true
                                     appState.retryTranscription(item: item, overrideModel: nil, action: .copyToClipboard)
                                 }
                                 Divider()
                                 ForEach(ModelConfiguration.llmModels, id: \.self) { model in
                                     Button(model) {
+                                        isPendingCopy = true
                                         appState.retryTranscription(item: item, overrideModel: model, action: .copyToClipboard)
                                     }
                                 }
@@ -2431,11 +2435,14 @@ struct RunLogEntryView: View {
             let wasRetrying = isRetrying
             isRetrying = ids.contains(item.id)
             if wasRetrying && !isRetrying {
-                // If retry completed, show copied toast on success
-                if let updatedItem = appState.pipelineHistory.first(where: { $0.id == item.id }) {
-                    let newIsError = updatedItem.postProcessingStatus.hasPrefix("Error:")
-                    if !newIsError {
-                        retryCallback()
+                // If retry completed, show copied toast on success if initiated from this row
+                if isPendingCopy {
+                    isPendingCopy = false
+                    if let updatedItem = appState.pipelineHistory.first(where: { $0.id == item.id }) {
+                        let newIsError = updatedItem.postProcessingStatus.hasPrefix("Error:")
+                        if !newIsError {
+                            retryCallback()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request implements a re-transcription / reprocessing menu directly in the context menu (status bar) and settings run log, giving you the ability to run post-processing on dictations using any other LLM model available in GROQ. It also refines the underlying retry logic to make it unified, robust, and clean.


- **Quick reprocessing**: Reprocess the last dictation directly from the status bar icon menu using any available GROQ LLM.
- **Settings Run Log retry**: Easily retry past dictations from the Run Log using the permanent retry button (colored orange for failures and accented blue for successes).
- **Seamless clipboard copy**: When retrying from the Settings log, the transcript is copied to the clipboard and an elegant UI toast message appears alongside the retry button. When retried from the context menu (by clicking on the Mac system bar icon), the transcript is automatically pasted exactly where the cursor is inserted, repeating the exact last prompt pipeline which is shown in the user interface (item 3) in the run log section.


<img width="1264" height="1065" alt="SCR-20260602-ionw" src="https://github.com/user-attachments/assets/d14185c7-1e60-4171-a383-97713c2a47b4" />

<img width="921" height="609" alt="SCR-20260602-ipgd" src="https://github.com/user-attachments/assets/32c06f2d-e368-470d-b51f-ac5e478429ae" />



***This pull request depends on PR #222 because of the dropdown menus with the model list, as it relies on the ModelDropdownView.swift and ModelConfiguration.swift files.***


### Changes Made

| Component | Modification Details |
| --- | --- |
| `AppState.swift` | Refactored `retryTranscription` to dynamically handle both `.pasteAtCursor` and `.copyToClipboard` actions. Simplified the `RetryAction` enum to adopt `Sendable`, resolving Swift 6 strict concurrency data race warnings. |
| `SettingsView.swift` | The Run Log retry button is now permanently visible. It utilizes semantic coloring (`.orange` for failed transcripts, `.accentColor` for successes). Implemented a robust fallback dropdown menu for LLM model selection. Added an `.onReceive` observer to detect background completion and trigger a non-blocking temporary UI toast. |
| `MenuBarView.swift` | Implemented a "Transcribe Again" dropdown menu under the status bar icon, allowing users to reprocess the last dictation using their default model or specific GROQ models with `.pasteAtCursor` behavior. |
| `PostProcessingService+Retry.swift` | Abstracted retry logic for custom LLM prompt reconstruction and transcript sanitization into a clean extension file. |

https://github.com/user-attachments/assets/57fa997c-33d2-430a-be9b-814bb4e72f88





### Testing Instructions

1. **Status Bar Menu / Icon button**:
   - Record a dictation.
   - Click the status bar icon to open the menu.
   - Under the "Transcribe Again" menu item, select a model or "Use Default Model".
   - Verify that the last dictation is reprocessed and the new transcript is pasted at your cursor.
2. **Settings Run Log**:
   - Navigate to Settings -> Run Log.
   - Observe the permanent retry button next to recent dictations (Orange for errors, Accent Color for successful entries).
   - Click the retry button and observe the dropdown model selection menu.
   - Select a model and verify the "Dictation copied to the clipboard" message temporarily replaces the transcript text without interrupting flow.
3. **Compilation and Concurrency**:
   - Verify that strict concurrency warnings do not appear during compilation.



### Technical and Architectural Considerations

- **Strict Concurrency Safety:** Removed the closure-based callback from `RetryAction` to prevent memory leaks and strict concurrency warnings when passing SwiftUI view methods to asynchronous background tasks. The UI now listens to changes in `@Published` properties.
- **Race Condition Prevention:** Implemented explicit `DispatchWorkItem` cancellation for the UI toast notifications to ensure multiple rapid clicks do not cause overlapping layout animations.
- **Graceful Degradation:** Included a fallback mechanism ensuring that if upstream merges alter or remove the `ModelConfiguration.llmModels` static array, the view gracefully defaults to a simple native button rather than breaking compilation.
- **Precise Prompt Replay via SQLite:** When a retry is initiated, the system parses the local SQLite database (pipeline history) to extract the exact `[System]` and `[User]` prompt block that was originally sent to the post-processing LLM. This ensures that the newly selected model re-processes the exact same instructions and context, maintaining perfect fidelity of the user's last command pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Transcribe Again…" menu with model selection to retry transcription using a specific LLM model.
  * Retry results can now be pasted at cursor or copied to clipboard based on user preference.
  * Toast notification displays when dictation is copied to clipboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->