### PR TITLE
fix: switch to the backup cleanup model when the main one is rate-limited, instead of retrying it every dictation

### DIFF
--- a/Sources/LLMCooldownManager.swift
+++ b/Sources/LLMCooldownManager.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Tracks per-model rate-limit cooldowns so subsequent requests skip a rate-limited model
+/// instead of sending a doomed request and paying an extra round-trip.
+///
+/// Two storage tiers:
+///   - Minute-level limits (retry-after < 1 hour): stored in memory, cleared on app restart.
+///   - Daily limits (retry-after >= 1 hour): persisted in UserDefaults so the cooldown
+///     survives app restarts and is visible in the Settings UI.
+actor LLMCooldownManager {
+
+    /// Shared instance used by all PostProcessingService instances across the app.
+    /// Rate limits apply at the Groq organization level, so one shared state is correct.
+    static let shared = LLMCooldownManager()
+
+    /// Cooldowns at or above this threshold are treated as daily limits and persisted.
+    private let dailyLimitThreshold: TimeInterval = 3600
+
+    /// In-memory store for short-lived minute-level cooldowns.
+    private var cooldowns: [String: Date] = [:]
+
+    /// Returns true if the given model is currently blocked by a rate-limit cooldown.
+    /// Checks both in-memory (minute-level) and UserDefaults (daily-level) stores.
+    func isInCooldown(_ model: String) -> Bool {
+        let now = Date()
+
+        // Check in-memory store first — minute-level limits live here.
+        if let until = cooldowns[model] {
+            if now < until { return true }
+            // Entry expired; remove it to keep the dictionary clean.
+            cooldowns.removeValue(forKey: model)
+        }
+
+        // Check UserDefaults for persisted daily-limit entries.
+        if let until = persistedExpiry(for: model) {
+            if now < until { return true }
+            // Entry expired; remove it from UserDefaults.
+            clearPersistedExpiry(for: model)
+        }
+
+        return false
+    }
+
+    /// Registers a cooldown for a model using the retry-after duration from the API 429 response.
+    /// Minute-level durations stay in memory; daily-level durations are also written to UserDefaults.
+    func setCooldown(_ model: String, retryAfterSeconds: TimeInterval) {
+        let expiryDate = Date().addingTimeInterval(retryAfterSeconds)
+        if retryAfterSeconds >= dailyLimitThreshold {
+            // Daily limit: persist to UserDefaults so it survives app restarts.
+            persistExpiry(expiryDate, for: model)
+        } else {
+            // Minute-level limit: keep in memory only; it will expire within minutes.
+            cooldowns[model] = expiryDate
+        }
+    }
+
+    // MARK: - UserDefaults (daily-limit persistence)
+
+    /// Shared key format so SettingsView can read expiry dates without going through the actor.
+    /// nonisolated allows this to be called synchronously from SwiftUI view code.
+    nonisolated static func udKey(for model: String) -> String {
+        "llm_cooldown_expiry_\(model)"
+    }
+
+    /// Instance wrapper used internally by the actor methods below.
+    private func udKey(_ model: String) -> String {
+        Self.udKey(for: model)
+    }
+
+    /// Reads the persisted cooldown expiry for a model from UserDefaults.
+    /// Returns nil if no entry exists.
+    private func persistedExpiry(for model: String) -> Date? {
+        let timestamp = UserDefaults.standard.double(forKey: udKey(model))
+        guard timestamp > 0 else { return nil }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    /// Writes a cooldown expiry date for a model to UserDefaults as a Unix timestamp.
+    private func persistExpiry(_ date: Date, for model: String) {
+        UserDefaults.standard.set(date.timeIntervalSince1970, forKey: udKey(model))
+    }
+
+    /// Removes a model's cooldown entry from UserDefaults once it has expired.
+    private func clearPersistedExpiry(for model: String) {
+        UserDefaults.standard.removeObject(forKey: udKey(model))
+    }
+}

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -2,6 +2,9 @@ import Foundation
 
 enum PostProcessingError: LocalizedError {
     case requestFailed(Int, String)
+    /// The model rejected the request because its rate limit was exceeded.
+    /// Carries the model name and the number of seconds until the limit resets.
+    case rateLimited(model: String, retryAfter: TimeInterval)
     case invalidResponse(String)
     case invalidInput(String)
     case emptyOutput
@@ -12,6 +15,8 @@ enum PostProcessingError: LocalizedError {
         switch self {
         case .requestFailed(let statusCode, let details):
             "Post-processing failed with status \(statusCode): \(details)"
+        case .rateLimited(let model, let retryAfter):
+            "Model \(model) rate-limited — retry in \(Int(retryAfter))s"
         case .invalidResponse(let details):
             "Invalid post-processing response: \(details)"
         case .invalidInput(let details):
@@ -254,8 +259,17 @@ Behavior:
         customSystemPrompt: String = "",
         outputLanguage: String = ""
     ) async throws -> PostProcessingResult {
-        let primaryModel = resolvedPrimaryModel()
+        var primaryModel = resolvedPrimaryModel()
         let retryModel = resolvedRetryModel(for: primaryModel)
+
+        // Circuit breaker: if the primary model has an active cooldown from a recent 429,
+        // switch to the fallback up-front — no wasted RPM slot on a doomed request.
+        // Reassigning primaryModel (not a new local) keeps the call site below byte-identical
+        // to upstream, so it never collides with the context-format parameter refactor.
+        if await LLMCooldownManager.shared.isInCooldown(primaryModel), let fallback = retryModel {
+            primaryModel = fallback
+        }
+
         do {
             return try await process(
                 transcript: transcript,
@@ -266,11 +280,17 @@ Behavior:
                 outputLanguage: outputLanguage
             )
         } catch let error as PostProcessingError {
+            // Unified fallback policy: decide whether to retry on the other model.
             let shouldFallback: Bool
             switch error {
+            case .rateLimited(_, let retryAfter):
+                // Register how long to avoid this model, then fall back to the other one.
+                await LLMCooldownManager.shared.setCooldown(primaryModel, retryAfterSeconds: retryAfter)
+                shouldFallback = true
             case .requestFailed(let statusCode, _):
                 shouldFallback = statusCode == 429
             case .emptyOutput:
+                // Empty output is a soft failure; try the other model once before giving up.
                 shouldFallback = true
             case .suspectedInstructionExecution:
                 shouldFallback = true
@@ -282,7 +302,8 @@ Behavior:
                 throw error
             }
 
-            guard let retryModel else {
+            // Guard against re-trying the same model when primaryModel is already the fallback.
+            guard let retryModel, primaryModel != retryModel else {
                 throw error
             }
 
@@ -311,8 +332,15 @@ Behavior:
         customVocabulary: [String],
         outputLanguage: String = ""
     ) async throws -> PostProcessingResult {
-        let primaryModel = resolvedPrimaryModel()
+        var primaryModel = resolvedPrimaryModel()
         let retryModel = resolvedRetryModel(for: primaryModel)
+
+        // Circuit breaker: switch to the fallback up-front when the primary is cooling down.
+        // Reassigning primaryModel keeps the call site below byte-identical to upstream.
+        if await LLMCooldownManager.shared.isInCooldown(primaryModel), let fallback = retryModel {
+            primaryModel = fallback
+        }
+
         do {
             return try await processCommandTransform(
                 selectedText: selectedText,
@@ -323,11 +351,15 @@ Behavior:
                 outputLanguage: outputLanguage
             )
         } catch let error as PostProcessingError {
+            // Unified fallback policy: decide whether to retry on the other model.
             let shouldFallback: Bool
             switch error {
-            case .requestFailed(let statusCode, _):
-                shouldFallback = statusCode == 429
+            case .rateLimited(_, let retryAfter):
+                // Register how long to avoid this model, then fall back to the other one.
+                await LLMCooldownManager.shared.setCooldown(primaryModel, retryAfterSeconds: retryAfter)
+                shouldFallback = true
             case .emptyOutput:
+                // Empty output is a soft failure; try the other model once before giving up.
                 shouldFallback = true
             default:
                 shouldFallback = false
@@ -337,7 +369,8 @@ Behavior:
                 throw error
             }
 
-            guard let retryModel else {
+            // Guard against re-trying the same model when primaryModel is already the fallback.
+            guard let retryModel, primaryModel != retryModel else {
                 throw error
             }
 
@@ -465,6 +498,16 @@ Model: \(model)
         }
 
         guard httpResponse.statusCode == 200 else {
+            // For 429 responses, read the retry-after duration from headers so the circuit
+            // breaker knows exactly when the model becomes available again.
+            if httpResponse.statusCode == 429 {
+                // Priority order: retry-after (seconds integer) → x-ratelimit-reset-tokens ("8.192s") → 60s fallback.
+                // The 60s fallback is only used when Groq omits both timing headers, which is rare.
+                let retryAfter = httpResponse.value(forHTTPHeaderField: "retry-after").flatMap(Double.init)
+                    ?? httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-tokens").flatMap(Self.parseGroqDuration)
+                    ?? 60.0
+                throw PostProcessingError.rateLimited(model: model, retryAfter: retryAfter)
+            }
             let message = String(data: data, encoding: .utf8) ?? ""
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
         }
@@ -476,7 +519,7 @@ Model: \(model)
               let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
-        
+
         var content = rawContent
         if config.shouldStripThinkTags {
             content = ModelConfiguration.stripThinkTags(content)
@@ -596,6 +639,13 @@ Model: \(model)
         }
 
         guard httpResponse.statusCode == 200 else {
+            // Same 429 handling as in process(): read retry-after to feed the circuit breaker.
+            if httpResponse.statusCode == 429 {
+                let retryAfter = httpResponse.value(forHTTPHeaderField: "retry-after").flatMap(Double.init)
+                    ?? httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-tokens").flatMap(Self.parseGroqDuration)
+                    ?? 60.0
+                throw PostProcessingError.rateLimited(model: model, retryAfter: retryAfter)
+            }
             let message = String(data: data, encoding: .utf8) ?? ""
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
         }
@@ -607,7 +657,7 @@ Model: \(model)
               let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
-        
+
         var content = rawContent
         if config.shouldStripThinkTags {
             content = ModelConfiguration.stripThinkTags(content)
@@ -724,5 +774,13 @@ Model: \(model)
 
         guard !terms.isEmpty else { return "" }
         return terms.joined(separator: ", ")
+    }
+
+    /// Converts Groq's duration string format (e.g. "8.192s") to a TimeInterval.
+    /// Used to parse x-ratelimit-reset-tokens as a fallback when retry-after is absent.
+    private static func parseGroqDuration(_ value: String) -> TimeInterval? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasSuffix("s") else { return nil }
+        return Double(trimmed.dropLast())
     }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -56,6 +56,10 @@ struct ProviderSettingsFields: View {
     @State private var postProcessingModelDraft: String = ""
     @State private var postProcessingFallbackModelDraft: String = ""
     @State private var contextModelDraft: String = ""
+    /// Updated by the cooldown timer so warning labels clear at expiry without user interaction.
+    @State private var now: Date = Date()
+    /// Tracks whether the Settings window is the frontmost active window.
+    @Environment(\.controlActiveState) private var controlActiveState
 
     let showsModelDescription: Bool
 
@@ -92,6 +96,27 @@ struct ProviderSettingsFields: View {
         postProcessingFallbackModelDraft = trimmed
         guard appState.postProcessingFallbackModel != trimmed else { return }
         appState.postProcessingFallbackModel = trimmed
+    }
+
+    /// True only when all three conditions are met: a cooldown warning is visible, the
+    /// Settings window is the frontmost key window, and the view is on the General tab
+    /// (which is implicit — this view leaves the hierarchy when any other tab is selected).
+    /// When false, no timer runs and no CPU is spent.
+    private var shouldRunCooldownTimer: Bool {
+        controlActiveState == .key &&
+        (dailyCooldownExpiry(for: appState.postProcessingModel) != nil ||
+         dailyCooldownExpiry(for: appState.postProcessingFallbackModel) != nil)
+    }
+
+    /// Reads the persisted daily-limit expiry date for a model directly from UserDefaults.
+    /// Uses the shared key from LLMCooldownManager to avoid duplicating the storage contract.
+    /// Returns nil if no daily limit is active or if the entry has already expired.
+    private func dailyCooldownExpiry(for model: String) -> Date? {
+        let key = LLMCooldownManager.udKey(for: model)
+        let timestamp = UserDefaults.standard.double(forKey: key)
+        guard timestamp > 0 else { return nil }
+        let date = Date(timeIntervalSince1970: timestamp)
+        return date > now ? date : nil
     }
 
     private func commitContextModel() {
@@ -164,6 +189,18 @@ struct ProviderSettingsFields: View {
                 }
             )
 
+            // Shows when this model has hit its daily Groq rate limit.
+            // Disappears automatically once the limit window resets.
+            if let expiry = dailyCooldownExpiry(for: appState.postProcessingModel) {
+                Label {
+                    Text("Daily limit reached — resets at \(expiry.formatted(date: .omitted, time: .shortened))")
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                }
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
+
             ModelDropdownView(
                 title: "Post-Processing Fallback Model",
                 subtitle: "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.",
@@ -176,6 +213,18 @@ struct ProviderSettingsFields: View {
                     appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
                 }
             )
+
+            // Shows when the fallback model has also hit its daily limit.
+            // In this state, both models are unavailable until their limits reset.
+            if let expiry = dailyCooldownExpiry(for: appState.postProcessingFallbackModel) {
+                Label {
+                    Text("Fallback daily limit reached — resets at \(expiry.formatted(date: .omitted, time: .shortened))")
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                }
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
 
             ModelDropdownView(
                 title: "Context Model",
@@ -340,8 +389,17 @@ struct ProviderSettingsFields: View {
                 contextModelDraft = value
             }
         }
+        // Tick every 5s only when: a warning is visible, the window is key, and this view
+        // is on screen (General tab). SwiftUI removes this timer when any condition turns false.
+        if shouldRunCooldownTimer {
+            Color.clear.frame(width: 0, height: 0)
+                .onReceive(Timer.publish(every: 5, on: .main, in: .common).autoconnect()) { value in
+                    now = value
+                }
+        }
     }
 }
+
 
 // MARK: - Settings
 


### PR DESCRIPTION
## Summary

- **Problem:** When the post-processing model's provider returns **HTTP 429 (rate limit)**, FreeFlow falls back to the secondary model for that request — but the next transcription retries the primary from scratch, paying an unnecessary round-trip and wasting a request slot on a call that will be rejected again.
- **Root cause:** `PostProcessingService` is instantiated per-request with no shared memory of prior failures between calls.
- **Fix:** A new `LLMCooldownManager` actor reads the standard **`retry-after`** header from the provider's 429 response and acts as a circuit breaker: subsequent requests skip the rate-limited model entirely until the cooldown expires. Because `429` and `retry-after` are HTTP standards, this works with **any OpenAI-compatible provider** (Groq is the default).

## What changed

### `Sources/LLMCooldownManager.swift` (new file)
Swift 6 `actor` with `static let shared` for app-wide state. Tracks per-model cooldowns in two tiers:
- **Minute-level limits** (`retry-after < 1 hour`): stored in memory, cleared on app restart.
- **Daily limits** (`retry-after ≥ 1 hour`): persisted to `UserDefaults` so the cooldown survives app restarts and is visible in Settings.

### `Sources/PostProcessingService.swift`
- Added `PostProcessingError.rateLimited(model: String, retryAfter: TimeInterval)` case.
- `executeAPIRequest`: on HTTP 429, reads `retry-after` → `x-ratelimit-reset-tokens` → 60s fallback (in priority order) and throws `.rateLimited` instead of `.requestFailed`.
- `processWithFallback` and `processCommandTransformWithFallback`: check `LLMCooldownManager.shared.isInCooldown` before selecting the model; register cooldown on `.rateLimited` and immediately retry with the fallback model.

### `Sources/SettingsView.swift`
Added two read-only indicators in **Advanced Provider Settings**, below each model dropdown, that appear only when a daily limit is active (reads directly from `UserDefaults` — no async required). Disappear automatically once the limit window resets.

## Behavior after this change

```
New transcription
    ↓
isInCooldown(primary)?
    ├── YES → use fallback directly (zero extra latency)
    └── NO  → try primary
              ├── 200 ✓ → result
              ├── rateLimited(retryAfter: Xs)
              │   ├── X < 3600 → setCooldown in-memory
              │   └── X ≥ 3600 → setCooldown + UserDefaults + indicator in Settings
              │   → try fallback (immediate response)
              └── emptyOutput → try fallback (existing behavior preserved)
```

## Notes for reviewer

- Model preferences (`postProcessingModel`, `postProcessingFallbackModel`) are **not changed**.
- When no 429 has occurred, `isInCooldown` always returns `false` — behavior is **identical to before**.
- **Provider-agnostic — works with any OpenAI-compatible provider, not just Groq.** The breaker triggers on the standard HTTP `429` status and reads the standard `retry-after` header for the cooldown duration; both are HTTP standards, so any provider configured via the **API Base URL** is covered. Groq's `x-ratelimit-reset-tokens` is only a *secondary* source for the duration — the protection itself is universal; only that extra precision is Groq-specific.
- The **60s fallback** kicks in when a provider supplies *neither* `retry-after` *nor* `x-ratelimit-reset-tokens` (e.g. a non-Groq provider, or rare Groq cases) — so the breaker still works, just with a fixed window. It is not a user-facing wait — it is the circuit-breaker window during which requests go to the fallback model immediately.
- This change layers cleanly on top of the existing instruction-execution guard: the unified fallback policy in `processWithFallback` preserves both the `.suspectedInstructionExecution` handling (raw transcript returned on a guarded retry) and this PR's rate-limit circuit breaker — neither supersedes the other.
- No changes to `ModelConfiguration.swift`, `LLMAPITransport.swift`, `AppState.swift`, or any other files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model cooldown tracking to help the app avoid repeatedly using unavailable providers.
  * Added clear on-screen warnings when a model or fallback has hit its daily limit, including the reset time.

* **Bug Fixes**
  * Improved fallback behavior so the app switches models more reliably after rate limits or empty responses.
  * Added better handling for rate-limit responses, including retry timing when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->