### PR TITLE
Show transcription errors in the drop-down overlay

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2742,11 +2742,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         guard self.isTranscribing else { return }
                         self.transcriptionTask = nil
                         self.transcribingAudioFileName = nil
-                        self.errorMessage = self.formattedTranscriptionError(error)
+                        let userFacingErrorMessage = self.formattedTranscriptionError(error)
+                        self.errorMessage = userFacingErrorMessage
                         self.isTranscribing = false
                         self.endCriticalDictationActivity()
                         self.statusText = "Error"
-                        self.overlayManager.dismiss()
+                        self.overlayManager.showError(userFacingErrorMessage)
                         self.lastPostProcessedTranscript = ""
                         self.lastRawTranscript = ""
                         self.lastContextSummary = ""

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -340,14 +340,17 @@ final class RecordingOverlayManager {
     }
 
     /// True iff the overlay renders as wings flanking the notch (notched display
-    /// + use_compact_overlay on). updateAvailable still uses the drop-down pill.
+    /// + use_compact_overlay on). updateAvailable and error toasts still use
+    /// the drop-down pill.
     private var useWingedLayout: Bool {
         guard screenHasNotch else { return false }
         let useCompact = (UserDefaults.standard.object(forKey: "use_compact_overlay") as? Bool) ?? true
         guard useCompact else { return false }
         switch overlayState.phase {
-        case .recording, .initializing, .transcribing, .feedback:
+        case .recording, .initializing, .transcribing:
             return true
+        case .feedback:
+            return overlayState.errorMessage?.isEmpty ?? true
         case .updateAvailable:
             return false
         }
@@ -379,12 +382,17 @@ final class RecordingOverlayManager {
 
         let width = overlayWidth
         let useCompact = (UserDefaults.standard.object(forKey: "use_compact_overlay") as? Bool) ?? true
+        let forceDropDownPill = overlayState.phase == .feedback
+            && !(overlayState.errorMessage?.isEmpty ?? true)
         // Compact mode: overlay sits flush with the menu bar on every display.
         // notchOverlap equals the menu-bar height on non-notched screens too,
         // so zero protrusion is universal — not notch-only. The legacy
         // 38pt drop-down pill remains available when use_compact_overlay
-        // is explicitly toggled off.
-        let height: CGFloat = useCompact ? notchOverlap : 38 + (screenHasNotch ? notchOverlap : 0)
+        // is explicitly toggled off. Error toasts also force the drop-down
+        // height so messages stay readable even when compact overlay is enabled.
+        let height: CGFloat = (useCompact && !forceDropDownPill)
+            ? notchOverlap
+            : 38 + (screenHasNotch ? notchOverlap : 0)
         let x = screen.frame.midX - width / 2
         let y = screen.frame.maxY - height
         return NSRect(x: x, y: y, width: width, height: height)


### PR DESCRIPTION
## Summary
- Keep transcription failures visible in the overlay instead of dismissing it immediately. Fixes #240 
- Route transcription errors into the feedback overlay as a user-facing message.
- Force the drop-down pill layout for error toasts so the message remains readable even when compact overlay mode is enabled.

## Testing
- Not run (PR content only).
- Reviewed the diff to confirm transcription errors now call `showError(...)` instead of `dismiss()`.
- Reviewed overlay layout logic to confirm feedback errors bypass winged compact layout and use the drop-down height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription error handling by displaying clearer, user-friendly error messages through an enhanced notification system that provides better feedback when transcription fails
  * Enhanced overlay layout and sizing logic to ensure error messages remain consistently visible and readable across all modes, particularly when compact display settings are enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->