### PR TITLE
Add tolerance to the hourly update-check timer

### DIFF
--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -201,6 +201,9 @@ final class UpdateManager: ObservableObject {
                 }
             }
         }
+        // Exact firing time does not matter for an hourly check; tolerance
+        // lets the system coalesce the wakeup with other timers to save power.
+        periodicTimer?.tolerance = 300
     }
 
     private func shouldAutoCheck() -> Bool {


### PR DESCRIPTION
## What this is

A one-line power hygiene fix to the hourly update-check timer.

`startPeriodicChecks()` schedules a repeating `Timer` at a 3600-second interval with no tolerance. A zero-tolerance timer forces the system to wake at the exact scheduled instant, which defeats timer coalescing — macOS cannot batch the wakeup with other pending work, so the process takes a dedicated wakeup every hour for a task that has no precision requirement at all.

## The fix

```swift
periodicTimer?.tolerance = 300
```

Apple's Energy Efficiency Guide recommends a tolerance of at least 10% of the interval for repeating timers. 300 seconds on a 3600-second timer fits that guidance, leaving macOS free to fire the check anywhere in a 5-minute window alongside other system work.

## Why the slack is safe

The timer body does not depend on precise timing: `shouldAutoCheck()` independently gates on elapsed time since the last successful check before any network request happens. Whether the tick lands at 60 minutes or 65 changes nothing about which checks run — the elapsed-time gate is the source of truth, the timer is just the heartbeat.

## Files

- `Sources/UpdateManager.swift` — +3 lines in `startPeriodicChecks()`

## Testing performed

Tested on an Apple Silicon MacBook Pro, macOS 26.5.1.

| Scenario | Result |
|----------|--------|
| Build, deploy, and launch with the change | App launches and runs normally |
| Full dictation round-trip on the new build | Recording → transcription → post-processing → text insertion, all normal |

Two things are deliberately **not** claimed: the coalescing effect itself (a kernel scheduling hint, not observable without a powermetrics session), and the update-check firing path (the elapsed-time gate makes it a no-op unless the check interval has passed, so it was not exercised during testing). The safety argument for both is the `shouldAutoCheck()` gate described above, verified by inspection.

## Test plan for reviewer

- [ ] Build and run; confirm the periodic update check still fires (hourly, or on the post-launch delayed check).
- [ ] Confirm no behavior change in update prompts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized periodic update checks to reduce system resource consumption and improve device efficiency during background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->