### PR TITLE
Enable audio ducking by default during dictation

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -194,9 +194,6 @@ private enum SessionIntent {
 }
 
 final class AppState: ObservableObject, @unchecked Sendable {
-    private enum ActiveAudioInterruption {
-        case muted(previouslyMuted: Bool)
-    }
 
     private let apiKeyStorageKey = "groq_api_key"
     private let apiBaseURLStorageKey = "api_base_url"
@@ -590,7 +587,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingShortcutStartMode: RecordingTriggerMode?
     private var realtimeService: RealtimeTranscriptionService?
     private var automaticTerminationDisabled = false
-    private var activeAudioInterruption: ActiveAudioInterruption?
+    private var activeAudioInterruption: SystemAudioStatus.OutputAudioDuckingSnapshot?
     private var pendingOverlayDismissToken: UUID?
     private var shouldMonitorHotkeys = false
     private var isCapturingShortcut = false
@@ -656,9 +653,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
-        let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
+        let dictationAudioInterruptionEnabled = UserDefaults.standard.object(
             forKey: dictationAudioInterruptionEnabledStorageKey
-        )
+        ) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: dictationAudioInterruptionEnabledStorageKey)
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -2072,25 +2071,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func applyAudioInterruptionIfNeeded() {
         guard dictationAudioInterruptionEnabled, activeAudioInterruption == nil else { return }
-
-        let wasMuted = SystemAudioStatus.isDefaultOutputMuted()
-        if wasMuted {
-            activeAudioInterruption = .muted(previouslyMuted: true)
-        } else if SystemAudioStatus.setDefaultOutputMuted(true) {
-            activeAudioInterruption = .muted(previouslyMuted: false)
-        }
+        activeAudioInterruption = SystemAudioStatus.beginDictationOutputDucking()
     }
 
     private func restoreAudioInterruptionIfNeeded() {
         guard let activeAudioInterruption else { return }
+        let snapshot = activeAudioInterruption
         self.activeAudioInterruption = nil
-
-        switch activeAudioInterruption {
-        case .muted(let previouslyMuted):
-            if !previouslyMuted {
-                _ = SystemAudioStatus.setDefaultOutputMuted(false)
-            }
-        }
+        SystemAudioStatus.restoreDictationOutputDucking(snapshot)
     }
 
     private func beginCriticalDictationActivity() {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1076,11 +1076,11 @@ struct GeneralSettingsView: View {
     private var dictationAudioSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             Toggle(
-                "Mute audio when dictation starts",
+                "Lower other audio when dictation starts",
                 isOn: $appState.dictationAudioInterruptionEnabled
             )
 
-            Text("\(AppName.displayName) restores the audio state it changed when dictation ends.")
+            Text("\(AppName.displayName) temporarily lowers system output volume while you dictate, then restores it when dictation ends. If volume control is unavailable, it falls back to muting output.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/SystemAudioStatus.swift
+++ b/Sources/SystemAudioStatus.swift
@@ -1,6 +1,24 @@
 import CoreAudio
 
 enum SystemAudioStatus {
+    struct VolumeScalarChange: Equatable {
+        let element: UInt32
+        let previousScalar: Float
+    }
+
+    struct OutputAudioDuckingSnapshot: Equatable {
+        enum Restoration: Equatable {
+            case unchanged
+            case restoreVolumes([VolumeScalarChange])
+            case unmute
+        }
+
+        let restoration: Restoration
+    }
+
+    private static let dictationDuckVolumeRatio: Float = 0.15
+    private static let minimumDuckTargetScalar: Float = 0.02
+
     static func isDefaultOutputMuted() -> Bool {
         guard let deviceID = defaultOutputDeviceID() else { return false }
 
@@ -67,6 +85,82 @@ enum SystemAudioStatus {
         return maxChannelVolume
     }
 
+    static func beginDictationOutputDucking() -> OutputAudioDuckingSnapshot {
+        guard let deviceID = defaultOutputDeviceID() else {
+            return OutputAudioDuckingSnapshot(restoration: .unchanged)
+        }
+
+        if isDefaultOutputMuted() {
+            return OutputAudioDuckingSnapshot(restoration: .unchanged)
+        }
+
+        let readableVolumes = readableOutputVolumeScalars(deviceID: deviceID)
+        if !readableVolumes.isEmpty {
+            var appliedChanges: [VolumeScalarChange] = []
+            for (element, previousScalar) in readableVolumes {
+                let duckedScalar = duckedVolumeScalar(for: previousScalar)
+                guard duckedScalar < previousScalar - 0.001 else { continue }
+                guard writeVolume(deviceID: deviceID, element: AudioObjectPropertyElement(element), scalar: duckedScalar) else {
+                    continue
+                }
+                appliedChanges.append(VolumeScalarChange(element: element, previousScalar: previousScalar))
+            }
+
+            if !appliedChanges.isEmpty {
+                return OutputAudioDuckingSnapshot(restoration: .restoreVolumes(appliedChanges))
+            }
+        }
+
+        if setDefaultOutputMuted(true) {
+            return OutputAudioDuckingSnapshot(restoration: .unmute)
+        }
+
+        return OutputAudioDuckingSnapshot(restoration: .unchanged)
+    }
+
+    static func restoreDictationOutputDucking(_ snapshot: OutputAudioDuckingSnapshot) {
+        guard let deviceID = defaultOutputDeviceID() else { return }
+
+        switch snapshot.restoration {
+        case .unchanged:
+            return
+        case .restoreVolumes(let changes):
+            for change in changes {
+                _ = writeVolume(
+                    deviceID: deviceID,
+                    element: AudioObjectPropertyElement(change.element),
+                    scalar: change.previousScalar
+                )
+            }
+        case .unmute:
+            _ = setDefaultOutputMuted(false)
+        }
+    }
+
+    private static func duckedVolumeScalar(for currentScalar: Float) -> Float {
+        let clampedCurrent = min(max(currentScalar, 0), 1)
+        let scaled = clampedCurrent * dictationDuckVolumeRatio
+        return min(max(scaled, minimumDuckTargetScalar), clampedCurrent)
+    }
+
+    private static func readableOutputVolumeScalars(deviceID: AudioDeviceID) -> [UInt32: Float] {
+        var volumes: [UInt32: Float] = [:]
+
+        if let masterVolume = readVolume(deviceID: deviceID, element: kAudioObjectPropertyElementMain) {
+            volumes[UInt32(kAudioObjectPropertyElementMain)] = masterVolume
+            return volumes
+        }
+
+        for channel in 1...2 {
+            let element = AudioObjectPropertyElement(channel)
+            if let volume = readVolume(deviceID: deviceID, element: element) {
+                volumes[UInt32(channel)] = volume
+            }
+        }
+
+        return volumes
+    }
+
     private static func readVolume(deviceID: AudioDeviceID, element: AudioObjectPropertyElement) -> Float? {
         var value: Float32 = 0
         var size = UInt32(MemoryLayout<Float32>.size)
@@ -88,6 +182,32 @@ enum SystemAudioStatus {
         )
 
         return status == noErr ? value : nil
+    }
+
+    private static func writeVolume(
+        deviceID: AudioDeviceID,
+        element: AudioObjectPropertyElement,
+        scalar: Float
+    ) -> Bool {
+        var value = min(max(scalar, 0), 1)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: element
+        )
+
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+
+        let status = AudioObjectSetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            UInt32(MemoryLayout<Float32>.size),
+            &value
+        )
+
+        return status == noErr
     }
 
     private static func defaultOutputDeviceID() -> AudioDeviceID? {

--- a/Sources/SystemAudioStatus.swift
+++ b/Sources/SystemAudioStatus.swift
@@ -13,7 +13,13 @@ enum SystemAudioStatus {
             case unmute
         }
 
+        let deviceID: AudioDeviceID?
         let restoration: Restoration
+
+        init(deviceID: AudioDeviceID? = nil, restoration: Restoration) {
+            self.deviceID = deviceID
+            self.restoration = restoration
+        }
     }
 
     private static let dictationDuckVolumeRatio: Float = 0.15
@@ -21,52 +27,12 @@ enum SystemAudioStatus {
 
     static func isDefaultOutputMuted() -> Bool {
         guard let deviceID = defaultOutputDeviceID() else { return false }
-
-        var muteValue: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyMute,
-            mScope: kAudioDevicePropertyScopeOutput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        guard AudioObjectHasProperty(deviceID, &address) else { return false }
-
-        let status = AudioObjectGetPropertyData(
-            deviceID,
-            &address,
-            0,
-            nil,
-            &size,
-            &muteValue
-        )
-
-        guard status == noErr else { return false }
-        return muteValue == 1
+        return isOutputMuted(deviceID: deviceID)
     }
 
     static func setDefaultOutputMuted(_ muted: Bool) -> Bool {
         guard let deviceID = defaultOutputDeviceID() else { return false }
-
-        var muteValue: UInt32 = muted ? 1 : 0
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyMute,
-            mScope: kAudioDevicePropertyScopeOutput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        guard AudioObjectHasProperty(deviceID, &address) else { return false }
-
-        let status = AudioObjectSetPropertyData(
-            deviceID,
-            &address,
-            0,
-            nil,
-            UInt32(MemoryLayout<UInt32>.size),
-            &muteValue
-        )
-
-        return status == noErr
+        return setOutputMuted(muted, deviceID: deviceID)
     }
 
     static func defaultOutputVolume() -> Float? {
@@ -90,7 +56,7 @@ enum SystemAudioStatus {
             return OutputAudioDuckingSnapshot(restoration: .unchanged)
         }
 
-        if isDefaultOutputMuted() {
+        if isOutputMuted(deviceID: deviceID) {
             return OutputAudioDuckingSnapshot(restoration: .unchanged)
         }
 
@@ -107,19 +73,22 @@ enum SystemAudioStatus {
             }
 
             if !appliedChanges.isEmpty {
-                return OutputAudioDuckingSnapshot(restoration: .restoreVolumes(appliedChanges))
+                return OutputAudioDuckingSnapshot(
+                    deviceID: deviceID,
+                    restoration: .restoreVolumes(appliedChanges)
+                )
             }
         }
 
-        if setDefaultOutputMuted(true) {
-            return OutputAudioDuckingSnapshot(restoration: .unmute)
+        if setOutputMuted(true, deviceID: deviceID) {
+            return OutputAudioDuckingSnapshot(deviceID: deviceID, restoration: .unmute)
         }
 
         return OutputAudioDuckingSnapshot(restoration: .unchanged)
     }
 
     static func restoreDictationOutputDucking(_ snapshot: OutputAudioDuckingSnapshot) {
-        guard let deviceID = defaultOutputDeviceID() else { return }
+        guard let deviceID = snapshot.deviceID else { return }
 
         switch snapshot.restoration {
         case .unchanged:
@@ -133,8 +102,54 @@ enum SystemAudioStatus {
                 )
             }
         case .unmute:
-            _ = setDefaultOutputMuted(false)
+            _ = setOutputMuted(false, deviceID: deviceID)
         }
+    }
+
+    private static func isOutputMuted(deviceID: AudioDeviceID) -> Bool {
+        var muteValue: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &size,
+            &muteValue
+        )
+
+        guard status == noErr else { return false }
+        return muteValue == 1
+    }
+
+    private static func setOutputMuted(_ muted: Bool, deviceID: AudioDeviceID) -> Bool {
+        var muteValue: UInt32 = muted ? 1 : 0
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+
+        let status = AudioObjectSetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            UInt32(MemoryLayout<UInt32>.size),
+            &muteValue
+        )
+
+        return status == noErr
     }
 
     private static func duckedVolumeScalar(for currentScalar: Float) -> Float {


### PR DESCRIPTION
## Summary

FreeFlow already had an opt-in setting to mute system output while dictating, but it was off by default and used a hard mute. This change enables the behavior by default and replaces the hard mute with volume ducking so background audio is lowered rather than silenced, while still falling back to mute on devices that do not expose volume control.

## How it works

When dictation starts, `SystemAudioStatus.beginDictationOutputDucking()` reads the current default output volume and lowers it to roughly 15% of the previous level. When dictation ends, `restoreDictationOutputDucking(_:)` restores the saved volume snapshot.

If the output device does not expose a writable volume scalar, the existing mute fallback is used instead. If the system was already muted before dictation started, no change is made.

## Implementation

- `Sources/SystemAudioStatus.swift` — add ducking snapshot types plus begin/restore helpers
- `Sources/AppState.swift` — wire ducking into the existing audio interruption lifecycle and default the setting to enabled for fresh installs
- `Sources/SettingsView.swift` — update the setting label and helper text to describe ducking behavior

## Behavior

- **New installs / users who never changed the setting:** audio ducking is enabled by default.
- **Users who explicitly disabled the setting:** their saved `false` preference is preserved.
- **Normal dictation flow:** volume is lowered on recording start and restored on stop, cancel, and recording-start failure paths.
- **Unsupported devices:** falls back to the previous hard-mute behavior.

## Testing performed

Tested on Apple Silicon with built-in speakers.

| Scenario | Result |
|----------|--------|
| Play background audio, hold Fn to dictate | Output volume ducks to ~15% while recording, then restores on release |
| Automated ducking API check | Volume moved from 0.312 → 0.047 during ducking, then restored to 0.312 |
| Disable setting in General settings | Dictation no longer changes system output volume |
| Cancel recording with Esc during toggle mode | Volume restores correctly |

## Test plan for reviewer

- [ ] Build and launch on a Mac with background audio playing
- [ ] Hold the dictation shortcut and confirm output volume lowers, then restores on release
- [ ] Disable **Lower other audio when dictation starts** and confirm dictation no longer changes system volume
- [ ] Test cancel/error paths (Esc cancel, recording failure) and confirm volume restoration still happens
- [ ] If possible, test a Bluetooth or external output device to confirm ducking or mute fallback behaves reasonably

## Notes / Considered

- **Why ducking instead of hard mute?** It keeps a faint background signal so users can tell playback is still active, which matches the intended Wispr-like experience.
- **Why default on?** The feature existed already but was easy to miss because it defaulted to off.
- **Crash mid-dictation:** if the process crashes before restore runs, volume may remain ducked. This is the same class of risk as the previous mute-based implementation.
- **Output device changes mid-session:** restore targets the current default output device, same limitation as the previous mute-based approach.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * During dictation, the app now intelligently lowers other system audio volume instead of muting, with a fallback to muting when volume control isn’t available.
  * Dictation audio volume is restored when dictation ends to match the previous output state.
* **Settings**
  * If the “Audio During Dictation” preference was previously unset, it now defaults to enabled.
* **Documentation**
  * Updated the “Audio During Dictation” setting label and description to reflect the new volume-lowering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->