### PR TITLE
In toggle mode, tap any one shortcut key (e.g. Fn or Space from Fn+Space) to end dictation — not the full combo

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1612,12 +1612,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return false
     }
 
+    // Starts monitoring system-wide hotkeys and binds event handlers
     func startHotkeyMonitoring() {
         shouldMonitorHotkeys = true
         hotkeyManager.onShortcutEvent = { [weak self] event in
-            DispatchQueue.main.async {
-                self?.handleShortcutEvent(event)
-            }
+            self?.handleShortcutEvent(event) ?? false
         }
         hotkeyManager.onEscapeKeyPressed = { [weak self] in
             self?.handleEscapeKeyPress() ?? false
@@ -1674,28 +1673,34 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private func handleShortcutEvent(_ event: ShortcutEvent) {
+    // Handles a shortcut event and returns true if the event was consumed
+    @discardableResult
+    private func handleShortcutEvent(_ event: ShortcutEvent) -> Bool {
         if event == .copyAgainTriggered {
             copyLastTranscriptToPasteboard()
-            return
+            return true
         }
 
         guard let action = shortcutSessionController.handle(event: event, isTranscribing: isTranscribing) else {
-            return
+            return false
         }
 
         switch action {
+        case .consumeOnly:
+            return true
         case .start(let mode):
             os_log(.info, log: recordingLog, "Shortcut start fired for mode %{public}@", mode.rawValue)
             scheduleShortcutStart(mode: mode)
+            return false
         case .stop:
             cancelPendingShortcutStart()
             guard isRecording else {
                 shortcutSessionController.reset()
                 activeRecordingTriggerMode = nil
-                return
+                return true
             }
             stopAndTranscribe()
+            return true
         case .switchedToToggle:
             if isRecording {
                 activeRecordingTriggerMode = .toggle
@@ -1703,6 +1708,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } else if pendingShortcutStartMode != nil {
                 pendingShortcutStartMode = .toggle
             }
+            return false
         }
     }
 

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -8,7 +8,8 @@ final class HotkeyManager {
     )
     private var inputState = ShortcutInputState()
 
-    var onShortcutEvent: ((ShortcutEvent) -> Void)?
+    // Callback triggered on shortcut events; returns true to consume the system key event
+    var onShortcutEvent: ((ShortcutEvent) -> Bool)?
     var onEscapeKeyPressed: (() -> Bool)?
 
     var currentPressedModifiers: ShortcutModifiers {
@@ -49,6 +50,7 @@ final class HotkeyManager {
         stop()
     }
 
+    // Processes raw input events, triggers callbacks, and determines if the event should be consumed
     private func handleInputEvent(_ event: ShortcutInputEvent) -> ShortcutConsumeDecision {
         let result = ShortcutMatcher.reduce(
             state: inputState,
@@ -56,9 +58,12 @@ final class HotkeyManager {
             configuration: configuration
         )
         inputState = result.state
+        var shouldConsume = false
         for event in result.emittedEvents {
-            onShortcutEvent?(event)
+            if onShortcutEvent?(event) == true {
+                shouldConsume = true
+            }
         }
-        return result.consumeDecision
+        return (result.consumeDecision == .consume || shouldConsume) ? .consume : .passthrough
     }
 }

--- a/Sources/SetupTestHotkeyHarness.swift
+++ b/Sources/SetupTestHotkeyHarness.swift
@@ -10,12 +10,18 @@ final class SetupTestHotkeyHarness: ObservableObject {
     var isTranscribing = false
     var onAction: ((DictationShortcutAction) -> Void)?
 
+    // Starts the hotkey monitoring and sets up the event callbacks
     func start(configuration: ShortcutConfiguration, startDelay: TimeInterval) throws {
+        // Handle events from the hotkey manager, returning true if consumed
         hotkeyManager.onShortcutEvent = { [weak self] event in
-            guard let self else { return }
+            guard let self else { return false }
+            if event == .copyAgainTriggered { return true }
             let action = self.sessionController.handle(event: event, isTranscribing: self.isTranscribing)
-            guard let action else { return }
+            guard let action else { return false }
             self.handle(action: action, startDelay: startDelay)
+            if case .stop = action { return true }
+            if case .consumeOnly = action { return true }
+            return false
         }
         cancelPendingStart()
         sessionController.reset()
@@ -52,6 +58,8 @@ final class SetupTestHotkeyHarness: ObservableObject {
             DispatchQueue.main.async {
                 self.onAction?(action)
             }
+        case .consumeOnly:
+            break
         }
     }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1317,6 +1317,8 @@ struct SetupView: View {
 
             case .switchedToToggle:
                 break
+            case .consumeOnly:
+                break
             }
         }
 

--- a/Sources/ShortcutCore/DictationShortcutSessionController.swift
+++ b/Sources/ShortcutCore/DictationShortcutSessionController.swift
@@ -4,21 +4,42 @@ enum DictationShortcutAction: Equatable {
     case start(RecordingTriggerMode)
     case stop
     case switchedToToggle
+    /// Swallow the system key event without changing dictation state (avoids leaking characters).
+    case consumeOnly
 }
 
 final class DictationShortcutSessionController {
     private(set) var activeMode: RecordingTriggerMode?
     private(set) var toggleStopArmed = false
+    /// Prevents restarting dictation immediately while the stop shortcut's keys are still being released.
+    private var ignoreToggleUntilComponentDeactivation = false
 
+    // Handles the incoming shortcut event and computes the next dictation action
     func handle(event: ShortcutEvent, isTranscribing: Bool) -> DictationShortcutAction? {
-        // Paste Again is handled before this controller runs; if it ever
-        // reaches here, treat as a no-op so dictation state is unaffected.
+        // Paste Again is handled externally; treat as no-op here.
         if event == .copyAgainTriggered { return nil }
 
+        // Reset the ignore flag when the user releases all keys
+        if event == .toggleComponentDeactivated {
+            ignoreToggleUntilComponentDeactivation = false
+        }
+
         if activeMode == nil {
+            // Swallow trailing components of a stop sequence to prevent leaking characters (e.g. spaces)
+            if ignoreToggleUntilComponentDeactivation {
+                switch event {
+                case .toggleActivated, .toggleComponentActivated, .toggleComponentInputReceived:
+                    return .consumeOnly
+                default:
+                    break
+                }
+            }
+
             guard !isTranscribing else { return nil }
             switch event {
             case .toggleActivated:
+                // Only start toggle if not ignoring due to a recent stop action
+                guard !ignoreToggleUntilComponentDeactivation else { return nil }
                 activeMode = .toggle
                 toggleStopArmed = false
                 return .start(.toggle)
@@ -26,7 +47,8 @@ final class DictationShortcutSessionController {
                 activeMode = .hold
                 toggleStopArmed = false
                 return .start(.hold)
-            case .holdDeactivated, .toggleDeactivated:
+            // Ignore deactivations and stateless toggle inputs when idle
+            case .holdDeactivated, .toggleDeactivated, .toggleComponentActivated, .toggleComponentDeactivated, .toggleComponentInputReceived:
                 return nil
             case .copyAgainTriggered:
                 return nil
@@ -45,7 +67,8 @@ final class DictationShortcutSessionController {
             case .holdDeactivated:
                 reset()
                 return .stop
-            case .holdActivated, .toggleDeactivated:
+            // Ignore other activations and stateless toggle inputs in hold mode
+            case .holdActivated, .toggleDeactivated, .toggleComponentActivated, .toggleComponentDeactivated, .toggleComponentInputReceived:
                 return nil
             case .copyAgainTriggered:
                 return nil
@@ -56,11 +79,15 @@ final class DictationShortcutSessionController {
             case .toggleDeactivated:
                 toggleStopArmed = true
                 return nil
-            case .toggleActivated:
+            // Stop recording on toggle shortcut activations or stateless component inputs
+            case .toggleActivated, .toggleComponentActivated, .toggleComponentInputReceived:
+                // Trigger stop if toggle is armed and we are not currently ignoring events
                 guard toggleStopArmed else { return nil }
+                guard !ignoreToggleUntilComponentDeactivation else { return nil }
                 reset()
+                ignoreToggleUntilComponentDeactivation = true
                 return .stop
-            case .holdActivated, .holdDeactivated:
+            case .holdActivated, .holdDeactivated, .toggleComponentDeactivated:
                 return nil
             case .copyAgainTriggered:
                 return nil
@@ -68,16 +95,21 @@ final class DictationShortcutSessionController {
         }
     }
 
+    // Begins a manual dictation session with the specified mode
     func beginManual(mode: RecordingTriggerMode) {
         activeMode = mode
         toggleStopArmed = false
+        ignoreToggleUntilComponentDeactivation = false
     }
 
+    // Forces the controller state into toggle mode
     func forceToggleMode() {
         activeMode = .toggle
         toggleStopArmed = false
+        ignoreToggleUntilComponentDeactivation = false
     }
 
+    // Resets the controller state to idle
     func reset() {
         activeMode = nil
         toggleStopArmed = false

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -17,6 +17,8 @@ struct ShortcutInputState: Equatable {
     var pressedModifierKeyCodes: Set<UInt16> = []
     var holdIsActive = false
     var toggleIsActive = false
+    /// True while any key or modifier belonging to the toggle shortcut is currently pressed.
+    var toggleComponentIsActive = false
     var copyAgainIsActive = false
 
     var currentModifiers: ShortcutModifiers {
@@ -59,6 +61,36 @@ struct ShortcutInputState: Equatable {
             return true
         }
 
+        return false
+    }
+
+    /// Returns true if the given key code belongs to a component of the toggle shortcut.
+    /// - Parameters:
+    ///   - keyCode: The raw key code of the input event.
+    ///   - kind: Whether the input is a regular key or a modifier key.
+    ///   - configuration: The active shortcut configuration to match against.
+    static func isToggleComponentInput(
+        keyCode: UInt16,
+        kind: ShortcutBindingKind,
+        configuration: ShortcutConfiguration
+    ) -> Bool {
+        let binding = configuration.toggle
+        guard !binding.isDisabled else { return false }
+
+        if kind == .key {
+            return binding.kind == .key && binding.keyCode == keyCode
+        } else if kind == .modifierKey {
+            if binding.kind == .modifierKey {
+                return binding.keyCode == keyCode
+            } else {
+                if let exactModifiers = binding.exactModifierKeyCodes {
+                    return exactModifiers.contains(keyCode)
+                } else if let modifier = ShortcutBinding.modifier(forKeyCode: keyCode) {
+                    // Safely extract the modifier and check intersection to prevent force-unwrap crashes
+                    return !binding.modifiers.isDisjoint(with: [modifier])
+                }
+            }
+        }
         return false
     }
 }
@@ -104,6 +136,14 @@ enum ShortcutMatcher {
                 nextState.pressedModifierKeyCodes.remove(keyCode)
             }
 
+            // Emit stateless event on pressed modifier if it is a toggle component
+            var statelessEvents: [ShortcutEvent] = []
+            if isDown {
+                if ShortcutInputState.isToggleComponentInput(keyCode: keyCode, kind: .modifierKey, configuration: configuration) {
+                    statelessEvents.append(.toggleComponentInputReceived)
+                }
+            }
+
             let shouldConsumeAfter = shouldConsumeModifierEvent(
                 for: keyCode,
                 state: nextState,
@@ -112,7 +152,7 @@ enum ShortcutMatcher {
             let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
             return ShortcutMatchResult(
                 state: nextState,
-                emittedEvents: emittedEvents,
+                emittedEvents: emittedEvents + statelessEvents,
                 consumeDecision: (shouldConsumeBefore || shouldConsumeAfter) ? .consume : .passthrough
             )
 
@@ -125,8 +165,9 @@ enum ShortcutMatcher {
 
             var nextState = state
             if isRepeat {
+                // Key repeats don't change state but might need consumption
                 return ShortcutMatchResult(
-                    state: nextState,
+                    state: state,
                     emittedEvents: [],
                     consumeDecision: shouldConsumeBefore ? .consume : .passthrough
                 )
@@ -138,6 +179,14 @@ enum ShortcutMatcher {
                 nextState.pressedKeyCodes.remove(keyCode)
             }
 
+            // Emit stateless event on pressed key if it is a toggle component
+            var statelessEvents: [ShortcutEvent] = []
+            if isDown {
+                if ShortcutInputState.isToggleComponentInput(keyCode: keyCode, kind: .key, configuration: configuration) {
+                    statelessEvents.append(.toggleComponentInputReceived)
+                }
+            }
+
             let shouldConsumeAfter = shouldConsumeKeyEvent(
                 for: keyCode,
                 state: nextState,
@@ -146,7 +195,7 @@ enum ShortcutMatcher {
             let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
             return ShortcutMatchResult(
                 state: nextState,
-                emittedEvents: emittedEvents,
+                emittedEvents: emittedEvents + statelessEvents,
                 consumeDecision: (shouldConsumeBefore || shouldConsumeAfter) ? .consume : .passthrough
             )
         }
@@ -167,6 +216,7 @@ enum ShortcutMatcher {
         )
     }
 
+    // Update the active states of all configured bindings and return triggered events
     private static func updateActiveBindings(
         in state: inout ShortcutInputState,
         configuration: ShortcutConfiguration
@@ -174,29 +224,36 @@ enum ShortcutMatcher {
         let previousHold = state.holdIsActive
         let previousToggle = state.toggleIsActive
         let previousCopyAgain = state.copyAgainIsActive
+        let previousToggleComponent = state.toggleComponentIsActive
 
         state.holdIsActive = bindingIsActive(configuration.hold, state: state, configuration: configuration)
         state.toggleIsActive = bindingIsActive(configuration.toggle, state: state, configuration: configuration)
         state.copyAgainIsActive = bindingIsActive(configuration.copyAgain, state: state, configuration: configuration)
+        state.toggleComponentIsActive = bindingHasAnyInputActive(configuration.toggle, state: state)
 
         return emitChanges(
             previousHold: previousHold,
             previousToggle: previousToggle,
             previousCopyAgain: previousCopyAgain,
+            previousToggleComponent: previousToggleComponent,
             currentHold: state.holdIsActive,
             currentToggle: state.toggleIsActive,
             currentCopyAgain: state.copyAgainIsActive,
+            currentToggleComponent: state.toggleComponentIsActive,
             configuration: configuration
         )
     }
 
+    // Determine the state transitions and emit corresponding shortcut events
     private static func emitChanges(
         previousHold: Bool,
         previousToggle: Bool,
         previousCopyAgain: Bool,
+        previousToggleComponent: Bool,
         currentHold: Bool,
         currentToggle: Bool,
         currentCopyAgain: Bool,
+        currentToggleComponent: Bool,
         configuration: ShortcutConfiguration
     ) -> [ShortcutEvent] {
         var activations: [(ShortcutEvent, Int)] = []
@@ -208,6 +265,10 @@ enum ShortcutMatcher {
         if !previousToggle && currentToggle {
             activations.append((.toggleActivated, configuration.toggle.specificityScore))
         }
+        // Emit event when any part of the toggle shortcut is pressed
+        if !previousToggleComponent && currentToggleComponent {
+            activations.append((.toggleComponentActivated, configuration.toggle.specificityScore))
+        }
         // Paste Again is a one-shot: fire on the leading edge only.
         if !previousCopyAgain && currentCopyAgain {
             activations.append((.copyAgainTriggered, configuration.copyAgain.specificityScore))
@@ -218,10 +279,45 @@ enum ShortcutMatcher {
         if previousToggle && !currentToggle {
             deactivations.append((.toggleDeactivated, configuration.toggle.specificityScore))
         }
+        // Emit event when all parts of the toggle shortcut are released
+        if previousToggleComponent && !currentToggleComponent {
+            deactivations.append((.toggleComponentDeactivated, configuration.toggle.specificityScore))
+        }
 
         let orderedActivations = activations.sorted(by: { $0.1 > $1.1 }).map(\.0)
         let orderedDeactivations = deactivations.sorted(by: { $0.1 < $1.1 }).map(\.0)
         return orderedActivations + orderedDeactivations
+    }
+
+    /// Returns true if any key or modifier belonging to the binding is currently pressed.
+    /// Unlike `bindingIsActive`, this matches a partial press of the shortcut, not the full combo.
+    /// - Parameters:
+    ///   - binding: The shortcut binding to test for partial activation.
+    ///   - state: The current pressed-input state.
+    private static func bindingHasAnyInputActive(
+        _ binding: ShortcutBinding,
+        state: ShortcutInputState
+    ) -> Bool {
+        guard !binding.isDisabled else { return false }
+        switch binding.kind {
+        case .disabled:
+            return false
+        case .key:
+            if state.pressedKeyCodes.contains(binding.keyCode) { return true }
+        case .modifierKey:
+            if state.pressedModifierKeyCodes.contains(binding.keyCode) { return true }
+        }
+        if let exactModifiers = binding.exactModifierKeyCodes {
+            if !exactModifiers.isDisjoint(with: state.pressedModifierKeyCodes) {
+                return true
+            }
+        } else {
+            let activeModifiers = state.currentModifiers
+            if !binding.modifiers.isDisjoint(with: activeModifiers) {
+                return true
+            }
+        }
+        return false
     }
 
     private static func bindingIsActive(

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -71,6 +71,12 @@ enum ShortcutEvent: Equatable {
     case holdDeactivated
     case toggleActivated
     case toggleDeactivated
+    /// Fired when any key/modifier of the toggle shortcut becomes pressed.
+    case toggleComponentActivated
+    /// Fired statelessly on keydown for any component of the toggle shortcut.
+    case toggleComponentInputReceived
+    /// Fired when all keys/modifiers of the toggle shortcut are released.
+    case toggleComponentDeactivated
     case copyAgainTriggered
 }
 


### PR DESCRIPTION
# Description

In **Tap to Toggle** mode, the dictation shortcut is a combination of two or more keys (e.g. `Fn` + `Space`, or `Fn` + `Control` + `Space`) that starts dictation with a single tap — no holding required. This PR changes how you **end** that dictation.

## Before → After

- **Before:** with a `Fn` + `Space` shortcut, ending dictation required pressing the **whole** `Fn` + `Space` combo again, or clicking the on-screen Stop button.
- **After:** with the same `Fn` + `Space` shortcut, tapping **either** `Fn` **or** `Space` on its own ends the dictation and sends it for transcription. This works for any multi-key combination (e.g. `Fn` + `Control` + `Space` → any one of the three keys ends it). Pressing `Space` to stop does **not** type a stray space into your text field.

## Changed Files

| File | Changes |
|---|---|
| `Sources/AppState.swift` | Implemented the `.consumeOnly` action to swallow trailing shortcut keys so they don't leak into the active text field. |
| `Sources/ShortcutCore/DictationShortcutSessionController.swift` | Added the `ignoreToggleUntilComponentDeactivation` flag to correctly track and consume stop-sequence events. Implemented the `.consumeOnly` action to prevent trailing keys from leaking. |
| `Sources/ShortcutCore/ShortcutMatcher.swift` | Added logic to detect individual toggle component inputs and emit stateless `toggleComponentInputReceived` events. Refactored modifier extraction to use safe `if let` binding instead of force unwrapping. |
| `Sources/ShortcutCore/ShortcutModels.swift` | Added the `toggleComponentInputReceived` event to the `ShortcutEvent` enumeration. |
| `Sources/HotkeyManager.swift` | Updated the `onShortcutEvent` handler to evaluate multiple emitted events per loop and correctly flag when a key press must be consumed by the OS. |
| `Sources/SetupTestHotkeyHarness.swift` | Updated the event closure signature to handle and consume the new `.consumeOnly` action. |
| `Sources/SetupView.swift` | Added support for the `.consumeOnly` action in the shortcut action switch statement. |

## Technical Details: Consuming Trailing Keys and Edge Cases

Handling global multi-key shortcuts requires carefully consuming keyboard events so they do not accidentally leak into the active text editor. The logic handles the following edge cases:

* **Consuming the Space Key (Trailing Keys)**: When a user stops dictation by releasing a sequence (like `Fn` + `Space`), they might release `Fn` before `Space`. This triggers a `toggleComponentInputReceived` event. The session controller intercepts this stateless event and returns `.consumeOnly`, which tells macOS to completely swallow the keystroke, preventing a stray space from being typed into the text box.
* **Component-Level Deactivation**: To prevent the keyboard from getting permanently locked, the system tracks when all components of the shortcut are physically released (`toggleComponentDeactivated`). It only resets the ignore state when the user completely lifts their fingers off the keys, preventing accidental double-triggers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved hotkey behavior with clearer “consumed vs. passed through” handling.
  * Added finer-grained toggle shortcut lifecycle tracking, including component-level activation, input, and deactivation.

* **Bug Fixes**
  * Refined event consumption to prevent unintended keyboard input propagation.
  * Improved dictation toggle responsiveness, including safer handling during rapid start/stop and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->