### PR TITLE
Fix recording overlay panel leak: dismissed panels stay alive and keep animating (CPU and Battery Hog)

### DIFF
--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -448,6 +448,11 @@ final class RecordingOverlayManager {
         overlayState.updateVersion = ""
         if let panel = overlayWindow {
             panel.orderOut(nil)
+            // orderOut alone leaves the panel retained in NSApp.windows with its
+            // SwiftUI hierarchy mounted — repeatForever animations keep flushing
+            // Core Animation forever. Unmount and close so the panel deallocates.
+            panel.contentView = nil
+            panel.close()
             overlayWindow = nil
         }
     }


### PR DESCRIPTION
## What happened

After a normal morning of dictation, Activity Monitor showed the app holding 6–7% CPU continuously — not during recording, but *after* every overlay had dismissed and the app was supposedly idle. Memory crept upward through the session as well. Nothing looked wrong: no window on screen, no recording in progress, no menu open.

## The diagnosis

`top` showed an odd signature first: sustained CPU with almost no idle wakeups. A misbehaving timer wakes the process over and over; this was the opposite — already-scheduled work running continuously on the main thread.

A 5-second `sample` of the process found it:

```
181 of 3055 main-thread samples:
  __CFRunLoopDoSource1
    __CFMachPortPerform
      UC::DriverCore::continueProcessing()  (UpdateCycle)
        CA::Transaction::commit()
          NSDisplayCycleFlush
            -[NSWindow layoutIfNeeded]
              ... RepeatAnimation.animate ...
```

Core Animation was flushing window layout every frame — while a window-enumeration check reported the app had **zero visible windows**. An invisible window was animating, forever.

## The bug

`RecordingOverlayManager.dismissAll()` hides the overlay panel with `orderOut(nil)` and drops its reference:

```swift
if let panel = overlayWindow {
    panel.orderOut(nil)
    overlayWindow = nil
}
```

But AppKit retains every ordered-in window in `NSApp.windows` until it is **closed** — `orderOut` only takes it off screen. Since `showOverlayPanel` creates a fresh panel whenever `overlayWindow` is nil, every dictation leaks one hidden panel with its `NSHostingView` hierarchy still mounted. Whatever is live in that hierarchy keeps running:

- the processing indicator's `.repeatForever` spinner rotation keeps driving Core Animation transaction flushes
- `InitializingDotsView`'s 0.5s `Timer` never gets its `.onDisappear`, so it never invalidates

Once you see it, it is obvious: the panels never die, so neither do their animations.

## Repro

1. Run the app from `main`.
2. Dictate once; let the overlay dismiss normally.
3. Watch the process in `top` — CPU settles at a few percent and never returns to 0.
4. Each additional dictation adds another hidden panel; `sample <pid> 5` shows `CA::Transaction::commit` / `RepeatAnimation` stacks with no visible windows.

## The fix

In `dismissAll()`, unmount the content view and close the panel so AppKit releases it:

```swift
panel.orderOut(nil)
panel.contentView = nil
panel.close()
overlayWindow = nil
```

This is the right place because every dismissal path — normal dismiss, error auto-dismiss, escape cancel, update overlay — funnels through `dismissAll()`. The panel already sets `isReleasedWhenClosed = false`, so `close()` is safe.

## Files

- `Sources/RecordingOverlay.swift` — +5 lines in `dismissAll()`

## Behavior

- Overlay show/hide behavior is unchanged: `showOverlayPanel` already created a fresh panel after every dismissal (the reference was already nil'd), so the create path is identical.
- A second `dismissAll()` on an already-dismissed overlay was a no-op before and still is (`overlayWindow` is nil).
- The mid-session reuse branch (phase transitions while the overlay stays visible) does not hit this code and is untouched.

## Testing performed

Tested on an Apple Silicon MacBook Pro, macOS 26.5.1, built-in mic, hold and toggle dictation modes.

| Scenario | Result |
|----------|--------|
| Three consecutive dictations, overlay dismissed each time | Text inserted normally; overlay appeared and dismissed as usual |
| CPU after dictations, before fix | 6–7% sustained indefinitely; `sample` showed Core Animation flush stacks driven by `RepeatAnimation`, zero visible windows |
| CPU after dictations, with fix | 0.0% across repeated 2-second `top` samples; 4261/4261 main-thread samples idle in `mach_msg` |
| 5-second `sample` grep for `RepeatAnimation` / `CA::Transaction::commit` / `layoutSubtreeIfNeeded`, with fix | 0 occurrences |
| Error-pill auto-dismiss path | Funnels through the same `dismissAll()`; no double-close (reference already nil) |

**Instrumentation:** `top -stats cpu,idlew` (sustained CPU with near-zero idle wakeups pointed at already-scheduled work rather than timer wakeups), `sample` call graphs before and after, window enumeration via Accessibility to confirm zero visible windows during the burn.

**Approaches tried:** none rejected at the keyboard — the first fix worked — but see Notes for alternatives considered and ruled out by inspection.

## Test plan for reviewer

- [ ] On `main`: dictate once, wait for the overlay to dismiss, watch `top -pid $(pgrep -f FreeFlow)` — CPU never returns to 0.
- [ ] On this branch: repeat — CPU returns to 0.0 once the overlay dismisses.
- [ ] Confirm the overlay still appears and dismisses normally across hold, toggle, error, and update-reminder paths.

## Notes / Considered

- **Single reusable panel instead of create-per-show** — ruled out as out of scope; closing the leaked panels is the root fix and keeps the diff minimal.
- **Invalidating animations via `.onDisappear`** — does not work here: the hierarchy never unmounts while the panel is alive, so `.onDisappear` never fires. Closing the panel is what unmounts it.
- **`close()` without `contentView = nil`** — close alone removes the panel from `NSApp.windows`; explicitly unmounting the hosting view makes teardown deterministic rather than relying on dealloc timing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recording overlay panels remaining in memory after being dismissed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->