### PR TITLE
feat: configurable recording-indicator position (top vs near cursor)

### DIFF
--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -57,12 +57,18 @@ private func makeNotchContent<V: View>(
     width: CGFloat,
     height: CGFloat,
     cornerRadius: CGFloat,
-    rootView: V
+    rootView: V,
+    roundsTopCorners: Bool = false
 ) -> NSView {
     let shaped = rootView
         .frame(width: width, height: height)
         .background(Color.black)
-        .clipShape(UnevenRoundedRectangle(bottomLeadingRadius: cornerRadius, bottomTrailingRadius: cornerRadius))
+        .clipShape(UnevenRoundedRectangle(
+            topLeadingRadius: roundsTopCorners ? cornerRadius : 0,
+            bottomLeadingRadius: cornerRadius,
+            bottomTrailingRadius: cornerRadius,
+            topTrailingRadius: roundsTopCorners ? cornerRadius : 0
+        ))
 
     let hosting = NSHostingView(rootView: shaped)
     hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
@@ -73,6 +79,8 @@ private func makeNotchContent<V: View>(
 // MARK: - Manager
 
 final class RecordingOverlayManager {
+    private static let nearCursorOverlayGap: CGFloat = 8
+
     private var overlayWindow: NSPanel?
     private let overlayState = RecordingOverlayState()
     private var lockedOverlayWidth: CGFloat?
@@ -106,6 +114,17 @@ final class RecordingOverlayManager {
         }
     }
 
+    /// `0` keeps the drop-down overlay at the top of the display. `1` moves
+    /// only the standard pill near the pointer; winged notch layout stays top-
+    /// anchored because it is part of the menu-bar affordance.
+    private var overlayVerticalPosition: Int {
+        UserDefaults.standard.integer(forKey: "overlay_vertical_position")
+    }
+
+    private var usesNearCursorOverlayPlacement: Bool {
+        overlayVerticalPosition == 1 && !useWingedLayout
+    }
+
     private var screenHasNotch: Bool {
         guard let screen = targetScreen else { return false }
         return screen.safeAreaInsets.top > 0
@@ -126,6 +145,33 @@ final class RecordingOverlayManager {
     private var overlayAcceptsMouseEvents: Bool {
         (overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle)
             || overlayState.phase == .updateAvailable
+    }
+
+    private func screen(containing point: NSPoint, fallback: NSScreen) -> NSScreen {
+        NSScreen.screens.first { screen in
+            screen.frame.contains(point)
+        } ?? fallback
+    }
+
+    private func clampedFrame(_ frame: NSRect, to visibleFrame: NSRect) -> NSRect {
+        let maxX = visibleFrame.maxX - frame.width
+        let maxY = visibleFrame.maxY - frame.height
+
+        let x: CGFloat
+        if maxX >= visibleFrame.minX {
+            x = min(max(frame.origin.x, visibleFrame.minX), maxX)
+        } else {
+            x = visibleFrame.midX - frame.width / 2
+        }
+
+        let y: CGFloat
+        if maxY >= visibleFrame.minY {
+            y = min(max(frame.origin.y, visibleFrame.minY), maxY)
+        } else {
+            y = visibleFrame.midY - frame.height / 2
+        }
+
+        return NSRect(x: x, y: y, width: frame.width, height: frame.height)
     }
 
     func showInitializing(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
@@ -258,7 +304,19 @@ final class RecordingOverlayManager {
 
         guard let screen = targetScreen else { return }
 
-        let hiddenFrame = NSRect(x: frame.origin.x, y: screen.frame.maxY, width: frame.width, height: frame.height)
+        let hiddenFrame: NSRect
+        if usesNearCursorOverlayPlacement {
+            let overlayScreen = self.screen(containing: NSEvent.mouseLocation, fallback: screen)
+            let entranceFrame = NSRect(
+                x: frame.origin.x,
+                y: frame.origin.y + frame.height,
+                width: frame.width,
+                height: frame.height
+            )
+            hiddenFrame = clampedFrame(entranceFrame, to: overlayScreen.visibleFrame)
+        } else {
+            hiddenFrame = NSRect(x: frame.origin.x, y: screen.frame.maxY, width: frame.width, height: frame.height)
+        }
         panel.setFrame(hiddenFrame, display: true)
         panel.alphaValue = 1
         panel.orderFrontRegardless()
@@ -307,10 +365,14 @@ final class RecordingOverlayManager {
             )
         }
 
+        let usesNearCursorPosition = usesNearCursorOverlayPlacement
+        let cornerRadius: CGFloat = usesNearCursorPosition ? 12 : (screenHasNotch ? 18 : 12)
+        let notchTopPadding: CGFloat = usesNearCursorPosition ? 0 : (screenHasNotch ? notchOverlap : 0)
+
         return makeNotchContent(
             width: frame.width,
             height: frame.height,
-            cornerRadius: screenHasNotch ? 18 : 12,
+            cornerRadius: cornerRadius,
             rootView: AnyView(
                 RecordingOverlayView(
                     state: overlayState,
@@ -321,8 +383,9 @@ final class RecordingOverlayManager {
                         self?.onUpdateOverlayPressed?()
                     }
                 )
-                .padding(.top, screenHasNotch ? notchOverlap : 0)
-            )
+                .padding(.top, notchTopPadding)
+            ),
+            roundsTopCorners: usesNearCursorPosition
         )
     }
 
@@ -363,23 +426,28 @@ final class RecordingOverlayManager {
     static let rightWingWidth: CGFloat = wingWidth
 
     private var overlayFrame: NSRect {
-        guard let screen = targetScreen else { return .zero }
+        guard let targetScreen = targetScreen else { return .zero }
 
         if useWingedLayout {
             // Anchor to the screen's auxiliary-area boundaries of the notch;
             // panel height matches the menu-bar overlap so nothing protrudes below.
             let nWidth = notchWidth
-            let nLeftX = screen.auxiliaryTopLeftArea?.maxX
-                ?? (screen.frame.midX - nWidth / 2)
+            let nLeftX = targetScreen.auxiliaryTopLeftArea?.maxX
+                ?? (targetScreen.frame.midX - nWidth / 2)
             let leftWing = Self.leftWingWidth
             let rightWing = Self.rightWingWidth
             let panelHeight = notchOverlap
             let panelWidth = leftWing + nWidth + rightWing
             let panelX = nLeftX - leftWing
-            let panelY = screen.frame.maxY - panelHeight
+            let panelY = targetScreen.frame.maxY - panelHeight
             return NSRect(x: panelX, y: panelY, width: panelWidth, height: panelHeight)
         }
 
+        let usesNearCursorPosition = overlayVerticalPosition == 1
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = usesNearCursorPosition
+            ? self.screen(containing: mouseLocation, fallback: targetScreen)
+            : targetScreen
         let width = overlayWidth
         let useCompact = (UserDefaults.standard.object(forKey: "use_compact_overlay") as? Bool) ?? true
         let forceDropDownPill = overlayState.phase == .feedback
@@ -390,12 +458,25 @@ final class RecordingOverlayManager {
         // 38pt drop-down pill remains available when use_compact_overlay
         // is explicitly toggled off. Error toasts also force the drop-down
         // height so messages stay readable even when compact overlay is enabled.
-        let height: CGFloat = (useCompact && !forceDropDownPill)
-            ? notchOverlap
-            : 38 + (screenHasNotch ? notchOverlap : 0)
+        let height: CGFloat
+        if usesNearCursorPosition {
+            height = 38
+        } else {
+            height = (useCompact && !forceDropDownPill)
+                ? notchOverlap
+                : 38 + (screenHasNotch ? notchOverlap : 0)
+        }
         let x = screen.frame.midX - width / 2
         let y = screen.frame.maxY - height
-        return NSRect(x: x, y: y, width: width, height: height)
+        guard usesNearCursorPosition else {
+            return NSRect(x: x, y: y, width: width, height: height)
+        }
+
+        let nearCursorY = mouseLocation.y - Self.nearCursorOverlayGap - height
+        return clampedFrame(
+            NSRect(x: x, y: nearCursorY, width: width, height: height),
+            to: screen.visibleFrame
+        )
     }
 
     private var overlayWidth: CGFloat {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import ApplicationServices
 
 // MARK: - State
 
@@ -151,6 +152,23 @@ final class RecordingOverlayManager {
         NSScreen.screens.first { screen in
             screen.frame.contains(point)
         } ?? fallback
+    }
+
+    private func nearCursorAnchorPoint() -> NSPoint {
+        let mouseLocation = NSEvent.mouseLocation
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedValue: CFTypeRef?, rangeValue: CFTypeRef?, boundsValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focusedValue) == .success,
+              let focusedRaw = focusedValue, CFGetTypeID(focusedRaw) == AXUIElementGetTypeID() else { return mouseLocation }
+        let focusedElement = unsafeBitCast(focusedRaw, to: AXUIElement.self)
+        guard AXUIElementCopyAttributeValue(focusedElement, kAXSelectedTextRangeAttribute as CFString, &rangeValue) == .success,
+              let rangeRaw = rangeValue, CFGetTypeID(rangeRaw) == AXValueGetTypeID(),
+              AXUIElementCopyParameterizedAttributeValue(focusedElement, kAXBoundsForRangeParameterizedAttribute as CFString, rangeRaw, &boundsValue) == .success,
+              let boundsRaw = boundsValue, CFGetTypeID(boundsRaw) == AXValueGetTypeID() else { return mouseLocation }
+        var rect = CGRect.zero
+        guard AXValueGetValue(unsafeBitCast(boundsRaw, to: AXValue.self), .cgRect, &rect), rect.height > 0, rect != .zero else { return mouseLocation }
+        let mainHeight = NSScreen.screens.first?.frame.height ?? mouseLocation.y + rect.maxY
+        return NSPoint(x: rect.midX, y: mainHeight - rect.maxY)
     }
 
     private func clampedFrame(_ frame: NSRect, to visibleFrame: NSRect) -> NSRect {
@@ -444,7 +462,7 @@ final class RecordingOverlayManager {
         }
 
         let usesNearCursorPosition = overlayVerticalPosition == 1
-        let mouseLocation = NSEvent.mouseLocation
+        let mouseLocation = usesNearCursorPosition ? nearCursorAnchorPoint() : NSEvent.mouseLocation
         let screen = usesNearCursorPosition
             ? self.screen(containing: mouseLocation, fallback: targetScreen)
             : targetScreen

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -466,7 +466,9 @@ final class RecordingOverlayManager {
                 ? notchOverlap
                 : 38 + (screenHasNotch ? notchOverlap : 0)
         }
-        let x = screen.frame.midX - width / 2
+        let x = usesNearCursorPosition
+            ? mouseLocation.x - width / 2
+            : screen.frame.midX - width / 2
         let y = screen.frame.maxY - height
         guard usesNearCursorPosition else {
             return NSRect(x: x, y: y, width: width, height: height)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -465,6 +465,7 @@ struct GeneralSettingsView: View {
     @Environment(\.openURL) private var openURL
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
     @AppStorage("overlay_display_id") private var overlayDisplayID = 0
+    @AppStorage("overlay_vertical_position") private var overlayVerticalPosition = 0
     @AppStorage("use_compact_overlay") private var useCompactOverlay = true
     @State private var screensVersion = 0
     @State private var apiKeyInput: String = ""
@@ -1068,6 +1069,10 @@ struct GeneralSettingsView: View {
             Divider()
 
             overlayDisplaySection
+
+            Divider()
+
+            overlayVerticalPositionSection
         }
     }
 
@@ -1112,6 +1117,24 @@ struct GeneralSettingsView: View {
         // reopening Settings. screensVersion is just a cache-buster.
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)) { _ in
             screensVersion &+= 1
+        }
+    }
+
+    /// Picks whether the drop-down recording overlay stays at the top of the
+    /// display or appears near the pointer while dictation is active.
+    private var overlayVerticalPositionSection: some View {
+        HStack {
+            Text("Show at")
+                .font(.system(size: 13))
+            Spacer()
+            Picker("", selection: $overlayVerticalPosition) {
+                Text("Top of screen (default)").tag(0)
+                Text("Near cursor").tag(1)
+            }
+            .labelsHidden()
+            .accessibilityLabel("Show at")
+            .pickerStyle(.menu)
+            .frame(maxWidth: 240)
         }
     }
 


### PR DESCRIPTION
## What

Adds an optional setting to choose where the recording / voice-input indicator appears: keep the current top-of-screen drop-down (default), or show it near the cursor / text caret while dictating.

Closes #212.

## Why

On slow or unstable connections the recording indicator only lives at the top of the screen, so the user has to keep glancing up to confirm dictation is still active. For people dictating into a text field lower on the display, that means looking away from where the text is actually landing. This adds a "Show at" choice so the indicator can follow the active input instead.

## How

Follows the same pattern already used for the multi-display "Show on" picker.

- **`Sources/SettingsView.swift`** — new `@AppStorage("overlay_vertical_position")` key (`0` = top, default; `1` = near cursor) and a small "Show at" `Picker` added to the overlay settings group, mirroring the existing `overlayDisplaySection` layout and accessibility wiring.
- **`Sources/RecordingOverlay.swift`** — the drop-down pill's `overlayFrame` branches on the new key. Position `0` keeps the existing `screen.frame.maxY`-anchored placement byte-for-byte (including notch handling), so existing users see no change. Position `1` anchors the pill just below the active text caret, resolved via the Accessibility API (focused element → selected-text-range bounds), and falls back to `NSEvent.mouseLocation` when AX bounds are unavailable. The result is clamped fully inside the target screen's `visibleFrame` so it never clips at an edge, the entrance animation slides locally instead of dropping from the menu bar, and the pill rounds all four corners since it is no longer flush with the top. The minimalist notch / winged layout stays top-anchored.

## Behavior

- **Default (top):** unchanged, including on notched displays.
- **Near cursor:** the pill appears just below the focused caret (or the pointer as a fallback), staying within the active screen's visible frame.
- **Multi-monitor:** near-cursor placement targets the screen the caret / cursor is on and composes with the existing `overlay_display_id` setting.
- **Persistence:** the choice is stored in `UserDefaults` (`@AppStorage`) and survives relaunch.
- **Edge clamp:** near a bottom or right edge, the panel is kept fully on-screen rather than rendering partially off-display.

## Testing

Built locally with `make CODESIGN_IDENTITY=-` (ad-hoc signed) against the macOS SDK — clean compile of all sources including the two changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable recording overlay placement via new "Show at" setting in preferences
  * Users can now choose between top-of-screen or near-cursor positioning for the recording overlay during dictation
  * Near-cursor placement smoothly animates the overlay from the cursor position

<!-- end of auto-generated comment: release notes by coderabbit.ai -->