### PR TITLE
Show mute warning when recording with system audio muted

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2143,7 +2143,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     )
                 }
                 overlayShown = true
+                let isMuted = self.alertSoundsEnabled && SystemAudioStatus.isDefaultOutputMuted()
                 self.playAlertSound(named: "Tink")
+                if isMuted {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                        guard let self, self.isRecording else { return }
+                        self.overlayManager.showError("Unmute to hear sound", dismissAfter: 3.0)
+                    }
+                }
             }
         }
         audioRecorder.onRecordingFailure = { [weak self] error in


### PR DESCRIPTION
## Summary

When a dictation recording starts while the system audio output is muted, the start and stop chimes play silently — there is no indication that sounds are being missed. This can be disorienting, especially for users who rely on the audio cues to know when recording has started or finished.

This adds a brief red error toast — "Unmute to hear sound" — that appears for 3 seconds after the recording overlay establishes, then auto-dismisses back to normal operation. Recording is not interrupted.

<img src="https://assets.themarketingshow.com/bugs/freeflow/mute-warning-pill-2026-06-10.png" width="500" alt="Red pill overlay showing Unmute to hear sound with exclamation mark icon">

## How it works

In `onRecordingReady`, after the recording overlay has rendered and the start sound has played, the system mute state is checked via the existing `SystemAudioStatus.isDefaultOutputMuted()`. If muted and alert sounds are enabled, `showError("Unmute to hear sound", dismissAfter: 3.0)` fires after a 0.3-second delay.

The delay is intentional — `transitionToRecording()` dispatches to `DispatchQueue.main.async`, and the error toast must run after that block completes to avoid being overwritten. A 0.3-second `asyncAfter` guarantees correct ordering.

## Implementation

- **1 file changed, 7 insertions** — no new views, state properties, or methods
- Uses existing `SystemAudioStatus.isDefaultOutputMuted()` (already used by the audio interruption feature)
- Uses existing `showError(_:dismissAfter:)` (already used for other transient error toasts)
- Only fires when `alertSoundsEnabled` is true — no point warning about muted audio when sounds are turned off in settings

## Notes / Considered

- **Why `showError` instead of a custom view?** A dedicated amber warning view was prototyped but `showError` is simpler (zero new code surface) and the red styling is more attention-grabbing for something the user should act on.
- **Why 0.3 seconds?** The recording overlay methods dispatch to `DispatchQueue.main.async`. Without the delay, the mute toast and the recording overlay race — the recording overlay can stomp the toast before it renders. 0.3 seconds is long enough for the overlay to fully establish but short enough to feel immediate.
- **Why not fire immediately on key press?** Placing the check in `beginRecording` (before the recording overlay renders) was tried first, but the 200ms initializing timer and the `onRecordingReady` callback both override the overlay phase, stomping the mute warning before it can render. Moving it to `onRecordingReady` with a short delay after the overlay is established was the only reliable placement.
- **Volume at zero vs mute button** — `isDefaultOutputMuted()` checks the CoreAudio mute property specifically. A volume slider dragged to zero without pressing the mute button will not trigger this warning. This is intentional — the mute button is a deliberate action; a low volume setting is a preference.
- **Non-notched Macs** — the pill sizing and positioning are handled by the existing `showError` layout, which already accounts for notched and non-notched displays.
- **Stale session guard** — the 0.3-second delayed closure checks `self.isRecording` before showing the toast. If a user stops recording within that 0.3-second window, the guard bails and no toast appears. A token-based invalidation pattern was considered but the `isRecording` check is sufficient — the worst case (a brief toast after a very fast stop) auto-dismisses in 3 seconds.

## Testing performed

Tested across 5 builds on a MacBook Pro (macOS, built-in speakers as default output):

| Scenario | Result |
|----------|--------|
| Mute via keyboard button, tap shortcut to record | Red "Unmute to hear sound" pill appears for 3 seconds, then returns to waveform. Recording continues normally. |
| Unmute, tap shortcut to record | No warning. Normal start chime plays, waveform appears immediately. |
| Multiple muted recordings in a row | Warning fires reliably each time. |
| Unmute mid-recording after warning | Warning auto-dismisses on its 3-second timer regardless of mute state change. |

**Instrumentation used during development:**
- File-based debug logging (`~/freeflow-mute-debug.log`) confirmed `SystemAudioStatus.isDefaultOutputMuted()` correctly returns `true` when the keyboard mute button is pressed and `false` when unmuted. Volume level is preserved (0.5) in both states — the mute property is independent of the volume slider.
- Log trace confirmed the full sequence: `onRecordingReady` → mute check → `scheduling showError in 0.3s` → `firing showError now`.

**Dispatch ordering verified:** Earlier attempts placed the mute check in `beginRecording` (immediate on key press) and in `onRecordingReady` without a delay. Both were stomped by `transitionToRecording()`'s async dispatch overriding the overlay phase. The 0.3-second `asyncAfter` was the minimum reliable delay.

## Test plan for reviewer

- [ ] Mute system audio, start a recording — red "Unmute to hear sound" pill appears for 3 seconds, then returns to waveform
- [ ] Unmute system audio, start a recording — no warning appears, normal flow
- [ ] Disable alert sounds in settings, mute system audio, start a recording — no warning (sounds are off anyway)
- [ ] Verify recording audio capture is not affected by the mute warning overlay


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App now displays a notification when alert sounds are enabled but device audio output is muted, helping you understand why sounds aren't playing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->