### PR TITLE
User-configurable 'Press Enter' voice command — custom & multilingual trigger phrases

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -225,6 +225,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let preserveClipboardStorageKey = "preserve_clipboard"
     private let keepDictationInClipboardHistoryStorageKey = "keep_dictation_in_clipboard_history"
     private let pressEnterVoiceCommandStorageKey = "press_enter_voice_command_enabled"
+    /// UserDefaults key under which the user's custom "Press Enter" command variations are persisted.
+    private let customPressEnterCommandsStorageKey = "custom_press_enter_commands"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
     private let voiceMacrosStorageKey = "voice_macros"
@@ -277,9 +279,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static let defaultPostProcessingModel = "openai/gpt-oss-20b"
     static let defaultPostProcessingFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     static let defaultContextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
-    private static let trailingPressEnterCommandPattern = try! NSRegularExpression(
-        pattern: #"(?i)(?:^|[ \t\r\n,;:\-]+)press[ \t\r\n]+enter[\s\p{P}]*$"#
-    )
 
     @Published var hasCompletedSetup: Bool {
         didSet {
@@ -516,6 +515,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
             UserDefaults.standard.set(isPressEnterVoiceCommandEnabled, forKey: pressEnterVoiceCommandStorageKey)
         }
     }
+    
+    /// Holds the user-defined variations for the "Press Enter" voice command.
+    /// A `didSet` observer immediately recompiles the regex into `compiledPressEnterRegex`
+    /// whenever the user edits their tags in Settings — so the transcription pipeline
+    /// always reads a pre-built regex and never compiles on the fly during dictation.
+    @Published var customPressEnterCommands: [String] {
+        didSet {
+            UserDefaults.standard.set(customPressEnterCommands, forKey: customPressEnterCommandsStorageKey)
+            compiledPressEnterRegex = MultilanguagePressEnter.compileRegex(for: customPressEnterCommands)
+        }
+    }
+    
+    /// The pre-compiled Regular Expression used to extract the "Press Enter" command
+    /// from the end of the dictated text. It is updated only when `customPressEnterCommands` changes.
+    private(set) var compiledPressEnterRegex: NSRegularExpression?
 
     @Published var alertSoundsEnabled: Bool {
         didSet {
@@ -685,6 +699,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
+        let customPressEnterCommands = UserDefaults.standard.stringArray(forKey: customPressEnterCommandsStorageKey) ?? ["press enter", "pressione enter", "hit enter", "回车"]
         let soundVolume: Float = UserDefaults.standard.object(forKey: soundVolumeStorageKey) != nil
             ? UserDefaults.standard.float(forKey: soundVolumeStorageKey) : 1.0
         let alertSoundsEnabled = UserDefaults.standard.object(forKey: alertSoundsEnabledStorageKey) != nil
@@ -755,6 +770,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
+        self.customPressEnterCommands = customPressEnterCommands
+        self.compiledPressEnterRegex = MultilanguagePressEnter.compileRegex(for: customPressEnterCommands)
         self.alertSoundsEnabled = alertSoundsEnabled
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
@@ -2365,7 +2382,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private static func parseTranscriptCommands(
         from transcript: String,
-        pressEnterCommandEnabled: Bool
+        pressEnterCommandEnabled: Bool,
+        compiledRegex: NSRegularExpression? = nil
     ) -> TranscriptCommandParsingResult {
         guard pressEnterCommandEnabled else {
             return TranscriptCommandParsingResult(
@@ -2374,23 +2392,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             )
         }
 
-        let fullRange = NSRange(transcript.startIndex..<transcript.endIndex, in: transcript)
-        guard
-            let match = trailingPressEnterCommandPattern.firstMatch(in: transcript, range: fullRange),
-            let commandRange = Range(match.range, in: transcript)
-        else {
-            return TranscriptCommandParsingResult(
-                transcript: transcript.trimmingCharacters(in: .whitespacesAndNewlines),
-                shouldPressEnterAfterPaste: false
-            )
-        }
-
-        var strippedTranscript = transcript
-        strippedTranscript.removeSubrange(commandRange)
-
+        let (strippedTranscript, didMatch) = MultilanguagePressEnter.extractCommand(from: transcript, withRegex: compiledRegex)
+        
         return TranscriptCommandParsingResult(
-            transcript: strippedTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
-            shouldPressEnterAfterPaste: true
+            transcript: strippedTranscript,
+            shouldPressEnterAfterPaste: didMatch
         )
     }
 
@@ -2620,7 +2626,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     let rawTranscript = try await transcript
                     let parsedTranscript = Self.parseTranscriptCommands(
                         from: rawTranscript,
-                        pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                        pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled,
+                        compiledRegex: self.compiledPressEnterRegex
                     )
                     try Task.checkCancellation()
                     // Capture the parsed raw transcript as lastTranscript before

--- a/Sources/MultilanguagePressEnter.swift
+++ b/Sources/MultilanguagePressEnter.swift
@@ -1,0 +1,159 @@
+/// A modular and robust utility for extracting customizable "press enter" voice commands.
+/// It compiles dynamic, user-defined command variations into a highly optimized regex.
+
+import Foundation
+import os.log
+
+public struct MultilanguagePressEnter: Sendable {
+    
+    /// A curated list of default commands across various languages.
+    /// This is used purely as a set of recommendations in the Settings UI so users can easily add them.
+    public static let suggestedCommands: [String] = [
+        // English
+        "press enter", "enter", "hit enter", "send", "press return",
+        // Portuguese (BR & PT)
+        "aperte enter", "dar enter", "pressione enter",
+        // Spanish
+        "presionar enter", "intro",
+        // French
+        "appuyer sur entrée", "entrée",
+        // German
+        "eingabetaste drücken", "enter drücken",
+        // Italian
+        "premi invio", "invio",
+        // Dutch
+        "druk op enter",
+        // Russian
+        "нажать enter",
+        // Japanese
+        "エンターを押す",
+        // Chinese
+        "回车",
+    ]
+    
+    // MARK: - Regex Compilation
+    
+    /// Compiles a list of user-defined string commands into a single, optimized Regular Expression.
+    /// - Parameter commands: An array of strings representing the active variations the user has chosen.
+    /// - Returns: A case-insensitive NSRegularExpression, or nil if no valid commands were provided.
+    public static func compileRegex(for commands: [String]) -> NSRegularExpression? {
+        // Sanitize incoming commands: remove leading/trailing spaces and collapse multiple spaces 
+        // between words into a single space. This guarantees our compiler handles clean data,
+        // even if raw inputs had extra spaces added by mistake.
+        let validCommands = commands.map { command -> String in
+            let words = command.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }
+            return words.joined(separator: " ")
+        }.filter { !$0.isEmpty }
+        
+        guard !validCommands.isEmpty else { return nil }
+        
+        let regexParts = validCommands.map { command -> String in
+            // Since the command is already normalized above, we can safely split by single spaces.
+            let words = command.components(separatedBy: " ")
+            
+            // Protect each word so the search engine reads it as plain text.
+            let escapedWords = words.map { NSRegularExpression.escapedPattern(for: $0) }
+            
+            // Glue the words back together, but allow the user to pause or leave multiple spaces between them.
+            return escapedWords.joined(separator: "[ \\t\\r\\n]+")
+        }
+        
+        // Combine all active user commands into one big search list using an OR (|) operator.
+        let joinedCommands = regexParts.joined(separator: "|")
+        
+        // Creating the search rule (Regex) step-by-step:
+        // 1. (?i)                 -> It doesn't matter if the letter is uppercase or lowercase.
+        // 2. ^                    -> Start reading from the very beginning of the sentence.
+        // 3. ([\\s\\S]*?)         -> Part 1 (The actual text): Save everything the person said. This is what we'll return clean.
+        // 4. (?:\\s*)             -> Ignore any blank spaces right before the command word.
+        // 5. (?:\b(?:\(joinedCommands))\b) -> Look for one of the user's active commands (e.g., "press enter") exactly as a word boundary.
+        // 6. ([\\s\\p{P}]*)$      -> Part 2 (The Punctuation): Grab any leftover punctuation at the very end (like '?' or '!').
+        let regexPattern = "(?i)^([\\s\\S]*?)(?:\\s*)(?:\\b(?:\(joinedCommands))\\b)([\\s\\p{P}]*)$"
+        
+        do {
+            // Compile the pattern into a Mac native NSRegularExpression
+            return try NSRegularExpression(pattern: regexPattern)
+        } catch {
+            // Log compilation errors instead of crashing the app
+            os_log(.error, "Failed to compile MultilanguagePressEnter regex: %{public}@", error.localizedDescription)
+            return nil
+        }
+    }
+    
+    // MARK: - Command Extraction
+    
+    /// Checks if the person ended the sentence with one of their configured custom commands.
+    /// If yes, the command is deleted and the function returns only the text the person actually meant to dictate.
+    /// - Parameters:
+    ///   - transcript: The raw text spoken by the user.
+    ///   - regex: The pre-compiled regular expression containing the user's active variations.
+    public static func extractCommand(from transcript: String, withRegex regex: NSRegularExpression?) -> (strippedTranscript: String, didMatch: Bool) {
+        guard let regex = regex else {
+            // Failsafe: If the search rule fails or doesn't exist, return the original text without changing anything.
+            return (transcript.trimmingCharacters(in: .whitespacesAndNewlines), false)
+        }
+        
+        var currentTranscript = transcript
+        var didMatchAny = false
+        var savedPunctuation = ""
+        
+        // We start a loop to handle stuttering or repeated commands.
+        // If the person says "final text. enter, enter", we will delete the commands from back to front until only the text is left.
+        while true {
+            let fullRange = NSRange(currentTranscript.startIndex..<currentTranscript.endIndex, in: currentTranscript)
+            
+            // Try to find the command hidden exactly at the end of the sentence.
+            guard let match = regex.firstMatch(in: currentTranscript, range: fullRange) else {
+                // If we can't find any more commands at the end, we stop the loop.
+                break
+            }
+            
+            // Here we cut out the two important parts that the search rule saved for us:
+            let group1Range = match.range(at: 1) // Part 1 (The actual text)
+            let group2Range = match.range(at: 2) // Part 2 (The Punctuation)
+            
+            if group1Range.location != NSNotFound, let range1 = Range(group1Range, in: currentTranscript) {
+                // We find out what final punctuation the voice system added (if any).
+                var trailingPunctuation = ""
+                if group2Range.location != NSNotFound, let range2 = Range(group2Range, in: currentTranscript) {
+                    trailingPunctuation = String(currentTranscript[range2])
+                }
+                
+                // If we find a question mark or exclamation mark that was stuck to the command being deleted,
+                // we save it in a "vault" to paste back onto the clean text later.
+                if trailingPunctuation.contains("?") {
+                    savedPunctuation = "?"
+                } else if trailingPunctuation.contains("!") && savedPunctuation != "?" {
+                    savedPunctuation = "!"
+                }
+                
+                // We grab the clean text (without the command) and prepare for the next round of the loop.
+                currentTranscript = String(currentTranscript[range1]).trimmingCharacters(in: .whitespacesAndNewlines)
+                didMatchAny = true
+            } else {
+                break
+            }
+        }
+        
+        // If we found at least one enter command, we put the finishing touches on the text:
+        if didMatchAny {
+            if savedPunctuation == "?" || savedPunctuation == "!" {
+                // Replace any existing terminal punctuation before restoring the saved punctuation.
+                if let last = currentTranscript.last, ",.!?".contains(last) {
+                    currentTranscript.removeLast()
+                }
+                currentTranscript.append(savedPunctuation)
+            } else if currentTranscript.hasSuffix(",") {
+                // If a comma was left at the end of the sentence because the person paused before saying "press enter",
+                // we replace it with a neat period.
+                currentTranscript.removeLast()
+                currentTranscript.append(".")
+            }
+            
+            return (currentTranscript, true)
+        }
+        
+        // If the person didn't say any command at the end, we just clean up the blank spaces and return it.
+        return (transcript.trimmingCharacters(in: .whitespacesAndNewlines), false)
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -478,6 +478,10 @@ struct GeneralSettingsView: View {
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
+    /// Controls whether the "Press Enter" customization panel (input field + suggestions) is expanded.
+    @State private var showPressEnterCustomization = false
+    /// Backing text for the field where the user types a new "Press Enter" variation to add.
+    @State private var pressEnterInput = ""
     @State private var copiedBuildInfo = false
     @State private var copiedBuildInfoResetWorkItem: DispatchWorkItem?
     @StateObject private var githubCache = GitHubMetadataCache.shared
@@ -665,6 +669,9 @@ struct GeneralSettingsView: View {
                 }
                 SettingsCard("Clipboard", icon: "doc.on.clipboard") {
                     clipboardSection
+                }
+                SettingsCard("Recognize 'Press Enter'", icon: "return") {
+                    pressEnterSection
                 }
                 SettingsCard("Microphone", icon: "mic.fill") {
                     microphoneSection
@@ -1205,16 +1212,137 @@ struct GeneralSettingsView: View {
             Text("When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, \(AppName.displayName) marks dictations transient and your clipboard manager skips them.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+    
+    // MARK: Press Enter Command
 
-            Divider()
-                .padding(.vertical, 2)
+    /// Settings card body for the "Press Enter" voice command: the enable toggle, the list of active
+    /// variation tags, and the collapsible customization panel for adding or suggesting new variations.
+    private var pressEnterSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Say \"press enter\" at the end of dictation to press Return", isOn: $appState.isPressEnterVoiceCommandEnabled)
 
-            Toggle("Say \"press enter\" to submit after paste", isOn: $appState.isPressEnterVoiceCommandEnabled)
-
-            Text("When the transcription ends with \"press enter\", \(AppName.displayName) removes those words before cleanup, pastes the remaining transcript, then presses Return.")
+            Text("When the transcription ends with one of these commands, FreeFlow removes the trigger words, pastes the transcript, then presses Return. Capitalization doesn't matter.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            
+            if appState.isPressEnterVoiceCommandEnabled {
+                VStack(alignment: .leading, spacing: 10) {
+                    // 1. Active Variations (Always Visible)
+                    // These are extracted from the customization collapse menu to give the user 
+                    // immediate context on what variations are currently active.
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Active variations:")
+                            .font(.caption.weight(.semibold))
+                            .foregroundColor(.secondary)
+                        
+                        if !appState.customPressEnterCommands.isEmpty {
+                            FlowLayout(spacing: 8) {
+                                ForEach(appState.customPressEnterCommands, id: \.self) { command in
+                                    PressEnterActiveTagView(command: command) {
+                                        withAnimation {
+                                            appState.customPressEnterCommands.removeAll { $0 == command }
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            Text("No variations active. The enter command is effectively disabled.")
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                        }
+                    }
+                    .padding(.top, 4)
+                    
+                    // 2. Customize Button
+                    // Acts as a toggle to show/hide the input field and suggested variations.
+                    // Designed with a larger clickable area (contentShape) for better accessibility.
+                    Button(action: {
+                        withAnimation {
+                            showPressEnterCustomization.toggle()
+                        }
+                    }) {
+                        HStack(spacing: 4) {
+                            Text("Customize")
+                                .font(.body.weight(.medium))
+                            Image(systemName: showPressEnterCustomization ? "chevron.up" : "chevron.down")
+                                .font(.callout)
+                        }
+                        .foregroundColor(.blue)
+                        .padding(.vertical, 4)
+                        .padding(.trailing, 8) // Give some padding for easier clicking
+                        .contentShape(Rectangle()) // Make the padded area clickable
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.bottom, 2)
+                }
+                
+                if showPressEnterCustomization {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Divider()
+                        
+                        // 3. Input field for adding new custom variations
+                        // Uses standard rounded borders for macOS HIG compliance.
+                        HStack(spacing: 6) {
+                            TextField("Add a new variation...", text: $pressEnterInput)
+                                .font(.body)
+                                .textFieldStyle(.roundedBorder)
+                                .onSubmit { addPressEnterCommand() }
+                            
+                            Button("Add") {
+                                addPressEnterCommand()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.regular)
+                            .disabled(pressEnterInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+                        
+                        // 4. Suggested List
+                        // Only shows suggestions that haven't been added yet to avoid redundancy.
+                        let unusedSuggestions = MultilanguagePressEnter.suggestedCommands.filter { !appState.customPressEnterCommands.contains($0) }
+                        if !unusedSuggestions.isEmpty {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Suggested variations:")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundColor(.secondary)
+                                
+                                FlowLayout(spacing: 8) {
+                                    ForEach(unusedSuggestions, id: \.self) { command in
+                                        PressEnterSuggestedTagView(command: command) {
+                                            withAnimation {
+                                                appState.customPressEnterCommands.append(command)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            .padding(.top, 4)
+                        }
+                    }
+                    .padding(.top, 4)
+                }
+            }
         }
+    }
+    
+    /// Validates and appends a newly typed variation into the user's active custom commands list.
+    /// - Sanitizes the string by trimming whitespaces and converting it to lowercase.
+    /// - Aborts if the resulting string is empty or already exists in the active list.
+    /// - Triggers a UI animation and updates `AppState.customPressEnterCommands`.
+    private func addPressEnterCommand() {
+        // Normalize the string: lowercase, remove leading/trailing spaces, and collapse multiple spaces into one.
+        let words = pressEnterInput.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }
+        let normalized = words.joined(separator: " ").lowercased()
+        
+        guard !normalized.isEmpty, !appState.customPressEnterCommands.contains(normalized) else {
+            pressEnterInput = ""
+            return
+        }
+        withAnimation {
+            appState.customPressEnterCommands.append(normalized)
+        }
+        pressEnterInput = ""
     }
 
     // MARK: Microphone
@@ -2733,6 +2861,98 @@ struct VoiceMacroEditorView: View {
             if let m = macro {
                 command = m.command
                 payload = m.payload
+            }
+        }
+    }
+}
+
+/// A macOS HIG compliant capsule view representing an active "Press Enter" variation.
+/// It features a subtle translucent glass effect in its idle state.
+/// When hovered, the text transitions into an "X" button smoothly without shifting the layout.
+///
+/// **Why is this extracted at the bottom of the file?**
+/// By separating this into its own `struct`, the local `@State private var isHovering` 
+/// belongs only to this specific tag. If this code were placed directly inside the `ForEach` 
+/// loop of `SettingsView`, managing hover states individually would require complex 
+/// dictionaries and cause the entire Settings screen to re-render pointlessly on every hover.
+struct PressEnterActiveTagView: View {
+    /// The active variation text displayed inside the capsule.
+    let command: String
+    /// Invoked when the user clicks the "X" to remove this variation.
+    let onRemove: () -> Void
+    
+    /// Tracks pointer hover so the label can cross-fade into the remove button.
+    @State private var isHovering = false
+    
+    /// Renders the capsule tag, swapping the label for an "X" remove button on hover.
+    var body: some View {
+        Text(command)
+            .font(.callout)
+            .fontWeight(.medium)
+            // Hide the text itself when hovering so the 'xmark' button takes focus
+            .opacity(isHovering ? 0 : 1)
+            .overlay {
+                Button(action: onRemove) {
+                    Image(systemName: "xmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .opacity(isHovering ? 1 : 0)
+            }
+            .foregroundStyle(Color.accentColor)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            // Subtle fill matching macOS standard tag styling
+            .background(Color.accentColor.opacity(0.15))
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .strokeBorder(Color.accentColor.opacity(0.4), lineWidth: 1)
+            )
+            .onHover { hovering in
+                withAnimation(.easeInOut(duration: 0.1)) {
+                    isHovering = hovering
+                }
+            }
+    }
+}
+
+/// A simple, pill-shaped view for suggested "Press Enter" variations.
+/// Displays a plus icon and text in a muted secondary color.
+/// On hover, it deepens the background color slightly to indicate clickability.
+///
+/// **Why is this extracted at the bottom of the file?**
+/// Like `PressEnterActiveTagView`, this MUST be a separated `struct`. If embedded 
+/// inside the `SettingsView` loop, its `@State` hover animation would be impossible to 
+/// handle cleanly per-item and would drastically degrade UI performance during interactions.
+struct PressEnterSuggestedTagView: View {
+    /// The suggested variation text displayed next to the plus icon.
+    let command: String
+    /// Invoked when the user taps the pill to add this suggestion to their active variations.
+    let onAdd: () -> Void
+    
+    /// Tracks pointer hover so the background can deepen to signal clickability.
+    @State private var isHovering = false
+    
+    /// Renders the tappable "+" pill that adds the suggested variation when clicked.
+    var body: some View {
+        Button(action: onAdd) {
+            HStack(spacing: 4) {
+                Image(systemName: "plus")
+                Text(command)
+            }
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(isHovering ? Color.secondary.opacity(0.2) : Color.secondary.opacity(0.1))
+            .foregroundColor(.secondary)
+            .cornerRadius(12)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.07)) {
+                isHovering = hovering
             }
         }
     }


### PR DESCRIPTION
## Description

FreeFlow already had a single, hard-coded **"press enter"** trigger that presses Return after a dictation. This PR makes the trigger **fully user-configurable**.

### What it adds
- A **Settings UI** to add and remove your own trigger phrases as removable tags — in **any language** and in **custom wordings** (e.g. "hit enter", "pressione enter", "send", "appuyer sur Entrée" — whatever you want).
- A quick-add **library of multilingual variations** with built-in suggestions in the UI.
- A robust extraction engine that strips the matched trigger from the **end** of the transcript — even across **repeated** triggers, **multi-line** endings, and trailing punctuation — **before** the text reaches the LLM cleanup step, **recording the intent to press Enter right after the cleaned text is pasted**.

---

<img width="1000" height="417" alt="SCR-20260616-ovpj" src="https://github.com/user-attachments/assets/66825dd3-3258-4753-884d-9de218093ea2" />
---
<img width="1000" height="691" alt="SCR-20260616-ouqr" src="https://github.com/user-attachments/assets/ae900226-2f8e-4c19-b283-fb91496bde60" />

---

### UI and UX

- **Tag-Based Settings Interface**: Overhauled the Press Enter settings section. Users can now view active variations as persistent UI tags.
- **Suggested Variations**: Integrated a quick-add library containing built-in variations for some common languages.
- **Apple HIG Compliance**: Active and suggested tags are designed with native macOS characteristics, including capsule shapes, semi-transparent backgrounds (`Color.accentColor.opacity(0.15)`), and smooth hover states.
- **SwiftUI Performance Optimization**: Hover state logic (`@State`) for tags was extracted into independent structures (`PressEnterActiveTagView` and `PressEnterSuggestedTagView`). This isolation prevents the primary `SettingsView` from continuously re-rendering during pointer interactions, ensuring high application performance.

### Technical Implementation

- **Modular Regex Engine**: Created `MultilanguagePressEnter.swift` to handle command compilation and extraction. The system compiles user-defined active commands into a single, optimized, case-insensitive `NSRegularExpression`.
- **Advanced Suffix Extraction**: Replaced simple `.hasSuffix()` checks. The new engine correctly strips trigger phrases from the end of the transcript even when followed by punctuation (e.g., "?", "!"). Relevant punctuation is preserved and re-applied to the finalized transcript.
- **Consecutive Trigger Handling**: The extraction loop dynamically handles repeated trigger words (e.g., "final phrase. enter, enter"), stripping them consecutively until only the intended transcript remains.
- **Input Sanitization**: Automatically normalizes user input for custom variations by collapsing excess whitespaces to ensure robust regex compilation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customizable “Recognize ‘Press Enter’” setting in General Settings.
  * Users can now add, view, and remove their own press-enter phrases, with suggested phrases shown for quick setup.
  * The app now better recognizes multiple phrase variations and handles trailing punctuation more naturally.

* **Bug Fixes**
  * Improved command detection so spoken “press enter” variations are stripped more reliably from transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->