### PR TITLE
fix: replace deprecated llama-4-scout-17b with llama-3.3-70b-versatile

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -53,14 +53,14 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         apiKey: String,
         baseURL: String = "https://api.groq.com/openai/v1",
         customContextPrompt: String = "",
-        contextModel: String = "meta-llama/llama-4-scout-17b-16e-instruct",
+        contextModel: String = "llama-3.3-70b-versatile",
         screenshotMaxDimension: CGFloat = AppContextService.defaultScreenshotMaxDimension
     ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.customContextPrompt = customContextPrompt
         let trimmedModel = contextModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.contextModel = trimmedModel.isEmpty ? "meta-llama/llama-4-scout-17b-16e-instruct" : trimmedModel
+        self.contextModel = trimmedModel.isEmpty ? "llama-3.3-70b-versatile" : trimmedModel
         self.screenshotMaxDimension = screenshotMaxDimension > 0
             ? screenshotMaxDimension
             : AppContextService.defaultScreenshotMaxDimension

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -275,8 +275,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         ("ca", "Catalan")
     ]
     static let defaultPostProcessingModel = "openai/gpt-oss-20b"
-    static let defaultPostProcessingFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
-    static let defaultContextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    static let defaultPostProcessingFallbackModel = "llama-3.3-70b-versatile"
+    static let defaultContextModel = "llama-3.3-70b-versatile"
     private static let trailingPressEnterCommandPattern = try! NSRegularExpression(
         pattern: #"(?i)(?:^|[ \t\r\n,;:\-]+)press[ \t\r\n]+enter[\s\p{P}]*$"#
     )

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -11,7 +11,6 @@ public struct ModelConfiguration {
     public static let llmModels = [
         "llama-3.3-70b-versatile",
         "llama-3.1-8b-instant",
-        "meta-llama/llama-4-scout-17b-16e-instruct",
         "openai/gpt-oss-20b",
         "openai/gpt-oss-120b",
         "openai/gpt-oss-safeguard-20b",
@@ -76,13 +75,6 @@ public struct ModelConfiguration {
                 shouldStripThinkTags: false
             )
         } else if cleanModel == "llama-3.3-70b-versatile" {
-            return ModelConfig(
-                maxCompletionTokens: nil,
-                reasoningEffort: nil,
-                includeReasoning: nil,
-                shouldStripThinkTags: false
-            )
-        } else if cleanModel == "meta-llama/llama-4-scout-17b-16e-instruct" {
             return ModelConfig(
                 maxCompletionTokens: nil,
                 reasoningEffort: nil,

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -133,7 +133,7 @@ Behavior:
     private let preferredFallbackModel: String
     private let instructionExecutionGuardEnabled: Bool
     private let defaultModel = "openai/gpt-oss-20b"
-    private let defaultFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    private let defaultFallbackModel = "llama-3.3-70b-versatile"
     private let defaultModelReasoningEffort = "low"
     private let postProcessingMaxCompletionTokens = 4096
     private var postProcessingTimeoutSeconds: TimeInterval {


### PR DESCRIPTION
## Summary

Groq has deprecated `meta-llama/llama-4-scout-17b-16e-instruct` as of June 25, 2026 and will decommission it on **July 17, 2026**. After that date, any request using this model ID will fail.

This PR replaces every hardcoded reference to the deprecated model with `llama-3.3-70b-versatile`, which is a Groq **Production-tier** model (not Preview), meaning it is covered by Groq's stability and reliability guarantees.

## Changes

| File | What changed |
|---|---|
| `Sources/AppState.swift` | `defaultPostProcessingFallbackModel` and `defaultContextModel` → `llama-3.3-70b-versatile` |
| `Sources/PostProcessingService.swift` | `defaultFallbackModel` constant → `llama-3.3-70b-versatile` |
| `Sources/AppContextService.swift` | Default parameter and empty-model fallback in `init` → `llama-3.3-70b-versatile` |
| `Sources/ModelConfiguration.swift` | Removed `meta-llama/llama-4-scout-17b-16e-instruct` from the selectable `llmModels` list and its corresponding `config(for:)` branch (it falls through to the generic default, same config) |

## Why `llama-3.3-70b-versatile`?

- **Production tier** on GroqCloud — not subject to sudden deprecation without notice (unlike Preview models).
- **Same rate-limit bucket** as the primary `openai/gpt-oss-20b` is separate, so using this as a fallback actually helps on 429s.
- **Strong quality** — 70B parameters, context window of 131K tokens, broadly used as the go-to open-weights model for text generation tasks.
- **Already present** in `llmModels` as the first entry, so it's already the recommended pick for users browsing the model list.

## Impact on existing users

Users who previously selected `meta-llama/llama-4-scout-17b-16e-instruct` explicitly in their settings will continue to see their saved value until they change it — the model still responds until July 17. After decommission, those users will need to manually switch. Removing it from `llmModels` prevents new users from selecting it going forward.

## References

- Groq deprecation notice: https://groq.com (June 25, 2026 developer email)
- Groq supported models: https://console.groq.com/docs/models
- Decommission date: **July 17, 2026**

-- 

Deprecation email

```
Hello Devs!

We want to inform you about the deprecation of the Llama 4 Scout 17B model.

We are deprecating Llama 4 Scout 17B today, and decommissioning it on July 17, 2026. After the decommission date, requests to the model will no longer be served.

We encourage you to transition your workloads to our recommended replacement model, GPT OSS 120B / Qwen3.6 27B, as soon as possible.

This deprecation applies to free and developer-tier usage. If you're an enterprise customer with a committed-spend contract, you are not affected — your access continues unchanged.

Additionally, you can view all models available on GroqCloud here.

 
NEXT STEPS
Migration Support: Our team is ready to assist you with the transition process. Please reach out if you need guidance on how to migrate your workloads effectively.

Documentation: Detailed guides and resources are available in our developer portal.

We appreciate your understanding and support as we move forward with these enhancements. If you have any questions, feel free to reach out to us at [support@groq.com](mailto:support@groq.com) or reply to this email.

Thanks for building with us,

The Groq Team
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s default and fallback AI model to a newer version for context handling and post-processing.
  * Removed reliance on an older model so fallback selection now resolves more consistently.
  * Aligned model availability with the current supported set to avoid selecting an outdated option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->