### PR TITLE
Add Preserve exact wording toggle to skip LLM cleanup

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1191,7 +1191,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessingService: postProcessingService,
                     customVocabulary: capturedCustomVocabulary,
                     customSystemPrompt: capturedCustomSystemPrompt,
-                    outputLanguage: self.outputLanguage
+                    outputLanguage: self.outputLanguage,
+                    preserveExactWording: self.preserveExactWording
                 )
                 finalTranscript = result.finalTranscript
                 processingStatus = Self.statusMessage(
@@ -2436,6 +2437,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case postProcessingSucceeded
         case postProcessingFailedFallback
         case preservedExactWording
+        case preservedExactWordingTranslated
+        case preservedExactWordingTranslationFailedFallback
         case commandModeSucceeded(invocation: CommandInvocation)
         case commandModeFailedFallback(invocation: CommandInvocation)
 
@@ -2453,6 +2456,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     : "Post-processing failed, using raw transcript"
             case .preservedExactWording:
                 return "Preserved exact wording, skipped post-processing"
+            case .preservedExactWordingTranslated:
+                return "Preserved exact wording, translated to output language"
+            case .preservedExactWordingTranslationFailedFallback:
+                return "Verbatim translation failed, using untranslated raw transcript"
             case .commandModeSucceeded(let invocation):
                 return "Edit mode succeeded (\(invocation.rawValue))"
             case .commandModeFailedFallback(let invocation):
@@ -2468,7 +2475,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         postProcessingService: PostProcessingService,
         customVocabulary: String,
         customSystemPrompt: String,
-        outputLanguage: String = ""
+        outputLanguage: String = "",
+        preserveExactWording: Bool
     ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
         let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -2497,11 +2505,34 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return (macro.payload, .voiceMacro(command: macro.command), "")
         }
 
-        // Preserve-exact-wording mode: skip the LLM cleanup step so the
-        // raw transcript from the transcription service is used verbatim,
-        // including profanity and informal wording.
+        // Preserve-exact-wording mode. Two sub-cases so translation
+        // stays honored:
+        //
+        //   1. No Output Language set — skip the LLM entirely and
+        //      return the raw transcript verbatim.
+        //   2. Output Language IS set — route through a stripped-down
+        //      translate-only prompt. The user asked for another
+        //      language; silently dropping translation defeats their
+        //      settings. The translate-only path preserves filler,
+        //      informal wording, and profanity 1:1 while still hitting
+        //      the target language.
         if preserveExactWording {
-            return (trimmedRawTranscript, .preservedExactWording, "")
+            let targetLanguage = outputLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+            if targetLanguage.isEmpty {
+                return (trimmedRawTranscript, .preservedExactWording, "")
+            }
+            do {
+                let result = try await postProcessingService.translateVerbatim(
+                    transcript: trimmedRawTranscript,
+                    targetLanguage: targetLanguage
+                )
+                return (result.transcript, .preservedExactWordingTranslated, result.prompt)
+            } catch {
+                os_log(.error, log: recordingLog,
+                       "Verbatim translation failed: %{public}@",
+                       error.localizedDescription)
+                return (trimmedRawTranscript, .preservedExactWordingTranslationFailedFallback, "")
+            }
         }
 
         do {
@@ -2671,7 +2702,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         postProcessingService: postProcessingService,
                         customVocabulary: self.customVocabulary,
                         customSystemPrompt: self.customSystemPrompt,
-                        outputLanguage: self.outputLanguage
+                        outputLanguage: self.outputLanguage,
+                        preserveExactWording: self.preserveExactWording
                     )
                     try Task.checkCancellation()
 
@@ -2718,7 +2750,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
                         let shouldPersistRawDictationFallback: Bool
                         switch result.outcome {
-                        case .postProcessingFailedFallback:
+                        case .postProcessingFailedFallback,
+                             .preservedExactWordingTranslationFailedFallback:
                             shouldPersistRawDictationFallback = !trimmedFinalTranscript.isEmpty
                         default:
                             shouldPersistRawDictationFallback = false

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -223,6 +223,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let contextScreenshotMaxDimensionStorageKey = "context_screenshot_max_dimension"
     private let shortcutStartDelayStorageKey = "shortcut_start_delay"
     private let preserveClipboardStorageKey = "preserve_clipboard"
+    private let preserveExactWordingStorageKey = "preserve_exact_wording"
     private let keepDictationInClipboardHistoryStorageKey = "keep_dictation_in_clipboard_history"
     private let pressEnterVoiceCommandStorageKey = "press_enter_voice_command_enabled"
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
@@ -505,6 +506,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var preserveExactWording: Bool {
+        didSet {
+            UserDefaults.standard.set(preserveExactWording, forKey: preserveExactWordingStorageKey)
+        }
+    }
+
     @Published var keepDictationInClipboardHistory: Bool {
         didSet {
             UserDefaults.standard.set(keepDictationInClipboardHistory, forKey: keepDictationInClipboardHistoryStorageKey)
@@ -676,6 +683,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
+        let preserveExactWording = UserDefaults.standard.bool(forKey: preserveExactWordingStorageKey)
         let keepDictationInClipboardHistory = UserDefaults.standard.bool(forKey: keepDictationInClipboardHistoryStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
@@ -750,6 +758,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.outputLanguage = outputLanguage
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
+        self.preserveExactWording = preserveExactWording
         self.keepDictationInClipboardHistory = keepDictationInClipboardHistory
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
@@ -2426,6 +2435,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case voiceMacro(command: String)
         case postProcessingSucceeded
         case postProcessingFailedFallback
+        case preservedExactWording
         case commandModeSucceeded(invocation: CommandInvocation)
         case commandModeFailedFallback(invocation: CommandInvocation)
 
@@ -2441,6 +2451,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return isRetry
                     ? "Post-processing failed on retry, using raw transcript"
                     : "Post-processing failed, using raw transcript"
+            case .preservedExactWording:
+                return "Preserved exact wording, skipped post-processing"
             case .commandModeSucceeded(let invocation):
                 return "Edit mode succeeded (\(invocation.rawValue))"
             case .commandModeFailedFallback(let invocation):
@@ -2484,7 +2496,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             os_log(.info, log: recordingLog, "Voice macro triggered: %{public}@", macro.command)
             return (macro.payload, .voiceMacro(command: macro.command), "")
         }
-        
+
+        // Preserve-exact-wording mode: skip the LLM cleanup step so the
+        // raw transcript from the transcription service is used verbatim,
+        // including profanity and informal wording.
+        if preserveExactWording {
+            return (trimmedRawTranscript, .preservedExactWording, "")
+        }
+
         do {
             let result = try await postProcessingService.postProcess(
                 transcript: trimmedRawTranscript,

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -814,8 +814,26 @@ Model: \(model)
         guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PostProcessingError.emptyOutput
         }
-        let sanitized = sanitizePostProcessedTranscript(content)
+        let sanitized = sanitizeVerbatimTranslation(content)
         return PostProcessingResult(transcript: sanitized, prompt: promptForDisplay)
+    }
+
+    /// Sanitizer for the verbatim translation path. Deliberately
+    /// omits the `"EMPTY"` sentinel that `sanitizePostProcessedTranscript`
+    /// uses — that sentinel is reserved by the cleanup prompt (which
+    /// asks the LLM to return `EMPTY` when there's nothing to paste).
+    /// The verbatim prompt has no such instruction, so a legitimate
+    /// literal translation of the word "empty" must reach the user
+    /// instead of being silently dropped.
+    private func sanitizeVerbatimTranslation(_ value: String) -> String {
+        var result = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !result.isEmpty else { return "" }
+        if result.hasPrefix("\"") && result.hasSuffix("\"") && result.count > 1 {
+            result.removeFirst()
+            result.removeLast()
+            result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return result
     }
 
     private func sanitizePostProcessedTranscript(_ value: String) -> String {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -197,6 +197,59 @@ Behavior:
         }
     }
 
+    /// Translate a raw transcript into the target language without
+    /// performing any of the polishing normally applied by the cleanup
+    /// pipeline. Preserves original phrasing 1:1 — no filler removal,
+    /// no reformatting, no rewording, no punctuation additions beyond
+    /// what's grammatically required by the target language.
+    ///
+    /// Used by the "Preserve exact wording" path when the user has
+    /// also configured an Output Language: skipping the LLM entirely
+    /// there would silently drop translation, so we route through a
+    /// minimal translate-only prompt instead.
+    func translateVerbatim(
+        transcript: String,
+        targetLanguage: String
+    ) async throws -> PostProcessingResult {
+        let trimmedTranscript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTranscript.isEmpty else {
+            throw PostProcessingError.invalidInput("Transcript must not be empty")
+        }
+        let trimmedLanguage = targetLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLanguage.isEmpty else {
+            throw PostProcessingError.invalidInput("Target language must not be empty")
+        }
+
+        let timeoutSeconds = postProcessingTimeoutSeconds
+        return try await withThrowingTaskGroup(of: PostProcessingResult.self) { group in
+            group.addTask { [weak self] in
+                guard let self else {
+                    throw PostProcessingError.invalidResponse("Post-processing service deallocated")
+                }
+                return try await self.translateVerbatimWithFallback(
+                    transcript: trimmedTranscript,
+                    targetLanguage: trimmedLanguage
+                )
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                throw PostProcessingError.requestTimedOut(timeoutSeconds)
+            }
+
+            do {
+                guard let result = try await group.next() else {
+                    throw PostProcessingError.invalidResponse("No translation result")
+                }
+                group.cancelAll()
+                return result
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+        }
+    }
+
     func commandTransform(
         selectedText: String,
         voiceCommand: String,
@@ -626,6 +679,143 @@ Model: \(model)
 
     static func applyOutputLanguage(_ prompt: String, language: String) -> String {
         prompt + "\n\nIMPORTANT: Translate the final cleaned text into \(language). Output ONLY in \(language), regardless of the original spoken language."
+    }
+
+    /// System prompt used for verbatim translation. Deliberately
+    /// minimal — the whole point of this path is to translate word-
+    /// for-word without cleanup, so we avoid every rewrite / formatting
+    /// instruction from `defaultSystemPrompt`.
+    static func verbatimTranslationSystemPrompt(targetLanguage: String) -> String {
+        """
+        You are a literal translator.
+
+        Translate the user's transcript into \(targetLanguage) as literally as possible.
+
+        Rules:
+        - Preserve every word the user spoke, including filler words such as "um", "uh", "like", "you know", false starts, and repetitions. Translate these into the closest natural equivalent in \(targetLanguage) rather than deleting them.
+        - Do NOT reword, summarize, restructure, or improve the sentence.
+        - Do NOT correct grammar mistakes, awkward phrasing, or informal wording. Keep the same register and flow.
+        - Do NOT add punctuation beyond what the target language grammatically requires. If the source has no punctuation, add only the minimum needed to make the sentence readable in \(targetLanguage).
+        - Do NOT wrap the output in quotes or explain your translation. Return only the translated text.
+        - Keep profanity, slang, and explicit language intact.
+        - Output ONLY in \(targetLanguage), regardless of the source language.
+        """
+    }
+
+    private func translateVerbatimWithFallback(
+        transcript: String,
+        targetLanguage: String
+    ) async throws -> PostProcessingResult {
+        let primaryModel = resolvedPrimaryModel()
+        let retryModel = resolvedRetryModel(for: primaryModel)
+        do {
+            return try await translateVerbatim(
+                transcript: transcript,
+                targetLanguage: targetLanguage,
+                model: primaryModel
+            )
+        } catch let error as PostProcessingError {
+            let shouldFallback: Bool
+            switch error {
+            case .requestFailed(let statusCode, _):
+                shouldFallback = statusCode == 429
+            case .emptyOutput:
+                shouldFallback = true
+            default:
+                shouldFallback = false
+            }
+            guard shouldFallback, let retryModel else { throw error }
+            return try await translateVerbatim(
+                transcript: transcript,
+                targetLanguage: targetLanguage,
+                model: retryModel
+            )
+        }
+    }
+
+    private func translateVerbatim(
+        transcript: String,
+        targetLanguage: String,
+        model: String
+    ) async throws -> PostProcessingResult {
+        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = postProcessingTimeoutSeconds
+
+        let systemPrompt = Self.verbatimTranslationSystemPrompt(targetLanguage: targetLanguage)
+        let userMessage = """
+        Translate the transcript below into \(targetLanguage), keeping the wording literal.
+
+        TRANSCRIPT:
+        <<<TRANSCRIPT
+        \(transcript)
+        TRANSCRIPT
+        """
+
+        let promptForDisplay = """
+        Model: \(model)
+
+        [System]
+        \(systemPrompt)
+
+        [User]
+        \(userMessage)
+        """
+
+        var payload: [String: Any] = [
+            "model": model,
+            "temperature": 0.0,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userMessage],
+            ],
+        ]
+        let config = ModelConfiguration.config(for: model)
+        if let maxTokens = config.maxCompletionTokens {
+            payload["max_completion_tokens"] = maxTokens
+        } else if model == defaultModel {
+            payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+        }
+        if let effort = config.reasoningEffort {
+            payload["reasoning_effort"] = effort
+        } else if model == defaultModel {
+            payload["reasoning_effort"] = defaultModelReasoningEffort
+        }
+        if let include = config.includeReasoning {
+            payload["include_reasoning"] = include
+        } else if model == defaultModel {
+            payload["include_reasoning"] = false
+        }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let (data, response) = try await LLMAPITransport.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PostProcessingError.invalidResponse("No HTTP response")
+        }
+        guard httpResponse.statusCode == 200 else {
+            let message = String(data: data, encoding: .utf8) ?? ""
+            throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
+        }
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let rawContent = message["content"] as? String else {
+            throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
+        }
+
+        var content = rawContent
+        if config.shouldStripThinkTags {
+            content = ModelConfiguration.stripThinkTags(content)
+        }
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PostProcessingError.emptyOutput
+        }
+        let sanitized = sanitizePostProcessedTranscript(content)
+        return PostProcessingResult(transcript: sanitized, prompt: promptForDisplay)
     }
 
     private func sanitizePostProcessedTranscript(_ value: String) -> String {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1196,7 +1196,11 @@ struct GeneralSettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             Toggle("Preserve exact wording", isOn: $appState.preserveExactWording)
 
-            Text("When on, \(AppName.displayName) skips the LLM cleanup step and pastes the raw transcript from the transcription service verbatim, including informal or explicit words. Voice macros and Edit Mode still run.")
+            Text("When on, \(AppName.displayName) skips the LLM cleanup step and pastes the transcript verbatim — filler words, informal phrasing, and explicit language are all preserved. Voice macros and Edit Mode still run.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("If Output Language is set, the transcript is still translated into that language, but the translation is literal: no rewording, no filler removal, no reformatting.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -663,6 +663,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("Edit Mode", icon: "pencil") {
                     commandModeSection
                 }
+                SettingsCard("Cleanup", icon: "sparkles") {
+                    cleanupSection
+                }
                 SettingsCard("Clipboard", icon: "doc.on.clipboard") {
                     clipboardSection
                 }
@@ -1184,6 +1187,18 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.red)
             }
+        }
+    }
+
+    // MARK: Cleanup
+
+    private var cleanupSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Preserve exact wording", isOn: $appState.preserveExactWording)
+
+            Text("When on, \(AppName.displayName) skips the LLM cleanup step and pastes the raw transcript from the transcription service verbatim, including informal or explicit words. Voice macros and Edit Mode still run.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 


### PR DESCRIPTION
## Summary

Add a **Preserve exact wording** toggle in Settings → Cleanup that, when enabled, skips the LLM post-processing step and pastes the raw transcript from the transcription service verbatim, including profanity, filler words, and informal wording.

## Motivation

There are legitimate cases where users want the raw transcript to reach the target text field unchanged:

- **Verbatim quotes and interviews** — journalism, research notes, court transcripts, etc., where any silent cleanup by the model could alter meaning.
- **Filler-word coaching** — some users record dictation deliberately to review how often they say "um", "like", etc., which the LLM currently strips.
- **Explicit language** — the cleanup model may sanitize wording the user actually intended.
- **Offline / rate-limited use** — post-processing is the slowest and most failure-prone part of the pipeline; letting users opt out gives them a fast, deterministic path that only depends on the transcription service.

## Behavior

- Default: **off**. No behavior change for existing users.
- When on: `processTranscript` returns the trimmed raw transcript early with a new `.preservedExactWording` `TranscriptProcessingOutcome` case. Post-processing is skipped entirely.
- **Voice macros and Edit Mode still run.** The early-return sits after the voice-macro lookup and does not affect the `commandInvocation` branches — those keep their existing semantics.
- The new outcome surfaces the status "Preserved exact wording, skipped post-processing" in the debug status line, keeping the existing status-message contract.

## Changes

- `Sources/AppState.swift` (+34, −1):
  - Storage key `preserveExactWordingStorageKey`.
  - `@Published var preserveExactWording: Bool` with `didSet` persistence, mirroring the existing `preserveClipboard` pattern.
  - Loaded in `init` from `UserDefaults` (defaults to `false`).
  - New `TranscriptProcessingOutcome.preservedExactWording` case with `statusMessage()`.
  - Early-return guard in `processTranscript` after the voice-macro branch and before `postProcessingService.postProcess(...)`.
- `Sources/SettingsView.swift` (+15):
  - New `SettingsCard("Cleanup", icon: "sparkles")` placed between "Edit Mode" and "Clipboard" in `GeneralSettingsView`.
  - `cleanupSection` with a `Toggle` bound to `appState.preserveExactWording` and a caption explaining the behavior.

Total diff: **+50 / −1** across 2 files, no new dependencies.

## Test plan

- Toggle off (default): identical behavior to `main`. Verified against the existing `postProcessingSucceeded` / `postProcessingFailedFallback` flows.
- Toggle on: raw transcript from Groq is pasted with no LLM pass. Voice macros still fire (verified with a test macro). Edit Mode still routes through `commandModeSucceeded`.
- Setting persists across app restarts.
- Status line reflects the new outcome.

## Notes for maintainers

Happy to adjust the label ("Preserve exact wording") or card placement if you have a preferred wording / grouping. The Cleanup card is new; if you'd rather fold the toggle into an existing card (e.g. "Edit Mode" or a new "Post-processing" grouping), the change is one-line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **“Preserve exact wording”** setting in General settings under a new **Cleanup** section.
* **Behavior Changes**
  * When enabled, transcript cleanup is skipped so the original wording is preserved.
  * If an Output Language is set, translation runs in a literal “verbatim” style and preserved-text outcomes are reflected in status.
  * Updated clipboard/raw-dictation fallback handling to treat translation-failed preserved wording consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->