### PR TITLE
Add option to paste custom words into vocabulary from status bar

### DIFF
--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -17,8 +17,10 @@ struct FreeFlowApp: App {
     }
 }
 
+@MainActor
 struct MenuBarLabel: View {
     @EnvironmentObject var appState: AppState
+    @ObservedObject var notificationManager = VocabularyNotificationManager.shared
 
     private var iconName: String {
         if appState.isRecording { return "record.circle" }
@@ -27,12 +29,18 @@ struct MenuBarLabel: View {
     }
 
     var body: some View {
-        if AppBuild.isDevBundle && !appState.isRecording && !appState.isTranscribing {
-            Image(nsImage: StampedMenuBarIcon.templateImage)
-                .renderingMode(.template)
-        } else {
-            Image(systemName: iconName)
+        HStack(spacing: 4) {
+            if notificationManager.showCheckmark {
+                Image(systemName: "checkmark")
+            }
+            if AppBuild.isDevBundle && !appState.isRecording && !appState.isTranscribing {
+                Image(nsImage: StampedMenuBarIcon.templateImage)
+                    .renderingMode(.template)
+            } else {
+                Image(systemName: iconName)
+            }
         }
+        .animation(.easeInOut(duration: 0.2), value: notificationManager.showCheckmark)
     }
 }
 

--- a/Sources/AppState+AddVocabularyButton.swift
+++ b/Sources/AppState+AddVocabularyButton.swift
@@ -1,0 +1,57 @@
+import AppKit
+
+// MARK: - Add Vocabulary Button Extension
+
+@MainActor
+extension AppState {
+    /// Pastes a word (or words) from the macOS pasteboard into the user's custom vocabulary.
+    /// Returns the pasted text if successful, or nil otherwise.
+    @discardableResult
+    func pasteWordToVocabulary() -> String? {
+        // Read text from pasteboard (macOS native clipboard API)
+        // Check if there's any non-whitespace content to paste
+        guard let pastedString = NSPasteboard.general.string(forType: .string),
+              !pastedString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        
+        // Clean and prepare the new word(s)
+        let wordsToAdd = pastedString
+            .split(whereSeparator: { $0 == "\n" || $0 == "," || $0 == ";" })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            
+        guard !wordsToAdd.isEmpty else { return nil }
+        
+        // Parse current vocabulary list to avoid adding exact duplicates
+        let currentWordsList = self.customVocabulary
+            .split(whereSeparator: { $0 == "\n" || $0 == "," || $0 == ";" })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            
+        let currentWordsSet = Set(currentWordsList.map { $0.lowercased() })
+        
+        let newUniqueWords = wordsToAdd.filter { !currentWordsSet.contains($0.lowercased()) }
+        
+        guard !newUniqueWords.isEmpty else { return nil }
+        
+        let newWordsString = newUniqueWords.joined(separator: ", ")
+        
+        // Append unique words to existing vocabulary
+        // We trim the block as a whole to safely append, but not the individual words themselves
+        var currentVocab = self.customVocabulary.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !currentVocab.isEmpty {
+            if !currentVocab.hasSuffix(",") {
+                currentVocab += ","
+            }
+            currentVocab += "\n\(newWordsString)"
+        } else {
+            currentVocab = newWordsString
+        }
+        
+        // Save back to the published state
+        self.customVocabulary = currentVocab
+        return newWordsString
+    }
+}
+

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -180,6 +180,14 @@ struct MenuBarView: View {
 
             Divider()
 
+            Button("Paste Custom Word to Vocabulary") {
+                if appState.pasteWordToVocabulary() != nil {
+                    VocabularyNotificationManager.shared.flashCheckmark()
+                }
+            }
+
+            Divider()
+
             Menu("Hold Shortcut") {
                 Button {
                     _ = appState.setShortcut(.disabled, for: .hold)

--- a/Sources/VocabularyNotificationManager.swift
+++ b/Sources/VocabularyNotificationManager.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// MARK: - Vocabulary Notification Manager
+
+/// Manages the transient status bar visual checkmark notification when pasting a word.
+@MainActor
+final class VocabularyNotificationManager: ObservableObject, @unchecked Sendable {
+    static let shared = VocabularyNotificationManager()
+    
+    @Published var showCheckmark: Bool = false
+    private var flashTask: Task<Void, Never>?
+    
+    private init() {}
+    
+    /// Flashes a checkmark in the menu bar for 2 seconds, cancelling any previous flash tasks.
+    func flashCheckmark() {
+        flashTask?.cancel()
+        flashTask = Task {
+            self.showCheckmark = true
+            do {
+                try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+                self.showCheckmark = false
+            } catch {
+                // Task was cancelled, leave the checkmark state alone for the next task
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
# Add option to paste custom words into vocabulary from status bar

This change adds a button to the status bar menu to quickly append clipboard content directly to the custom vocabulary. This allows users to add new terms without opening the settings window.

## Proposed Changes

- Added a "Paste Custom Word to Vocabulary" option in the status bar menu.
- Implemented vocabulary updating logic via an extension on AppState to retrieve, sanitize, and append clipboard text to the custom vocabulary, preserving any intentional spacing.
- Created a transient notification manager that displays a visual checkmark indicator next to the status bar icon for 2 seconds when a word is successfully added.
- The feature ensures Swift 6 concurrency safety by fully adopting `@MainActor` and `@unchecked Sendable` where applicable.

## Modified and Added Files

| File | Status | Description |
| :--- | :--- | :--- |
| [Sources/AppState+AddVocabularyButton.swift](file:///Users/saphi/bin/freeflow%202/Sources/AppState%2BAddVocabularyButton.swift) | Added | Extension containing the logic to fetch text from the pasteboard and append it to the custom vocabulary, preserving internal spacing and avoiding duplicates. |
| [Sources/VocabularyNotificationManager.swift](file:///Users/saphi/bin/freeflow%202/Sources/VocabularyNotificationManager.swift) | Added | Manager to handle the transient state of the status bar notification securely isolated to the Main Actor. |
| [Sources/App.swift](file:///Users/saphi/bin/freeflow%202/Sources/App.swift) | Modified | Updated the status bar label to display a checkmark when a vocabulary word is successfully added, adopting Swift 6 concurrency rules. |
| [Sources/MenuBarView.swift](file:///Users/saphi/bin/freeflow%202/Sources/MenuBarView.swift) | Modified | Added the "Paste Custom Word to Vocabulary" button to the status bar menu. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Paste Custom Word to Vocabulary" menu button for quick clipboard import
  * Clipboard content is validated, trimmed, de-duplicated, and supports multiple words/lines
  * Menu bar now shows an animated checkmark confirmation for 2 seconds on successful paste
<!-- end of auto-generated comment: release notes by coderabbit.ai -->