### PR TITLE
Distinguish network outages from slow-provider timeouts in transcription errors

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6,6 +6,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        NetworkMonitor.shared.start()
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleShowSetup),

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2241,6 +2241,57 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return "Failed to start recording: \(error.localizedDescription)"
     }
 
+    /// Turn a transcription failure into a concise, user-facing message,
+    /// classifying by the locale-independent `URLError.Code` rather than the
+    /// system's English description (which varies across releases and locales).
+    private func formattedTranscriptionError(_ error: Error) -> String {
+        if let code = Self.urlErrorCode(in: error) {
+            switch code {
+            case .notConnectedToInternet, .networkConnectionLost,
+                 .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed:
+                return "No internet — check connection"
+            case .timedOut:
+                return NetworkMonitor.shared.isOnline
+                    ? "Request timed out — try again"
+                    : "No internet — check connection"
+            default:
+                break
+            }
+        }
+
+        let lower = error.localizedDescription.lowercased()
+        if lower.contains("timed out") || lower.contains("timeout") {
+            return NetworkMonitor.shared.isOnline
+                ? "Request timed out — try again"
+                : "No internet — check connection"
+        }
+        if lower.contains("offline") || lower.contains("internet connection")
+            || lower.contains("not connected") || lower.contains("network")
+            || lower.contains("cannot find host") {
+            return "No internet — check connection"
+        }
+        return error.localizedDescription
+    }
+
+    /// Find a `URLError.Code` anywhere in the error's underlying-error chain,
+    /// so a wrapped transport error is still classified by its root cause.
+    private static func urlErrorCode(in error: Error) -> URLError.Code? {
+        var current: Error? = error
+        var depth = 0
+        while let err = current, depth < 8 {
+            if let urlError = err as? URLError {
+                return urlError.code
+            }
+            let nsError = err as NSError
+            if nsError.domain == NSURLErrorDomain {
+                return URLError.Code(rawValue: nsError.code)
+            }
+            current = nsError.userInfo[NSUnderlyingErrorKey] as? Error
+            depth += 1
+        }
+        return nil
+    }
+
     func showMicrophonePermissionAlert() {
         let alert = NSAlert()
         alert.messageText = "Microphone Permission Required"
@@ -2682,7 +2733,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         guard self.isTranscribing else { return }
                         self.transcriptionTask = nil
                         self.transcribingAudioFileName = nil
-                        self.errorMessage = error.localizedDescription
+                        self.errorMessage = self.formattedTranscriptionError(error)
                         self.isTranscribing = false
                         self.endCriticalDictationActivity()
                         self.statusText = "Error"

--- a/Sources/NetworkMonitor.swift
+++ b/Sources/NetworkMonitor.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Network
+
+/// Live network-reachability tracker. A single long-running `NWPathMonitor`
+/// keeps `isOnline` current so transcription error classification can tell a
+/// real network outage apart from a slow provider — a hung socket trips the
+/// request timeout, which otherwise looks identical to "the server is slow."
+final class NetworkMonitor {
+    static let shared = NetworkMonitor()
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.zachlatta.freeflow.network-monitor")
+    private let lock = NSLock()
+    private var started = false
+
+    // Default to online so the first request, before the monitor's first path
+    // update lands, is never wrongly blamed on the network.
+    private var _isOnline = true
+
+    private init() {}
+
+    /// Current reachability. Safe to read from any thread.
+    var isOnline: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isOnline
+    }
+
+    /// Begin monitoring. Idempotent — call once at launch.
+    func start() {
+        lock.lock()
+        if started {
+            lock.unlock()
+            return
+        }
+        started = true
+        lock.unlock()
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            let online = path.status == .satisfied
+            self.lock.lock()
+            self._isOnline = online
+            self.lock.unlock()
+        }
+        monitor.start(queue: queue)
+    }
+}


### PR DESCRIPTION
## Summary

When a transcription request fails, the message shown to the user is the raw system `localizedDescription`. A dropped connection surfaces as **"The Internet connection appears to be offline."** — technically accurate, but it reads like an app bug and buries the actual cause.

This classifies transcription errors by the locale-independent `URLError.Code` instead of matching the system's English description, and adds a lightweight `NetworkMonitor` so a request *timeout* can be told apart from a genuine *outage* (a hung socket trips the request timeout and otherwise looks identical to a slow provider).

## What changes

- **`NetworkMonitor`** — a long-running `NWPathMonitor` exposing `isOnline`. Started once at launch, read-only on the hot path, so there is no added cost to a successful dictation.
- **`formattedTranscriptionError(_:)`** — classifies by `URLError.Code`, walking the underlying-error chain so a wrapped transport error is still caught. Connectivity failures collapse to a single clear **"No internet — check connection"**; a timeout while still online stays **"Request timed out — try again"**.

## Testing performed

Tested on macOS 15 (Apple silicon), Groq transcription provider.

| Scenario | Result |
|---|---|
| Interface disabled (Wi-Fi off), then dictate | Toast reads **"No internet — check connection"** instead of the raw system string |
| Branch built against current `main` | Compiles clean, no new warnings |
| Repeated dictation round-trips, network up | Unaffected — transcribes and pastes as before (exercised in daily use on a build carrying this classification; not separately re-run on this isolated branch) |

**Approaches tried:** matching the error's English `localizedDescription` was the original approach. It breaks because the string varies across releases and locales ("offline" vs "not connected" vs "lost"), so some connectivity failures fell through the phrase checks and displayed raw. Classifying by `URLError.Code` is stable across both.

<img src="https://assets.themarketingshow.com/bugs/freeflow/network-error-no-internet-toast-2026-06-20.png" width="500" alt="Transcription error toast reading 'No internet — check connection'">

## Test plan for reviewer

- [ ] Disable Wi-Fi, then dictate — expect **"No internet — check connection"**.
- [ ] With the network up, dictate normally — expect a normal transcript, no regression.
- [ ] Throttle/blackhole the provider to force a timeout while still online — expect **"Request timed out — try again"**.

## Scope

Deliberately minimal: detection is limited to what `NWPathMonitor` reports for free. The harder "connected to a router with a dead uplink" case — where the OS still reports a satisfied path — is a known limitation left out of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time network connectivity monitoring to improve app reliability
  * Enhanced transcription failure error messages with clearer network diagnostics, distinguishing between connection issues and timeouts based on live network status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->