### PR TITLE
fix: fall back to the backup cleanup model the moment the main one is rate-limited, instead of retrying it every dictation

### DIFF
--- a/Sources/LLMCooldownManager.swift
+++ b/Sources/LLMCooldownManager.swift
@@ -60,14 +60,17 @@ actor LLMCooldownManager {
         }
     }
 
-    /// Returns the model to use up-front: the fallback when the primary is in a rate-limit
-    /// cooldown and a fallback exists, otherwise the primary. Lets a caller route around a
-    /// cooling-down model in a single call. Behaviorally identical to the inline swap it replaces.
-    func effectivePrimary(_ primary: String, fallback: String?) -> String {
-        if isInCooldown(primary), let fallback {
-            return fallback
+    /// Returns an available model to use up-front, or nil when none is: the primary if it is not
+    /// cooling down; otherwise the fallback if it exists and is itself not cooling down; otherwise
+    /// nil, so the caller can skip a doomed request when BOTH models are rate-limited.
+    func effectivePrimary(_ primary: String, fallback: String?) -> String? {
+        if !isInCooldown(primary) {
+            return primary
         }
-        return primary
+        guard let fallback, !isInCooldown(fallback) else {
+            return nil
+        }
+        return fallback
     }
 
     // MARK: - UserDefaults (daily-limit persistence)
@@ -105,19 +108,24 @@ actor LLMCooldownManager {
 
     /// Reads from a Groq 429 response how long the model must cool down AND whether the limit is a
     /// daily one (so the caller persists it even when the remaining time is short).
-    /// Priority: `retry-after` (delta-seconds) → `x-ratelimit-reset-requests` (the daily /
-    /// Requests-Per-Day reset) → `x-ratelimit-reset-tokens` (the per-minute / Tokens-Per-Minute
-    /// reset) → a short re-probe fallback when no timing header is present. Only the RPD header
-    /// marks the limit daily; `retry-after` is ambiguous, so its daily-ness is left to the duration
-    /// threshold in `setCooldown`. nonisolated static so the call site computes it without an actor hop.
+    /// Priority: an exhausted daily request quota (`x-ratelimit-remaining-requests` <= 0, using the
+    /// `x-ratelimit-reset-requests` RPD reset) → `retry-after` (delta-seconds) →
+    /// `x-ratelimit-reset-tokens` (the per-minute / Tokens-Per-Minute reset) → a short re-probe
+    /// fallback. The RPD check runs FIRST because Groq usually also sends `retry-after`; honoring
+    /// that first would hide a short, near-reset daily window and stop it from persisting.
+    /// nonisolated static so the call site computes it without an actor hop.
     nonisolated static func rateLimitCooldown(from httpResponse: HTTPURLResponse) -> (seconds: TimeInterval, isDaily: Bool) {
+        // Daily (RPD) quota spent: classify as daily and use its reset even when retry-after is also
+        // present, so a short near-reset daily window still persists and surfaces in Settings.
+        let remainingRequests = httpResponse.value(forHTTPHeaderField: "x-ratelimit-remaining-requests")
+            .flatMap { Double($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        if let remainingRequests, remainingRequests <= 0,
+           let dailyReset = httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-requests").flatMap(parseGroqDuration) {
+            return (dailyReset, true)
+        }
         // retry-after is the authoritative wait Groq sets specifically on a 429.
         if let value = httpResponse.value(forHTTPHeaderField: "retry-after").flatMap(parseGroqDuration) {
             return (value, false)
-        }
-        // x-ratelimit-reset-requests carries the daily (RPD) reset, e.g. "2m59.56s" or hours.
-        if let value = httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-requests").flatMap(parseGroqDuration) {
-            return (value, true)
         }
         // x-ratelimit-reset-tokens carries the per-minute (TPM) reset, e.g. "7.66s".
         if let value = httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-tokens").flatMap(parseGroqDuration) {

--- a/Sources/LLMCooldownManager.swift
+++ b/Sources/LLMCooldownManager.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Tracks per-model rate-limit cooldowns so subsequent requests skip a rate-limited model
+/// instead of sending a doomed request and paying an extra round-trip.
+///
+/// Two storage tiers:
+///   - Minute-level limits (retry-after < 1 hour): stored in memory, cleared on app restart.
+///   - Daily limits (retry-after >= 1 hour): persisted in UserDefaults so the cooldown
+///     survives app restarts and is visible in the Settings UI.
+actor LLMCooldownManager {
+
+    /// Shared instance used by all PostProcessingService instances across the app.
+    /// Rate limits apply at the Groq organization level, so one shared state is correct.
+    static let shared = LLMCooldownManager()
+
+    /// Cooldowns at or above this threshold are treated as daily limits and persisted.
+    private let dailyLimitThreshold: TimeInterval = 3600
+
+    /// Fallback cooldown used when a 429 carries no parseable timing header. Kept well below
+    /// `dailyLimitThreshold` so it stays in memory and lets the next call re-probe soon.
+    private static let defaultReprobeCooldownSeconds: TimeInterval = 60
+
+    /// In-memory store for short-lived minute-level cooldowns.
+    private var cooldowns: [String: Date] = [:]
+
+    /// Returns true if the given model is currently blocked by a rate-limit cooldown.
+    /// Checks both in-memory (minute-level) and UserDefaults (daily-level) stores.
+    func isInCooldown(_ model: String) -> Bool {
+        let now = Date()
+
+        // Check in-memory store first — minute-level limits live here.
+        if let until = cooldowns[model] {
+            if now < until { return true }
+            // Entry expired; remove it to keep the dictionary clean.
+            cooldowns.removeValue(forKey: model)
+        }
+
+        // Check UserDefaults for persisted daily-limit entries.
+        if let until = persistedExpiry(for: model) {
+            if now < until { return true }
+            // Entry expired; remove it from UserDefaults.
+            clearPersistedExpiry(for: model)
+        }
+
+        return false
+    }
+
+    /// Registers a cooldown for a model using the retry-after duration from the API 429 response.
+    /// Minute-level durations stay in memory; daily-level durations are also written to UserDefaults.
+    func setCooldown(_ model: String, retryAfterSeconds: TimeInterval) {
+        let expiryDate = Date().addingTimeInterval(retryAfterSeconds)
+        if retryAfterSeconds >= dailyLimitThreshold {
+            // Daily limit: persist to UserDefaults so it survives app restarts.
+            persistExpiry(expiryDate, for: model)
+        } else {
+            // Minute-level limit: keep in memory only; it will expire within minutes.
+            cooldowns[model] = expiryDate
+        }
+    }
+
+    /// Returns the model to use up-front: the fallback when the primary is in a rate-limit
+    /// cooldown and a fallback exists, otherwise the primary. Lets a caller route around a
+    /// cooling-down model in a single call. Behaviorally identical to the inline swap it replaces.
+    func effectivePrimary(_ primary: String, fallback: String?) -> String {
+        if isInCooldown(primary), let fallback {
+            return fallback
+        }
+        return primary
+    }
+
+    // MARK: - UserDefaults (daily-limit persistence)
+
+    /// Shared key format so SettingsView can read expiry dates without going through the actor.
+    /// nonisolated allows this to be called synchronously from SwiftUI view code.
+    nonisolated static func udKey(for model: String) -> String {
+        "llm_cooldown_expiry_\(model)"
+    }
+
+    /// Instance wrapper used internally by the actor methods below.
+    private func udKey(_ model: String) -> String {
+        Self.udKey(for: model)
+    }
+
+    /// Reads the persisted cooldown expiry for a model from UserDefaults.
+    /// Returns nil if no entry exists.
+    private func persistedExpiry(for model: String) -> Date? {
+        let timestamp = UserDefaults.standard.double(forKey: udKey(model))
+        guard timestamp > 0 else { return nil }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    /// Writes a cooldown expiry date for a model to UserDefaults as a Unix timestamp.
+    private func persistExpiry(_ date: Date, for model: String) {
+        UserDefaults.standard.set(date.timeIntervalSince1970, forKey: udKey(model))
+    }
+
+    /// Removes a model's cooldown entry from UserDefaults once it has expired.
+    private func clearPersistedExpiry(for model: String) {
+        UserDefaults.standard.removeObject(forKey: udKey(model))
+    }
+
+    // MARK: - Rate-limit header parsing
+
+    /// Reads how long a rate-limited model must cool down from a Groq 429 response.
+    /// Priority: `retry-after` (delta-seconds) → `x-ratelimit-reset-requests` (the daily /
+    /// Requests-Per-Day reset) → `x-ratelimit-reset-tokens` (the per-minute / Tokens-Per-Minute
+    /// reset) → a 60s fallback when no timing header is present. Reading reset-requests is what
+    /// lets a genuine daily limit cross the persistence threshold and surface in Settings.
+    /// nonisolated static so the HTTP call site computes it synchronously without an actor hop.
+    nonisolated static func retryAfterSeconds(from httpResponse: HTTPURLResponse) -> TimeInterval {
+        // retry-after is the authoritative wait Groq sets specifically on a 429.
+        if let value = httpResponse.value(forHTTPHeaderField: "retry-after").flatMap(parseGroqDuration) {
+            return value
+        }
+        // x-ratelimit-reset-requests carries the daily (RPD) reset, e.g. "2m59.56s" or hours.
+        if let value = httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-requests").flatMap(parseGroqDuration) {
+            return value
+        }
+        // x-ratelimit-reset-tokens carries the per-minute (TPM) reset, e.g. "7.66s".
+        if let value = httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-tokens").flatMap(parseGroqDuration) {
+            return value
+        }
+        // No timing header present (rare): cool down briefly so the next call can re-probe.
+        return Self.defaultReprobeCooldownSeconds
+    }
+
+    /// Parses a Groq duration string into a TimeInterval. Accepts bare seconds ("2", "7.66"),
+    /// a single suffixed unit ("7.66s", "120ms"), and compound forms ("2m59.56s", "1h0m0s",
+    /// "1h2m3.5s"). Returns nil for empty, unrecognized-unit, negative, or non-finite input —
+    /// so a malformed header can never yield a negative/NaN/infinite cooldown.
+    private nonisolated static func parseGroqDuration(_ value: String) -> TimeInterval? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        // A bare number is plain seconds — covers the `retry-after` integer form ("2").
+        // Reject NaN/infinite/negative (Double() also accepts "nan"/"inf"/"-3"/"0x10").
+        if let seconds = Double(trimmed) { return (seconds.isFinite && seconds >= 0) ? seconds : nil }
+        // Otherwise accumulate <number><unit> segments left to right (h, m, s, ms).
+        var total: TimeInterval = 0
+        var numberBuffer = ""
+        var matchedAnyUnit = false
+        var index = trimmed.startIndex
+        while index < trimmed.endIndex {
+            let character = trimmed[index]
+            if character.isNumber || character == "." {
+                numberBuffer.append(character)
+                index = trimmed.index(after: index)
+                continue
+            }
+            // Hit a unit: the preceding digits must form a valid number.
+            guard let number = Double(numberBuffer) else { return nil }
+            numberBuffer = ""
+            // "ms" must be checked before the single-letter "m"/"s".
+            if trimmed[index...].hasPrefix("ms") {
+                total += number / 1000.0
+                index = trimmed.index(index, offsetBy: 2)
+            } else if character == "h" {
+                total += number * 3600.0
+                index = trimmed.index(after: index)
+            } else if character == "m" {
+                total += number * 60.0
+                index = trimmed.index(after: index)
+            } else if character == "s" {
+                total += number
+                index = trimmed.index(after: index)
+            } else {
+                return nil // Unrecognized unit.
+            }
+            matchedAnyUnit = true
+        }
+        // Reject a trailing number with no unit (e.g. "1h30") and unit-less input.
+        guard numberBuffer.isEmpty, matchedAnyUnit else { return nil }
+        // Reject a non-finite/negative accumulated total for the same safety reason.
+        return (total.isFinite && total >= 0) ? total : nil
+    }
+}

--- a/Sources/LLMCooldownManager.swift
+++ b/Sources/LLMCooldownManager.swift
@@ -47,9 +47,11 @@ actor LLMCooldownManager {
 
     /// Registers a cooldown for a model using the retry-after duration from the API 429 response.
     /// Minute-level durations stay in memory; daily-level durations are also written to UserDefaults.
-    func setCooldown(_ model: String, retryAfterSeconds: TimeInterval) {
+    /// Pass `persist: true` for a daily-limit signal (the RPD reset header) so a daily quota that
+    /// happens to reset in under an hour is still persisted and shown in Settings, not kept in memory.
+    func setCooldown(_ model: String, retryAfterSeconds: TimeInterval, persist: Bool = false) {
         let expiryDate = Date().addingTimeInterval(retryAfterSeconds)
-        if retryAfterSeconds >= dailyLimitThreshold {
+        if persist || retryAfterSeconds >= dailyLimitThreshold {
             // Daily limit: persist to UserDefaults so it survives app restarts.
             persistExpiry(expiryDate, for: model)
         } else {
@@ -101,27 +103,28 @@ actor LLMCooldownManager {
 
     // MARK: - Rate-limit header parsing
 
-    /// Reads how long a rate-limited model must cool down from a Groq 429 response.
+    /// Reads from a Groq 429 response how long the model must cool down AND whether the limit is a
+    /// daily one (so the caller persists it even when the remaining time is short).
     /// Priority: `retry-after` (delta-seconds) → `x-ratelimit-reset-requests` (the daily /
     /// Requests-Per-Day reset) → `x-ratelimit-reset-tokens` (the per-minute / Tokens-Per-Minute
-    /// reset) → a 60s fallback when no timing header is present. Reading reset-requests is what
-    /// lets a genuine daily limit cross the persistence threshold and surface in Settings.
-    /// nonisolated static so the HTTP call site computes it synchronously without an actor hop.
-    nonisolated static func retryAfterSeconds(from httpResponse: HTTPURLResponse) -> TimeInterval {
+    /// reset) → a short re-probe fallback when no timing header is present. Only the RPD header
+    /// marks the limit daily; `retry-after` is ambiguous, so its daily-ness is left to the duration
+    /// threshold in `setCooldown`. nonisolated static so the call site computes it without an actor hop.
+    nonisolated static func rateLimitCooldown(from httpResponse: HTTPURLResponse) -> (seconds: TimeInterval, isDaily: Bool) {
         // retry-after is the authoritative wait Groq sets specifically on a 429.
         if let value = httpResponse.value(forHTTPHeaderField: "retry-after").flatMap(parseGroqDuration) {
-            return value
+            return (value, false)
         }
         // x-ratelimit-reset-requests carries the daily (RPD) reset, e.g. "2m59.56s" or hours.
         if let value = httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-requests").flatMap(parseGroqDuration) {
-            return value
+            return (value, true)
         }
         // x-ratelimit-reset-tokens carries the per-minute (TPM) reset, e.g. "7.66s".
         if let value = httpResponse.value(forHTTPHeaderField: "x-ratelimit-reset-tokens").flatMap(parseGroqDuration) {
-            return value
+            return (value, false)
         }
         // No timing header present (rare): cool down briefly so the next call can re-probe.
-        return Self.defaultReprobeCooldownSeconds
+        return (Self.defaultReprobeCooldownSeconds, false)
     }
 
     /// Parses a Groq duration string into a TimeInterval. Accepts bare seconds ("2", "7.66"),

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -262,9 +262,13 @@ Behavior:
         var primaryModel = resolvedPrimaryModel()
         let retryModel = resolvedRetryModel(for: primaryModel)
 
-        // Circuit breaker: swap to the fallback up-front if the primary is cooling down.
-        // Reassigning primaryModel keeps the call site below byte-identical to upstream.
-        primaryModel = await LLMCooldownManager.shared.effectivePrimary(primaryModel, fallback: retryModel)
+        // Circuit breaker: pick a model that isn't cooling down. If BOTH are cooling, skip cleanup
+        // and return the raw transcript rather than send a doomed request. Reassigning primaryModel
+        // keeps the call site below byte-identical to upstream.
+        guard let availableModel = await LLMCooldownManager.shared.effectivePrimary(primaryModel, fallback: retryModel) else {
+            return PostProcessingResult(transcript: transcript.trimmingCharacters(in: .whitespacesAndNewlines), prompt: "")
+        }
+        primaryModel = availableModel
 
         do {
             return try await process(
@@ -341,8 +345,12 @@ Behavior:
         var primaryModel = resolvedPrimaryModel()
         let retryModel = resolvedRetryModel(for: primaryModel)
 
-        // Circuit breaker: swap to the fallback up-front if the primary is cooling down.
-        primaryModel = await LLMCooldownManager.shared.effectivePrimary(primaryModel, fallback: retryModel)
+        // Circuit breaker: pick a model that isn't cooling down. If BOTH are cooling, skip the
+        // transform and return the selection unchanged rather than send a doomed request.
+        guard let availableModel = await LLMCooldownManager.shared.effectivePrimary(primaryModel, fallback: retryModel) else {
+            return PostProcessingResult(transcript: selectedText, prompt: "")
+        }
+        primaryModel = availableModel
 
         do {
             return try await processCommandTransform(

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -2,6 +2,9 @@ import Foundation
 
 enum PostProcessingError: LocalizedError {
     case requestFailed(Int, String)
+    /// The model rejected the request because its rate limit was exceeded.
+    /// Carries the model name and the number of seconds until the limit resets.
+    case rateLimited(model: String, retryAfter: TimeInterval)
     case invalidResponse(String)
     case invalidInput(String)
     case emptyOutput
@@ -12,6 +15,8 @@ enum PostProcessingError: LocalizedError {
         switch self {
         case .requestFailed(let statusCode, let details):
             "Post-processing failed with status \(statusCode): \(details)"
+        case .rateLimited(let model, let retryAfter):
+            "Model \(model) rate-limited — retry in \(Int(retryAfter))s"
         case .invalidResponse(let details):
             "Invalid post-processing response: \(details)"
         case .invalidInput(let details):
@@ -254,8 +259,13 @@ Behavior:
         customSystemPrompt: String = "",
         outputLanguage: String = ""
     ) async throws -> PostProcessingResult {
-        let primaryModel = resolvedPrimaryModel()
+        var primaryModel = resolvedPrimaryModel()
         let retryModel = resolvedRetryModel(for: primaryModel)
+
+        // Circuit breaker: swap to the fallback up-front if the primary is cooling down.
+        // Reassigning primaryModel keeps the call site below byte-identical to upstream.
+        primaryModel = await LLMCooldownManager.shared.effectivePrimary(primaryModel, fallback: retryModel)
+
         do {
             return try await process(
                 transcript: transcript,
@@ -266,11 +276,17 @@ Behavior:
                 outputLanguage: outputLanguage
             )
         } catch let error as PostProcessingError {
+            // Unified fallback policy: decide whether to retry on the other model.
             let shouldFallback: Bool
             switch error {
+            case .rateLimited:
+                // The cooldown was already registered inside process() when the 429 was
+                // detected — for the fallback attempt too — so here we only switch models.
+                shouldFallback = true
             case .requestFailed(let statusCode, _):
                 shouldFallback = statusCode == 429
             case .emptyOutput:
+                // Empty output is a soft failure; try the other model once before giving up.
                 shouldFallback = true
             case .suspectedInstructionExecution:
                 shouldFallback = true
@@ -282,7 +298,8 @@ Behavior:
                 throw error
             }
 
-            guard let retryModel else {
+            // Guard against re-trying the same model when primaryModel is already the fallback.
+            guard let retryModel, primaryModel != retryModel else {
                 throw error
             }
 
@@ -311,8 +328,12 @@ Behavior:
         customVocabulary: [String],
         outputLanguage: String = ""
     ) async throws -> PostProcessingResult {
-        let primaryModel = resolvedPrimaryModel()
+        var primaryModel = resolvedPrimaryModel()
         let retryModel = resolvedRetryModel(for: primaryModel)
+
+        // Circuit breaker: swap to the fallback up-front if the primary is cooling down.
+        primaryModel = await LLMCooldownManager.shared.effectivePrimary(primaryModel, fallback: retryModel)
+
         do {
             return try await processCommandTransform(
                 selectedText: selectedText,
@@ -323,11 +344,15 @@ Behavior:
                 outputLanguage: outputLanguage
             )
         } catch let error as PostProcessingError {
+            // Unified fallback policy: decide whether to retry on the other model.
             let shouldFallback: Bool
             switch error {
-            case .requestFailed(let statusCode, _):
-                shouldFallback = statusCode == 429
+            case .rateLimited:
+                // The cooldown was already registered inside processCommandTransform() when the
+                // 429 was detected — for the fallback attempt too — so here we only switch models.
+                shouldFallback = true
             case .emptyOutput:
+                // Empty output is a soft failure; try the other model once before giving up.
                 shouldFallback = true
             default:
                 shouldFallback = false
@@ -337,7 +362,8 @@ Behavior:
                 throw error
             }
 
-            guard let retryModel else {
+            // Guard against re-trying the same model when primaryModel is already the fallback.
+            guard let retryModel, primaryModel != retryModel else {
                 throw error
             }
 
@@ -465,6 +491,15 @@ Model: \(model)
         }
 
         guard httpResponse.statusCode == 200 else {
+            // For 429 responses, read how long the model is rate-limited from the headers so
+            // the circuit breaker knows exactly when it becomes available again.
+            if httpResponse.statusCode == 429 {
+                // Register the cooldown here so BOTH the primary and the fallback attempt feed
+                // the breaker (the retry calls this same method), then surface the error.
+                let retryAfter = LLMCooldownManager.retryAfterSeconds(from: httpResponse)
+                await LLMCooldownManager.shared.setCooldown(model, retryAfterSeconds: retryAfter)
+                throw PostProcessingError.rateLimited(model: model, retryAfter: retryAfter)
+            }
             let message = String(data: data, encoding: .utf8) ?? ""
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
         }
@@ -476,7 +511,7 @@ Model: \(model)
               let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
-        
+
         var content = rawContent
         if config.shouldStripThinkTags {
             content = ModelConfiguration.stripThinkTags(content)
@@ -596,6 +631,13 @@ Model: \(model)
         }
 
         guard httpResponse.statusCode == 200 else {
+            // Same 429 handling as process(): register the cooldown for whichever model
+            // (primary or fallback) hit the limit, then surface the error.
+            if httpResponse.statusCode == 429 {
+                let retryAfter = LLMCooldownManager.retryAfterSeconds(from: httpResponse)
+                await LLMCooldownManager.shared.setCooldown(model, retryAfterSeconds: retryAfter)
+                throw PostProcessingError.rateLimited(model: model, retryAfter: retryAfter)
+            }
             let message = String(data: data, encoding: .utf8) ?? ""
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
         }
@@ -607,7 +649,7 @@ Model: \(model)
               let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
-        
+
         var content = rawContent
         if config.shouldStripThinkTags {
             content = ModelConfiguration.stripThinkTags(content)

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -298,8 +298,18 @@ Behavior:
                 throw error
             }
 
-            // Guard against re-trying the same model when primaryModel is already the fallback.
-            guard let retryModel, primaryModel != retryModel else {
+            // No distinct fallback left to try. Still honor the raw-transcript safe-exit for a
+            // suspected-instruction-execution so an up-front cooldown swap doesn't lose it.
+            guard let retryModel else {
+                throw error
+            }
+            guard primaryModel != retryModel else {
+                if case .suspectedInstructionExecution = error {
+                    return PostProcessingResult(
+                        transcript: transcript.trimmingCharacters(in: .whitespacesAndNewlines),
+                        prompt: ""
+                    )
+                }
                 throw error
             }
 
@@ -496,9 +506,9 @@ Model: \(model)
             if httpResponse.statusCode == 429 {
                 // Register the cooldown here so BOTH the primary and the fallback attempt feed
                 // the breaker (the retry calls this same method), then surface the error.
-                let retryAfter = LLMCooldownManager.retryAfterSeconds(from: httpResponse)
-                await LLMCooldownManager.shared.setCooldown(model, retryAfterSeconds: retryAfter)
-                throw PostProcessingError.rateLimited(model: model, retryAfter: retryAfter)
+                let cooldown = LLMCooldownManager.rateLimitCooldown(from: httpResponse)
+                await LLMCooldownManager.shared.setCooldown(model, retryAfterSeconds: cooldown.seconds, persist: cooldown.isDaily)
+                throw PostProcessingError.rateLimited(model: model, retryAfter: cooldown.seconds)
             }
             let message = String(data: data, encoding: .utf8) ?? ""
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
@@ -634,9 +644,9 @@ Model: \(model)
             // Same 429 handling as process(): register the cooldown for whichever model
             // (primary or fallback) hit the limit, then surface the error.
             if httpResponse.statusCode == 429 {
-                let retryAfter = LLMCooldownManager.retryAfterSeconds(from: httpResponse)
-                await LLMCooldownManager.shared.setCooldown(model, retryAfterSeconds: retryAfter)
-                throw PostProcessingError.rateLimited(model: model, retryAfter: retryAfter)
+                let cooldown = LLMCooldownManager.rateLimitCooldown(from: httpResponse)
+                await LLMCooldownManager.shared.setCooldown(model, retryAfterSeconds: cooldown.seconds, persist: cooldown.isDaily)
+                throw PostProcessingError.rateLimited(model: model, retryAfter: cooldown.seconds)
             }
             let message = String(data: data, encoding: .utf8) ?? ""
             throw PostProcessingError.requestFailed(httpResponse.statusCode, message)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -119,6 +119,16 @@ struct ProviderSettingsFields: View {
         return date > now ? date : nil
     }
 
+    /// Formats a cooldown reset time, including the date only when the reset falls on a later day,
+    /// so a daily limit that resets after midnight is not shown as an ambiguous bare time.
+    private func formattedCooldownReset(_ expiry: Date) -> String {
+        // Calendar.isDate(_:inSameDayAs:) is a macOS-native calendar-aware same-day comparison.
+        if Calendar.current.isDate(expiry, inSameDayAs: now) {
+            return expiry.formatted(date: .omitted, time: .shortened)
+        }
+        return expiry.formatted(date: .abbreviated, time: .shortened)
+    }
+
     private func commitContextModel() {
         let trimmed = contextModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         contextModelDraft = trimmed
@@ -193,7 +203,7 @@ struct ProviderSettingsFields: View {
             // Disappears automatically once the limit window resets.
             if let expiry = dailyCooldownExpiry(for: appState.postProcessingModel) {
                 Label {
-                    Text("Daily limit reached — resets at \(expiry.formatted(date: .omitted, time: .shortened))")
+                    Text("Daily limit reached — resets at \(formattedCooldownReset(expiry))")
                 } icon: {
                     Image(systemName: "exclamationmark.triangle.fill")
                 }
@@ -218,7 +228,7 @@ struct ProviderSettingsFields: View {
             // In this state, both models are unavailable until their limits reset.
             if let expiry = dailyCooldownExpiry(for: appState.postProcessingFallbackModel) {
                 Label {
-                    Text("Fallback daily limit reached — resets at \(expiry.formatted(date: .omitted, time: .shortened))")
+                    Text("Fallback daily limit reached — resets at \(formattedCooldownReset(expiry))")
                 } icon: {
                     Image(systemName: "exclamationmark.triangle.fill")
                 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -56,6 +56,10 @@ struct ProviderSettingsFields: View {
     @State private var postProcessingModelDraft: String = ""
     @State private var postProcessingFallbackModelDraft: String = ""
     @State private var contextModelDraft: String = ""
+    /// Updated by the cooldown timer so warning labels clear at expiry without user interaction.
+    @State private var now: Date = Date()
+    /// Tracks whether the Settings window is the frontmost active window.
+    @Environment(\.controlActiveState) private var controlActiveState
 
     let showsModelDescription: Bool
 
@@ -92,6 +96,27 @@ struct ProviderSettingsFields: View {
         postProcessingFallbackModelDraft = trimmed
         guard appState.postProcessingFallbackModel != trimmed else { return }
         appState.postProcessingFallbackModel = trimmed
+    }
+
+    /// True when this view's hosting window is the frontmost key window. While true a 5s timer
+    /// advances `now`, so a daily-limit warning appears within ~5s of being written and clears
+    /// within ~5s of expiry. SwiftUI removes the timer when this view leaves the hierarchy
+    /// (switching tabs or dismissing the Setup sheet). The timer must NOT be gated on a warning
+    /// already being visible: nothing else observes the UserDefaults cooldown keys, so a freshly
+    /// written cooldown would otherwise never trigger a re-render. Cost is negligible.
+    private var shouldRunCooldownTimer: Bool {
+        controlActiveState == .key
+    }
+
+    /// Reads the persisted daily-limit expiry date for a model directly from UserDefaults.
+    /// Uses the shared key from LLMCooldownManager to avoid duplicating the storage contract.
+    /// Returns nil if no daily limit is active or if the entry has already expired.
+    private func dailyCooldownExpiry(for model: String) -> Date? {
+        let key = LLMCooldownManager.udKey(for: model)
+        let timestamp = UserDefaults.standard.double(forKey: key)
+        guard timestamp > 0 else { return nil }
+        let date = Date(timeIntervalSince1970: timestamp)
+        return date > now ? date : nil
     }
 
     private func commitContextModel() {
@@ -164,6 +189,18 @@ struct ProviderSettingsFields: View {
                 }
             )
 
+            // Shows when this model has hit its daily Groq rate limit.
+            // Disappears automatically once the limit window resets.
+            if let expiry = dailyCooldownExpiry(for: appState.postProcessingModel) {
+                Label {
+                    Text("Daily limit reached — resets at \(expiry.formatted(date: .omitted, time: .shortened))")
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                }
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
+
             ModelDropdownView(
                 title: "Post-Processing Fallback Model",
                 subtitle: "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.",
@@ -176,6 +213,18 @@ struct ProviderSettingsFields: View {
                     appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
                 }
             )
+
+            // Shows when the fallback model has also hit its daily limit.
+            // In this state, both models are unavailable until their limits reset.
+            if let expiry = dailyCooldownExpiry(for: appState.postProcessingFallbackModel) {
+                Label {
+                    Text("Fallback daily limit reached — resets at \(expiry.formatted(date: .omitted, time: .shortened))")
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                }
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
 
             ModelDropdownView(
                 title: "Context Model",
@@ -339,6 +388,15 @@ struct ProviderSettingsFields: View {
             if !isEditingContextModel {
                 contextModelDraft = value
             }
+        }
+        // Tick every 5s while this view's window is key so a daily-limit warning can appear and
+        // auto-clear without any external state change. SwiftUI removes this timer when the
+        // window is backgrounded or this view leaves the hierarchy (tab switch or sheet dismissal).
+        if shouldRunCooldownTimer {
+            Color.clear.frame(width: 0, height: 0)
+                .onReceive(Timer.publish(every: 5, on: .main, in: .common).autoconnect()) { value in
+                    now = value
+                }
         }
     }
 }


### PR DESCRIPTION
Supersedes #238. That PR was reworked from scratch after a self-review surfaced edge cases in the 429 handling and to shrink the footprint in `PostProcessingService.swift`. Opening a fresh PR so the review starts clean on the final code.

## Summary

When the post-processing (cleanup) model returns HTTP 429 (rate limit), the app now records a short per-model cooldown and routes the next requests to the backup model up-front, instead of retrying the rate-limited model on every dictation. Daily limits are persisted and shown in Settings so you can see when a model is unavailable until its quota resets.

## Changes

| Component | Details |
|---|---|
| `LLMCooldownManager.swift` (new) | Small actor that records per-model cooldowns — minute-level in memory, daily (>= 1h) persisted to UserDefaults. Also owns the 429 header parsing (`retryAfterSeconds` / `parseGroqDuration`) and the up-front model choice (`effectivePrimary`). Self-contained so the backbone stays thin. |
| `PostProcessingService.swift` | Minimal hooks only: on a 429, register the cooldown and surface a `.rateLimited` error; before each request, switch to the backup if the primary is cooling down. |
| `SettingsView.swift` | A per-model daily-limit warning that appears when a limit is hit and auto-clears as the window resets. |

## What was wrong before (and is now fixed)

- Daily limits were never detected: only the per-minute reset header was read, and the duration parser only understood a bare `"<n>s"`, so daily limits never crossed the persistence threshold or showed in Settings. The daily-reset header is now read and compound formats (`2m59.56s`, `1h0m0s`, `120ms`) are parsed.
- The backup model's own rate limit was never recorded; now both the primary and the backup feed the breaker.
- The Settings warning did not refresh on its own; it now appears and auto-clears within a few seconds.

## Edge cases considered

- Malformed, negative, or non-finite header values are rejected, so a bad header can never produce a negative, NaN, or infinite cooldown.
- No backup configured, or both models rate-limited: the request falls through gracefully without retrying the same model.
- Header lookup is case-insensitive; when no timing header is present, a short re-probe cooldown is used.

## Testing

- The duration parser was unit-tested across bare, suffixed, compound, and invalid inputs (including negative / NaN / infinite, all rejected).
- Built and run in the integrated local build alongside the other in-progress features; no conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cooldown tracking for rate-limited models to reduce repeated 429 retries.
  * The app now routes requests to a fallback model while the primary is cooling down.
  * Settings displays “daily limit reached” warnings with clearer reset times and automatically hides them after expiry.
* **Bug Fixes**
  * Improved retry and fallback behavior by using rate-limit headers to determine cooldown duration and ensuring safe fallback selection.
  * Enhanced rate-limit messaging to report the affected model and retry-after time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->