### PR TITLE
Multi-toggle for what App Context sends (Off / App summary / Screenshot LLM) + per-app "send screenshot" allow-list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ endif
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 
+# AppContextService now depends on this source, so the test build needs it too.
+$(TEST_RUNNER): Sources/AppContextSource.swift
+
 test: $(TEST_RUNNER)
 	@$(TEST_RUNNER)
 
@@ -79,7 +82,7 @@ $(TEST_RUNNER): Sources/AppContextService.swift Sources/LLMAPITransport.swift So
 		-o "$(TEST_RUNNER)" \
 		-sdk $(shell xcrun --show-sdk-path) \
 		-target $(ARCH)-apple-macosx13.0 \
-		Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Tests/AppContextServiceTests.swift
+		$^
 
 icon: $(ICON_ICNS)
 

--- a/Sources/AppContextScopeStore.swift
+++ b/Sources/AppContextScopeStore.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+/// Observable store for the per-app screenshot allowlist, persisted to `AppContextSource.appsKey`.
+/// Uses `ObservableObject` (not `@Observable`) because the deployment target is macOS 13.
+@MainActor
+final class AppContextAllowlist: ObservableObject {
+    /// The allowlisted bundle identifiers (persisted).
+    @Published private(set) var bundleIDs: [String]
+
+    /// Loads the persisted allowlist (empty by default).
+    init() {
+        bundleIDs = UserDefaults.standard.array(forKey: AppContextSource.appsKey) as? [String] ?? []
+    }
+
+    /// Adds bundle ids, skipping blanks and duplicates; persists only if something changed.
+    func add(_ ids: [String]) {
+        let existing = Set(bundleIDs)
+        let fresh = ids.filter { !$0.isEmpty && !existing.contains($0) }
+        guard !fresh.isEmpty else { return }
+        bundleIDs.append(contentsOf: fresh)
+        persist()
+    }
+
+    /// Removes a bundle id and persists.
+    func remove(_ id: String) {
+        bundleIDs.removeAll { $0 == id }
+        persist()
+    }
+
+    /// Writes the allowlist back to `UserDefaults`.
+    private func persist() {
+        UserDefaults.standard.set(bundleIDs, forKey: AppContextSource.appsKey)
+    }
+
+    /// Opens the "Add app…" picker and adds the bundle ids of any chosen apps.
+    func presentPicker() {
+        // AppKit open panel rooted at /Applications, limited to .app bundles.
+        let panel = NSOpenPanel()
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        panel.allowedContentTypes = [.application]
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        guard panel.runModal() == .OK else { return }
+        add(panel.urls.compactMap { Bundle(url: $0)?.bundleIdentifier })
+    }
+}
+
+/// Resolves and caches an app's display name + icon from its bundle id (for the chips).
+@MainActor
+enum AppContextAppInfo {
+    private static var cache: [String: (name: String, icon: NSImage?)] = [:]
+
+    /// Returns the app's display name (falls back to the bundle id) and icon. Resolved once per id.
+    static func info(forBundleID id: String) -> (name: String, icon: NSImage?) {
+        if let hit = cache[id] { return hit }
+        // Resolve the app's URL once, then its Finder name and icon (AppKit).
+        let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: id)
+        let name = url.map { FileManager.default.displayName(atPath: $0.path) } ?? id
+        let icon = url.map { NSWorkspace.shared.icon(forFile: $0.path) }
+        let result = (name, icon)
+        cache[id] = result
+        return result
+    }
+}
+
+/// The screenshot scope multiselector: two radio cards plus the per-app chips and "Add app…" picker.
+/// Binds the scope to `AppContextSource.scopeKey` via `@AppStorage` and observes the allowlist store.
+struct ScreenshotScopeSection: View {
+    /// Persisted scope (`"all"` | `"specific"`), defaulting to `all`.
+    @AppStorage(AppContextSource.scopeKey) private var scopeRaw: String = AppContextSource.Scope.all.rawValue
+    /// The allowlist store, owned by this view.
+    @StateObject private var allowlist = AppContextAllowlist()
+    /// Reflects the parent `.disabled()` (true only in Screenshot mode) — used to grey out chip icons.
+    @Environment(\.isEnabled) private var isEnabled
+
+    /// Current scope from the persisted value.
+    private var scope: AppContextSource.Scope { AppContextSource.Scope(rawValue: scopeRaw) ?? .all }
+
+    /// Header + the two scope options, plus the app chips when `specific`.
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Screenshot scope")
+                .font(.caption.weight(.semibold))
+            scopeOption(.all, title: "Send screenshot to all apps", subtitle: "Every app takes a screenshot.")
+            scopeOption(.specific, title: "Only specific apps", subtitle: "Other apps use App summary instead.")
+            if scope == .specific {
+                specificAppsEditor
+            }
+        }
+    }
+
+    /// One selectable scope row in the app's radio-row style (checkmark + blue accent when selected).
+    private func scopeOption(_ option: AppContextSource.Scope, title: String, subtitle: String) -> some View {
+        let selected = scope == option
+        return Button {
+            scopeRaw = option.rawValue
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(selected ? .blue : .secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(selected ? Color.blue.opacity(0.1) : Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(selected ? Color.blue : Color.clear, lineWidth: 1.5)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        // Read the row as one element to VoiceOver, with its selected state.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title). \(subtitle)")
+        .accessibilityAddTraits(selected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    /// The app chips (or an empty-state line) plus the dashed "Add app…" button.
+    private var specificAppsEditor: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if allowlist.bundleIDs.isEmpty {
+                Text("No apps added yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            FlowLayout(spacing: 6) {
+                ForEach(allowlist.bundleIDs, id: \.self) { id in
+                    chip(for: id)
+                }
+                addButton
+            }
+        }
+    }
+
+    /// A removable app chip: icon + name + ✕.
+    private func chip(for id: String) -> some View {
+        let info = AppContextAppInfo.info(forBundleID: id)
+        return HStack(spacing: 6) {
+            if let icon = info.icon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    // Desaturate when the screenshot block is disabled, so the icon dims like the text.
+                    .grayscale(isEnabled ? 0 : 1)
+            }
+            Text(info.name)
+                .font(.caption)
+            Button {
+                allowlist.remove(id)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption2)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .accessibilityLabel("Remove \(info.name)")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color(nsColor: .controlBackgroundColor)))
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.25), lineWidth: 1))
+    }
+
+    /// The dashed "Add app…" button that opens the picker.
+    private var addButton: some View {
+        Button {
+            allowlist.presentPicker()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "plus")
+                Text("Add app…")
+            }
+            .font(.caption)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.5), style: StrokeStyle(lineWidth: 1, dash: [4]))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Add app")
+    }
+}

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -333,8 +333,8 @@ Selected text: \(selectedText ?? "None")
         case .off:
             return ""
         case .metadata:
-            // One AX read: host / web-capable / address-bar focus.
-            let web = AppContextSource.webContext()
+            // One AX read: host / web-capable / address-bar focus (skips if the frontmost app changed).
+            let web = AppContextSource.webContext(expectedBundleID: bundleIdentifier)
             return AppContextSource.metadataSummary(
                 appName: appName,
                 pageTitle: windowTitle,

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -45,6 +45,9 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     private let maxScreenshotDataURILength = 500_000
     private let screenshotCompressionPrimary = 0.5
     private let screenshotMaxDimension: CGFloat
+    /// Forces the vision path on this instance only — set by the "Test Vision Prompt" button on its own
+    /// throwaway service so the test works in any mode/scope. Real dictations use a separate instance.
+    var forceScreenshotForTest = false
     private var contextRequestTimeoutSeconds: TimeInterval {
         let override = UserDefaults.standard.double(forKey: "context_request_timeout_seconds")
         return override > 0 ? override : 20
@@ -176,6 +179,11 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         screenshotDataURL: String?,
         contextSystemPrompt: String
     ) async -> (activity: String, prompt: String)? {
+        // Skip vision/LLM inference unless this app uses Screenshot mode.
+        guard forceScreenshotForTest || AppContextSource.effectiveSource(forBundleID: bundleIdentifier) == .screenshot else {
+            return nil
+        }
+
         let attempts: [(model: String, screenshotDataURL: String?)] =
             if let screenshotDataURL {
                 [
@@ -318,6 +326,26 @@ Selected text: \(selectedText ?? "None")
         windowTitle: String?,
         screenshotAvailable: Bool
     ) -> String {
+        // Off → empty, App summary → metadata line, Screenshot → original error text below.
+        let source: AppContextSource.EffectiveSource =
+            forceScreenshotForTest ? .screenshot : AppContextSource.effectiveSource(forBundleID: bundleIdentifier)
+        switch source {
+        case .off:
+            return ""
+        case .metadata:
+            // One AX read: host / web-capable / address-bar focus.
+            let web = AppContextSource.webContext()
+            return AppContextSource.metadataSummary(
+                appName: appName,
+                pageTitle: windowTitle,
+                webHost: web.host,
+                isWebApp: web.isWebApp,
+                addressBarFocused: web.addressBarFocused
+            )
+        case .screenshot:
+            break
+        }
+
         let activeApp = appName ?? "the active application"
         if screenshotAvailable {
             return "Could not reliably infer a two-sentence summary for \(activeApp) from the screenshot and metadata."
@@ -423,6 +451,13 @@ Selected text: \(selectedText ?? "None")
         appElement: AXUIElement,
         focusedWindowTitle: String?
     ) -> (dataURL: String?, mimeType: String?, error: String?) {
+        // Derive the bundle id from the pid; skip capture unless this app uses Screenshot mode.
+        let bundleID = NSRunningApplication(processIdentifier: processIdentifier)?.bundleIdentifier
+        guard forceScreenshotForTest || AppContextSource.effectiveSource(forBundleID: bundleID) == .screenshot else {
+            // Intentional skip, not a failure — no error so it isn't logged/shown as one.
+            return (nil, nil, nil)
+        }
+
         if !CGPreflightScreenCaptureAccess() {
             return (
                 nil,

--- a/Sources/AppContextSource.swift
+++ b/Sources/AppContextSource.swift
@@ -1,0 +1,301 @@
+import Foundation
+import AppKit
+import ApplicationServices
+
+/// Model for the "App Context" feature: the three UserDefaults settings (mode, screenshot scope,
+/// allowlist), the effective-source decision, the "App summary" line, and the browser-URL AX reads.
+/// All static / value-typed so it can be read from any thread (leaves read UserDefaults; the UI writes
+/// via `@AppStorage`). Defaults reproduce upstream (Screenshot + all apps), so a fresh install is unchanged.
+enum AppContextSource {
+
+    // MARK: - UserDefaults keys
+
+    /// Context source mode: `"off" | "metadata" | "screenshot"`.
+    static let modeKey = "appContextMode"
+    /// Per-app screenshot scope: `"all" | "specific"`.
+    static let scopeKey = "appContextScreenshotScope"
+    /// Screenshot allowlist: an array of bundle identifiers.
+    static let appsKey = "appContextScreenshotApps"
+
+    // MARK: - Settings enums
+
+    /// The chosen context source. `screenshot` is the upstream default.
+    enum Mode: String, CaseIterable {
+        /// No context is sent.
+        case off
+        /// A one-line on-device text summary; no image, no vision model.
+        case metadata
+        /// Capture the window and ask the vision model (upstream behavior).
+        case screenshot
+    }
+
+    /// Whether Screenshot mode applies to every app or only an allowlisted subset.
+    enum Scope: String, CaseIterable {
+        /// Every app takes a screenshot.
+        case all
+        /// Only allowlisted apps; the rest fall back to `metadata`.
+        case specific
+    }
+
+    /// The resolved source for one `collectContext()` call.
+    enum EffectiveSource {
+        /// Capture + vision model.
+        case screenshot
+        /// One-line metadata summary; no image, no LLM.
+        case metadata
+        /// No context.
+        case off
+    }
+
+    // MARK: - Settings reads (default = upstream behavior)
+
+    /// Current mode; defaults to `.screenshot`.
+    static var currentMode: Mode {
+        Mode(rawValue: UserDefaults.standard.string(forKey: modeKey) ?? "") ?? .screenshot
+    }
+
+    /// Current scope; defaults to `.all`.
+    static var currentScope: Scope {
+        Scope(rawValue: UserDefaults.standard.string(forKey: scopeKey) ?? "") ?? .all
+    }
+
+    /// Current allowlist (bundle ids); empty by default. `UserDefaults` stores `[String]` natively.
+    static var allowlist: [String] {
+        UserDefaults.standard.array(forKey: appsKey) as? [String] ?? []
+    }
+
+    // MARK: - Effective source
+
+    /// Resolves the source for one call from the frontmost app's bundle id.
+    /// In Screenshot+specific, apps outside the allowlist (or a `nil` id) fall back to `.metadata`.
+    static func effectiveSource(forBundleID id: String?) -> EffectiveSource {
+        switch currentMode {
+        case .off:
+            return .off
+        case .metadata:
+            return .metadata
+        case .screenshot:
+            if currentScope == .all { return .screenshot }
+            if let id, allowlist.contains(id) { return .screenshot }
+            return .metadata
+        }
+    }
+
+    // MARK: - Deterministic metadata summary (App summary mode)
+
+    /// Builds the "App summary" one-line activity string (offline, no LLM, pure — testable without AX).
+    /// Forms: `on <host> in <app>` (collapsed to `in <app>` when the host matches the app name),
+    /// `in the <app> address bar`, `on "<title>" in <app>` (web app with no readable URL), else `in <app>`.
+    /// - Parameters:
+    ///   - appName: Frontmost app's localized name.
+    ///   - pageTitle: Focused window/page title (cleaned here).
+    ///   - webHost: Current page host (e.g. `github.com`), or `nil`.
+    ///   - isWebApp: Whether the app renders web content.
+    ///   - addressBarFocused: Whether the address/search bar is focused.
+    static func metadataSummary(
+        appName: String?,
+        pageTitle: String?,
+        webHost: String?,
+        isWebApp: Bool,
+        addressBarFocused: Bool
+    ) -> String {
+        let app = (appName?.isEmpty == false) ? appName! : "the active app"
+        let title = cleanedPageTitle(pageTitle, appName: appName, host: webHost)
+
+        if let webHost, !webHost.isEmpty {
+            // Drop "in <app>" when the host already names the app (e.g. the ChatGPT web app).
+            let base = hostMatchesApp(webHost, appName: appName)
+                ? "User is dictating in \(app)"
+                : "User is dictating on \(webHost) in \(app)"
+            if let title { return "\(base) (\"\(title)\")" }
+            return base
+        }
+
+        if addressBarFocused {
+            return "User is dictating in the \(app) address bar"
+        }
+
+        // Web app whose URL the browser doesn't expose (e.g. Firefox/Zen) — use the page title.
+        if isWebApp, let title {
+            return "User is dictating on \"\(title)\" in \(app)"
+        }
+
+        return "User is dictating in \(app)"
+    }
+
+    // MARK: - Metadata summary helpers (pure)
+
+    /// Lowercased letters/digits only, for loose name-vs-host comparison.
+    private static func normalizedToken(_ value: String) -> String {
+        value.lowercased().unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
+    /// The host's brand label (the second-to-last DNS label: `github.com`→`github`).
+    /// Note: not public-suffix aware, so multi-part TLDs are approximate (`bbc.co.uk`→`co`); only used
+    /// for the optional cosmetic collapse below, so a miss just keeps the full `on <host>` form.
+    private static func hostBrand(_ host: String) -> String {
+        let labels = host.split(separator: ".").map(String.init)
+        guard labels.count >= 2 else { return host }
+        return labels[labels.count - 2]
+    }
+
+    /// True when the host's brand equals the app name (a web app named after its site, e.g. ChatGPT).
+    /// Exact match, so a real browser ("Google Chrome" on google.com) is not collapsed.
+    private static func hostMatchesApp(_ host: String, appName: String?) -> Bool {
+        guard let appName, !appName.isEmpty else { return false }
+        return normalizedToken(hostBrand(host)) == normalizedToken(appName)
+    }
+
+    /// Cleans the page title: strips a trailing " — <app>" suffix browsers add, removes embedded quotes,
+    /// and returns `nil` if it's empty or just repeats the app name or host.
+    private static func cleanedPageTitle(_ pageTitle: String?, appName: String?, host: String?) -> String? {
+        guard var title = pageTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty else {
+            return nil
+        }
+
+        // Strip the trailing " — <BrowserName>" / " - <BrowserName>" browsers append.
+        if let appName, !appName.isEmpty {
+            for separator in [" — ", " – ", " - "] {
+                let suffix = separator + appName
+                if title.count > suffix.count, title.lowercased().hasSuffix(suffix.lowercased()) {
+                    title = String(title.dropLast(suffix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+                    break
+                }
+            }
+        }
+
+        // Remove embedded double quotes so the quoted summary stays balanced.
+        title = title.replacingOccurrences(of: "\"", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !title.isEmpty else { return nil }
+        if let appName, normalizedToken(title) == normalizedToken(appName) { return nil }
+        if let host, normalizedToken(title) == normalizedToken(host) { return nil }
+        return title
+    }
+
+    // MARK: - Browser URL & focus (Accessibility)
+    //
+    // Reads the frontmost app's page host and focus via AX. Detection is structural (finds an AXWebArea,
+    // no browser allowlist), so it covers Safari, Chromium browsers (Chrome, Edge, Brave, Arc, Opera,
+    // Vivaldi, newer ones), PWAs, and Gecko (Firefox/Zen) where AX is exposed. Requires the Accessibility
+    // permission the app already uses.
+
+    /// Max AX nodes visited when searching for the web area — bounds cost on large non-web trees.
+    private static let traversalBudget = 250
+    /// Max parent hops when checking if the focused element is inside the web content.
+    private static let maxParentHops = 12
+
+    /// Reads one dictation's web context: page host (if readable), whether the app renders web content,
+    /// and whether the address/search bar is focused. Reads `frontmostApplication` independently (the
+    /// caller can't pass an element down without touching the byte-identical `collectContext`); the gap
+    /// is synchronous, so the app is effectively stable.
+    static func webContext() -> (host: String?, isWebApp: Bool, addressBarFocused: Bool) {
+        guard AXIsProcessTrusted() else { return (nil, false, false) }
+        guard let app = NSWorkspace.shared.frontmostApplication else { return (nil, false, false) }
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+
+        // Opt Chromium/Electron apps into exposing their AX tree (harmless for apps that already do).
+        AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+
+        // Safari exposes the page URL on the focused window's AXDocument.
+        var urlString = copyElement(appElement, "AXFocusedWindow").flatMap { copyURLString($0, "AXDocument") }
+
+        // Find the web area once; reused for the Chromium/PWA URL and the web-capable flag.
+        let webArea = findWebArea(appElement)
+        if urlString == nil, let webArea {
+            urlString = copyURLString(webArea, "AXURL")
+        }
+
+        let host = hostFromURLString(urlString)
+        let isWebApp = (webArea != nil) || (host != nil)
+        let addressBarFocused = isWebApp && focusedIsChromeTextField(appElement)
+        return (host, isWebApp, addressBarFocused)
+    }
+
+    /// Clean host from a URL string: http(s) only, lowercased, leading `www.` stripped; else `nil`.
+    /// (IDN hosts come back as punycode `xn--…` — left as-is; rare for these users.)
+    private static func hostFromURLString(_ raw: String?) -> String? {
+        guard let raw, let url = URL(string: raw),
+              let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https",
+              var host = url.host?.lowercased(), !host.isEmpty
+        else { return nil }
+        if host.hasPrefix("www.") { host = String(host.dropFirst(4)) }
+        return host
+    }
+
+    /// True when the focused element is the address/search bar: a text-input role that is browser chrome
+    /// (not inside the web page).
+    private static func focusedIsChromeTextField(_ appElement: AXUIElement) -> Bool {
+        guard let focused = copyElement(appElement, "AXFocusedUIElement"),
+              let role = copyString(focused, "AXRole") else { return false }
+        let textInputRoles: Set<String> = ["AXTextField", "AXComboBox", "AXSearchField"]
+        guard textInputRoles.contains(role) else { return false }
+        return !isInsideWebArea(focused)
+    }
+
+    /// Walks up the parent chain (capped) to see if the element sits inside an `AXWebArea`.
+    private static func isInsideWebArea(_ element: AXUIElement) -> Bool {
+        var current = element
+        var hops = 0
+        while hops < maxParentHops {
+            guard let parent = copyElement(current, "AXParent") else { return false }
+            if copyString(parent, "AXRole") == "AXWebArea" { return true }
+            current = parent
+            hops += 1
+        }
+        return false
+    }
+
+    /// Breadth-first search for the first `AXWebArea`, bounded by `traversalBudget` visited nodes.
+    /// BFS reaches the shallow web area before a wide toolbar subtree can exhaust the budget.
+    private static func findWebArea(_ root: AXUIElement) -> AXUIElement? {
+        var queue = [root]
+        var head = 0
+        var visited = 0
+        while head < queue.count, visited < traversalBudget {
+            let element = queue[head]
+            head += 1
+            visited += 1
+            if copyString(element, "AXRole") == "AXWebArea" { return element }
+            if let children = copyChildren(element) { queue.append(contentsOf: children) }
+        }
+        return nil
+    }
+
+    // MARK: - AX attribute helpers
+
+    /// Copies an element-typed AX attribute (e.g. the focused window).
+    private static func copyElement(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
+              let value, CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
+        return (value as! AXUIElement)
+    }
+
+    /// Copies a string-typed AX attribute.
+    private static func copyString(_ element: AXUIElement, _ attribute: String) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    /// Copies a URL- or string-typed AX attribute as a URL string (value may be a CFURL or a String).
+    private static func copyURLString(_ element: AXUIElement, _ attribute: String) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
+              let value else { return nil }
+        if CFGetTypeID(value) == CFURLGetTypeID() { return ((value as! CFURL) as URL).absoluteString }
+        return value as? String
+    }
+
+    /// Copies the element's AX children (`as?` bridges the CFArray and yields nil on any non-array).
+    private static func copyChildren(_ element: AXUIElement) -> [AXUIElement]? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &value) == .success,
+              let children = value as? [AXUIElement] else { return nil }
+        return children
+    }
+}

--- a/Sources/AppContextSource.swift
+++ b/Sources/AppContextSource.swift
@@ -102,6 +102,11 @@ enum AppContextSource {
         let app = (appName?.isEmpty == false) ? appName! : "the active app"
         let title = cleanedPageTitle(pageTitle, appName: appName, host: webHost)
 
+        // Address bar focused → you're typing a URL/search, not into the page; check before the host.
+        if addressBarFocused {
+            return "User is dictating in the \(app) address bar"
+        }
+
         if let webHost, !webHost.isEmpty {
             // Drop "in <app>" when the host already names the app (e.g. the ChatGPT web app).
             let base = hostMatchesApp(webHost, appName: appName)
@@ -109,10 +114,6 @@ enum AppContextSource {
                 : "User is dictating on \(webHost) in \(app)"
             if let title { return "\(base) (\"\(title)\")" }
             return base
-        }
-
-        if addressBarFocused {
-            return "User is dictating in the \(app) address bar"
         }
 
         // Web app whose URL the browser doesn't expose (e.g. Firefox/Zen) — use the page title.
@@ -189,12 +190,15 @@ enum AppContextSource {
     private static let maxParentHops = 12
 
     /// Reads one dictation's web context: page host (if readable), whether the app renders web content,
-    /// and whether the address/search bar is focused. Reads `frontmostApplication` independently (the
-    /// caller can't pass an element down without touching the byte-identical `collectContext`); the gap
-    /// is synchronous, so the app is effectively stable.
-    static func webContext() -> (host: String?, isWebApp: Bool, addressBarFocused: Bool) {
+    /// and whether the address/search bar is focused. Reads `frontmostApplication` here (the caller can't
+    /// pass the element down without editing the byte-identical `collectContext`), but bails when the
+    /// frontmost app no longer matches `expectedBundleID`, so it never mixes another app's page into a
+    /// summary captured for a different app.
+    static func webContext(expectedBundleID: String?) -> (host: String?, isWebApp: Bool, addressBarFocused: Bool) {
         guard AXIsProcessTrusted() else { return (nil, false, false) }
         guard let app = NSWorkspace.shared.frontmostApplication else { return (nil, false, false) }
+        // Focus changed since collectContext captured the app → don't read a different app's page.
+        if let expectedBundleID, app.bundleIdentifier != expectedBundleID { return (nil, false, false) }
         let appElement = AXUIElementCreateApplication(app.processIdentifier)
 
         // Opt Chromium/Electron apps into exposing their AX tree (harmless for apps that already do).

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1523,6 +1523,7 @@ struct PromptsSettingsView: View {
     @State private var contextTestOutput: String? = nil
     @State private var contextTestError: String? = nil
     @State private var contextTestPrompt: String? = nil
+    @AppStorage(AppContextSource.modeKey) private var appContextMode: String = AppContextSource.Mode.screenshot.rawValue
 
     var body: some View {
         ScrollView {
@@ -1533,7 +1534,7 @@ struct PromptsSettingsView: View {
                 SettingsCard("Instruction Guard", icon: "shield.lefthalf.filled") {
                     instructionGuardSection
                 }
-                SettingsCard("Context Prompt", icon: "eye.fill") {
+                SettingsCard("App Context", icon: "doc.text.viewfinder") {
                     contextPromptSection
                 }
             }
@@ -1793,6 +1794,18 @@ struct PromptsSettingsView: View {
 
     // MARK: Context Prompt
 
+    /// The per-mode description shown under the Context source segmented control.
+    private var contextSourceDescription: String {
+        switch AppContextSource.Mode(rawValue: appContextMode) ?? .screenshot {
+        case .off:
+            return "No context is sent — the cleanup model sees only your transcript."
+        case .metadata:
+            return "Sends one line of text about your app and page — instant, no added latency. E.g. \"User is dictating on github.com (Pull requests) in Safari\", or \"in the Chrome address bar\"."
+        case .screenshot:
+            return "Captures the window and asks the vision model — catches on-screen names and terms (e.g. in email). Uses vision quota; depending on your connection (ping, upload speed) it can add up to ~3 s per transcription."
+        }
+    }
+
     private var contextPromptSection: some View {
         let isCustom = !appState.customContextPrompt.isEmpty
         let hasNewerDefault = isCustom
@@ -1800,201 +1813,245 @@ struct PromptsSettingsView: View {
             && appState.customContextPromptLastModified < AppContextService.defaultContextPromptDate
 
         return VStack(alignment: .leading, spacing: 10) {
-            Text("Controls how \(AppName.displayName) infers your current activity from app metadata and screenshots.")
+            Text("Controls how \(AppName.displayName) infers your current activity and what it sends to the AI.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            if hasNewerDefault {
-                HStack(spacing: 8) {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                        .foregroundStyle(.blue)
-                    Text("A newer default prompt is available.")
+            // MARK: Context source (always active)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Context source")
                         .font(.caption.weight(.semibold))
                     Spacer()
-                    Button("View Default") {
-                        showDefaultContextPrompt.toggle()
+                    Picker("", selection: $appContextMode) {
+                        Text("Off").tag(AppContextSource.Mode.off.rawValue)
+                        Text("App summary").tag(AppContextSource.Mode.metadata.rawValue)
+                        Text("Screenshot").tag(AppContextSource.Mode.screenshot.rawValue)
                     }
-                    .font(.caption)
-                    Button("Switch to Default") {
-                        customContextPromptInput = AppContextService.defaultContextPrompt
-                        appState.customContextPrompt = ""
-                        appState.customContextPromptLastModified = ""
-                    }
-                    .font(.caption)
-                }
-                .padding(10)
-                .background(Color.blue.opacity(0.1))
-                .cornerRadius(6)
-            }
-
-            if showDefaultContextPrompt {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text("Default Context Prompt")
-                            .font(.caption.weight(.semibold))
-                        Spacer()
-                        Button("Hide") {
-                            showDefaultContextPrompt = false
-                        }
-                        .font(.caption)
-                    }
-                    Text(AppContextService.defaultContextPrompt)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-                .padding(10)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(6)
-            }
-
-            TextEditor(text: $customContextPromptInput)
-                .font(.system(.body, design: .monospaced))
-                .frame(minHeight: 120, maxHeight: 200)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
-                )
-                .onChange(of: customContextPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customContextPrompt.isEmpty {
-                            appState.customContextPrompt = ""
-                            appState.customContextPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customContextPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customContextPromptLastModified != today {
-                            appState.customContextPromptLastModified = today
-                        }
-                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .fixedSize()
+                    .accessibilityLabel("Context source")
                 }
 
-            HStack {
-                if isCustom {
-                    Label("Using custom prompt", systemImage: "pencil")
-                        .font(.caption)
-                        .foregroundStyle(.blue)
-                } else {
-                    Label("Using default", systemImage: "checkmark.circle")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if isCustom {
-                    Button("Reset to Default") {
-                        customContextPromptInput = AppContextService.defaultContextPrompt
-                        appState.customContextPrompt = ""
-                        appState.customContextPromptLastModified = ""
-                    }
+                Text(contextSourceDescription)
                     .font(.caption)
-                }
+                    .foregroundStyle(.secondary)
             }
 
             Divider()
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Screenshot Resolution")
-                    .font(.caption.weight(.semibold))
-
-                Text("Controls the maximum image dimension sent for context inference.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Picker("", selection: $appState.contextScreenshotMaxDimension) {
-                    ForEach(AppState.contextScreenshotDimensionOptions, id: \.self) { dimension in
-                        Text("\(dimension) px").tag(dimension)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .accessibilityLabel("Screenshot Resolution")
-
-                HStack {
-                    if appState.contextScreenshotMaxDimension == AppState.defaultContextScreenshotMaxDimension {
-                        Label("Using default", systemImage: "checkmark.circle")
+            // MARK: Screenshot-only block — obscured + disabled unless in Screenshot mode
+            VStack(alignment: .leading, spacing: 10) {
+                // a) Vision Prompt
+                VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Vision Prompt")
+                            .font(.caption.weight(.semibold))
+                        Text("Instruction sent to the vision model in Screenshot mode.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                    } else {
-                        Label("Using custom value", systemImage: "pencil")
+                    }
+
+                    if hasNewerDefault {
+                        HStack(spacing: 8) {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .foregroundStyle(.blue)
+                            Text("A newer default prompt is available.")
+                                .font(.caption.weight(.semibold))
+                            Spacer()
+                            Button("View Default") {
+                                showDefaultContextPrompt.toggle()
+                            }
                             .font(.caption)
-                            .foregroundStyle(.blue)
-                    }
-                    Spacer()
-                    if appState.contextScreenshotMaxDimension != AppState.defaultContextScreenshotMaxDimension {
-                        Button("Reset to Default") {
-                            appState.contextScreenshotMaxDimension = AppState.defaultContextScreenshotMaxDimension
+                            Button("Switch to Default") {
+                                customContextPromptInput = AppContextService.defaultContextPrompt
+                                appState.customContextPrompt = ""
+                                appState.customContextPromptLastModified = ""
+                            }
+                            .font(.caption)
                         }
-                        .font(.caption)
+                        .padding(10)
+                        .background(Color.blue.opacity(0.1))
+                        .cornerRadius(6)
                     }
-                }
-            }
 
-            Divider()
+                    if showDefaultContextPrompt {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Text("Default Vision Prompt")
+                                    .font(.caption.weight(.semibold))
+                                Spacer()
+                                Button("Hide") {
+                                    showDefaultContextPrompt = false
+                                }
+                                .font(.caption)
+                            }
+                            Text(AppContextService.defaultContextPrompt)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                        .padding(10)
+                        .background(Color(nsColor: .controlBackgroundColor))
+                        .cornerRadius(6)
+                    }
 
-            // Test section
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Test Context Prompt")
-                    .font(.caption.weight(.semibold))
-                Text("Captures a screenshot and metadata from the frontmost app, then runs the context prompt to infer activity.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    TextEditor(text: $customContextPromptInput)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 120, maxHeight: 200)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                        )
+                        .onChange(of: customContextPromptInput) { newValue in
+                            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                            let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if trimmed == defaultTrimmed || trimmed.isEmpty {
+                                if !appState.customContextPrompt.isEmpty {
+                                    appState.customContextPrompt = ""
+                                    appState.customContextPromptLastModified = ""
+                                }
+                            } else {
+                                appState.customContextPrompt = trimmed
+                                let today = iso8601DayFormatter.string(from: Date())
+                                if appState.customContextPromptLastModified != today {
+                                    appState.customContextPromptLastModified = today
+                                }
+                            }
+                        }
 
-                Button {
-                    runContextPromptTest()
-                } label: {
-                    HStack(spacing: 6) {
-                        if contextTestRunning {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text("Running...")
+                    HStack {
+                        if isCustom {
+                            Label("Using custom prompt", systemImage: "pencil")
+                                .font(.caption)
+                                .foregroundStyle(.blue)
                         } else {
-                            Image(systemName: "play.fill")
-                            Text("Test Context Prompt")
+                            Label("Using default", systemImage: "checkmark.circle")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if isCustom {
+                            Button("Reset to Default") {
+                                customContextPromptInput = AppContextService.defaultContextPrompt
+                                appState.customContextPrompt = ""
+                                appState.customContextPromptLastModified = ""
+                            }
+                            .font(.caption)
                         }
                     }
                 }
-                .disabled(contextTestRunning || appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
-                if appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Label("API key required to test", systemImage: "exclamationmark.triangle")
+                // b) Test Vision Prompt
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Test Vision Prompt")
+                        .font(.caption.weight(.semibold))
+                    Text("Runs the vision prompt on a fresh screenshot of the frontmost app.")
                         .font(.caption)
-                        .foregroundStyle(.orange)
-                }
+                        .foregroundStyle(.secondary)
 
-                if let error = contextTestError {
-                    Label(error, systemImage: "xmark.circle.fill")
+                    Button {
+                        runContextPromptTest()
+                    } label: {
+                        HStack(spacing: 6) {
+                            if contextTestRunning {
+                                ProgressView()
+                                    .controlSize(.small)
+                                Text("Running...")
+                            } else {
+                                Image(systemName: "play.fill")
+                                Text("Test Vision Prompt")
+                            }
+                        }
+                    }
+                    .disabled(contextTestRunning || appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    if appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Label("API key required to test", systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+
+                    if let error = contextTestError {
+                        Label(error, systemImage: "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+
+                    if let output = contextTestOutput {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Result:")
+                                .font(.caption.weight(.semibold))
+                            Text(output.isEmpty ? "(empty — no output)" : output)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                                .padding(8)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.green.opacity(0.08))
+                                .cornerRadius(6)
+                        }
+                    }
+
+                    if let prompt = contextTestPrompt {
+                        DisclosureGroup("Full prompt sent") {
+                            Text(prompt)
+                                .font(.system(.caption2, design: .monospaced))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                         .font(.caption)
-                        .foregroundStyle(.red)
-                }
-
-                if let output = contextTestOutput {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Result:")
-                            .font(.caption.weight(.semibold))
-                        Text(output.isEmpty ? "(empty — no output)" : output)
-                            .font(.system(.caption, design: .monospaced))
-                            .textSelection(.enabled)
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.green.opacity(0.08))
-                            .cornerRadius(6)
+                        .foregroundStyle(.secondary)
                     }
                 }
 
-                if let prompt = contextTestPrompt {
-                    DisclosureGroup("Full prompt sent") {
-                        Text(prompt)
-                            .font(.system(.caption2, design: .monospaced))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                Divider()
+
+                // c) Screenshot scope — the per-app multiselector
+                ScreenshotScopeSection()
+
+                Divider()
+
+                // d) Screenshot Resolution
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Screenshot Resolution")
+                        .font(.caption.weight(.semibold))
+
+                    Text("Maximum image dimension sent for context inference.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Picker("", selection: $appState.contextScreenshotMaxDimension) {
+                        ForEach(AppState.contextScreenshotDimensionOptions, id: \.self) { dimension in
+                            Text("\(dimension) px").tag(dimension)
+                        }
                     }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .accessibilityLabel("Screenshot Resolution")
+
+                    HStack {
+                        if appState.contextScreenshotMaxDimension == AppState.defaultContextScreenshotMaxDimension {
+                            Label("Using default", systemImage: "checkmark.circle")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Label("Using custom value", systemImage: "pencil")
+                                .font(.caption)
+                                .foregroundStyle(.blue)
+                        }
+                        Spacer()
+                        if appState.contextScreenshotMaxDimension != AppState.defaultContextScreenshotMaxDimension {
+                            Button("Reset to Default") {
+                                appState.contextScreenshotMaxDimension = AppState.defaultContextScreenshotMaxDimension
+                            }
+                            .font(.caption)
+                        }
+                    }
                 }
             }
+            .opacity(appContextMode == AppContextSource.Mode.screenshot.rawValue ? 1 : 0.5)
+            .disabled(appContextMode != AppContextSource.Mode.screenshot.rawValue)
         }
     }
 
@@ -2005,6 +2062,8 @@ struct PromptsSettingsView: View {
         contextTestPrompt = nil
 
         let service = appState.makeAppContextService()
+        // Force the vision path on this throwaway instance, regardless of the saved mode/scope.
+        service.forceScreenshotForTest = true
 
         Task {
             let context = await service.collectContext()


### PR DESCRIPTION
## Summary

This reworks the existing App Context settings _(formerly "Context Prompt")_ in the prompts tab into a single control over current activity and what it sends to the AI. Alongside the existing screenshot path, it adds on-device context detection: FreeFlow can describe the user app, window, and current web page locally and send a one-line text description — no image, no vision model. A single multi-toggle selects one of three context sources.

**Screenshot sending can now be disabled or limited to a chosen list of apps.**
With the default settings, behavior is identical to before this PR.
   
<img width="1560" height="1469" alt="CleanShot 2026-06-25 at 06 31 43@2x" src="https://github.com/user-attachments/assets/ded204ec-e292-4b67-8269-ef681ec119cf" />
 
---

## Context source

Control with three options:

- **Off** — no context is sent; the cleanup model sees only your transcript.
- **App summary** — FreeFlow builds one line of plain text about your app and current page on-device and sends it as text. No image, no vision model, no added latency.
- **Screenshot LLM** — FreeFlow captures the active window and sends it to the vision model (the existing behavior). Depending on your connection (ping and upload speed) this can add up to ~3 s per transcription, and it uses vision quota.


<img width="1196" height="288" alt="CleanShot 2026-06-25 at 06 27 52@2x" src="https://github.com/user-attachments/assets/fedf4a09-8bd5-40e9-b188-8a6ce95eb346" />
<img width="1196" height="288" alt="CleanShot 2026-06-25 at 06 28 10@2x" src="https://github.com/user-attachments/assets/84af5f74-9632-4110-8320-393d904eb0e6" />
<img width="1196" height="288" alt="CleanShot 2026-06-25 at 06 28 15@2x" src="https://github.com/user-attachments/assets/84691ba7-f071-4f17-b1ce-9b58bde89dbe" />
   
---

## Per-app "send screenshot" allow-list

Shown in Screenshot mode. Two choices:

- **Send screenshot to all apps** — every app is captured (the default).
- **Only specific apps** — only the apps you add are captured; every other app falls back to **App summary** (not Off). Apps are added through a standard file picker (`/Applications`) and listed as removable chips with their icon and name.

This lets you keep the screenshot only where it helps — for example an email client, where the model benefits from seeing recipients and the subject — while everything else stays fast and text-only.

<img width="1560" height="1586" alt="CleanShot 2026-06-25 at 06 34 05@2x" src="https://github.com/user-attachments/assets/d9079beb-9c80-405e-9676-221910f7ebd5" />
    
---

## What "App summary" sends

The one-line summary is built from window/app metadata read through the Accessibility API:

- For web pages it includes the site host and page title, e.g. `User is dictating on github.com (Pull requests) in Safari`.
- The site is read from the page itself (no fixed list of browsers), so it works in Safari, Chromium-based browsers (Chrome, Edge, Brave, Arc, Opera, Vivaldi, …), and standalone web apps / PWAs; Firefox/Zen are covered where their Accessibility data allows.
- When the site name already matches the app, the redundant part is dropped (the ChatGPT app reads `User is dictating in ChatGPT`).
- When you're typing in the address/search bar, it reads `User is dictating in the <app> address bar`.
- Otherwise it reads `User is dictating in <app>`.


---

## Vision Prompt, Test, and Resolution

The controls that already existed are kept and grouped under Screenshot mode, since they only apply when the vision model runs:

- **Vision Prompt** — the former "Context Prompt" editor, renamed. The prompt text and its behavior are unchanged.
- **Test Vision Prompt** — the former "Test Context Prompt" button, renamed. It now always runs the vision path, so the test works regardless of the selected mode or app scope.
- **Screenshot Resolution** — the existing control, moved into this card.

When the source is Off or App summary, this whole block is disabled and dimmed, and the app icons in the allow-list chips are greyed so they read as inactive.

<img width="1560" height="1574" alt="CleanShot 2026-06-25 at 06 54 55@2x" src="https://github.com/user-attachments/assets/5ad45a38-421e-4d44-8cbf-6562b839c63c" />
    
---

## Defaults and scope

- Defaults reproduce today's behavior exactly: **Screenshot + all apps + 1024 px**. Existing users see no change.
- The new settings are stored in `UserDefaults`; **`AppState`, the post-processing/cleanup logic, and the run-history database are not touched.**
- Deployment target is macOS 13.

---

## Changes by file

**`Sources/AppContextSource.swift` (new, ~300 lines)** — the settings model and the Accessibility reads.
- Three `UserDefaults` keys (`appContextMode`, `appContextScreenshotScope`, `appContextScreenshotApps`) and the `Mode` / `Scope` / `EffectiveSource` enums, with reads that default to the upstream behavior.
- `effectiveSource(forBundleID:)` — resolves the source for one dictation, including the per-app rule (apps outside the allow-list fall back to App summary).
- `metadataSummary(...)` — a pure function that composes the App-summary line (host + title, redundancy collapse, address-bar wording, title cleanup), plus the small string helpers it uses.
- A "Browser URL & focus" section that reads the page host and focus through Accessibility: `webContext()` (one read; opts the app into Accessibility and skips when permission is missing), a breadth-first `AXWebArea` search, address-bar detection, and the low-level attribute helpers.

**`Sources/AppContextScopeStore.swift` (new, ~195 lines)** — the allow-list store and the scope UI.
- `AppContextAllowlist` — an observable store that loads/persists the bundle-id list to `UserDefaults` and presents the "Add app…" file picker.
- `AppContextAppInfo` — resolves and caches each app's display name and icon.
- `ScreenshotScopeSection` — the two radio rows, the app chips (icon, name, remove button), the dashed "Add app…" button, the empty state, accessibility labels, and the icon-greying when the block is disabled.

**`Sources/AppContextService.swift` (modified, +35 lines)** — the existing context service.
- Three small guards, one at the top of each leaf function, so the chosen source is honored: the window capture is skipped outside Screenshot mode; the vision/LLM call is skipped outside Screenshot mode; the fallback returns empty (Off) or the App-summary line (App summary) and otherwise keeps the original text.
- A per-instance `forceScreenshotForTest` flag used only by the Test button.
- The body of `collectContext(...)` is unchanged (byte-identical to `main`).

**`Sources/SettingsView.swift` (modified)** — the Prompts tab.
- Renamed the card "Context Prompt" → "App Context" and rebuilt its body into the layout above: the Context source segmented control + per-mode description, then the Screenshot-only block (Vision Prompt editor, Test Vision Prompt, the scope section, Screenshot Resolution) wrapped so it disables and dims outside Screenshot mode.
- Added the `appContextMode` setting and pointed the Test button at the per-instance flag.
- Label and styling updates so the card matches the rest of the tab (renamed labels, consistent fonts/spacing, the disabled-state dimming).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an “App Context” setting with selectable modes: off, app metadata, or screenshot-based behavior.
  * Introduced a screenshot scope allowlist UI to allow specific apps (with persisted add/remove and app name/icon display).
  * Added a segmented “Context source” picker with mode-specific descriptions.

* **Bug Fixes**
  * Screenshot/vision inference and capture now only run when the selected mode requires them (while still supporting forced test runs).
  * Improved context fallback behavior and summary generation based on the effective mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->