### PR TITLE
feat: background HTTP pre-transcription while recording

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -694,7 +694,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let keepDictationInClipboardHistory = UserDefaults.standard.bool(forKey: keepDictationInClipboardHistoryStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
-        let prefetchTranscriptionEnabled = UserDefaults.standard.bool(forKey: prefetchTranscriptionEnabledStorageKey)
+        let prefetchTranscriptionEnabled = UserDefaults.standard.object(forKey: prefetchTranscriptionEnabledStorageKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: prefetchTranscriptionEnabledStorageKey)
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
@@ -2911,7 +2913,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func startPrefetchTranscriberIfEnabled() {
         guard prefetchTranscriptionEnabled, !realtimeStreamingEnabled else { return }
         guard let service = try? makeTranscriptionService() else { return }
-        let transcriber = PrefetchTranscriber(service: service)
+
+        // Durable transcript file: one chunk appended per 28 s as it completes.
+        // Named by Unix timestamp so recordings don't collide.
+        let ts = Int(Date().timeIntervalSince1970)
+        let saveURL = Self.audioStorageDirectory()
+            .appendingPathComponent("prefetch_transcript_\(ts).txt")
+
+        let transcriber = PrefetchTranscriber(service: service, saveURL: saveURL)
         prefetchTranscriber = transcriber
         audioRecorder.onPCM16Samples = { [weak transcriber] data in
             transcriber?.appendPCM16(data)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -234,6 +234,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let outputLanguageStorageKey = "output_language"
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
+    private let prefetchTranscriptionEnabledStorageKey = "prefetch_transcription_enabled"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -490,6 +491,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// When true, audio is transcribed in 28-second background chunks while
+    /// recording so only the tail needs processing after the user stops.
+    /// Ignored when ``realtimeStreamingEnabled`` is also true (realtime takes
+    /// priority). Works with any HTTP transcription provider.
+    @Published var prefetchTranscriptionEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(
+                prefetchTranscriptionEnabled,
+                forKey: prefetchTranscriptionEnabledStorageKey
+            )
+        }
+    }
+
     @Published var dictationAudioInterruptionEnabled: Bool {
         didSet {
             UserDefaults.standard.set(
@@ -606,6 +620,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
     private var realtimeService: RealtimeTranscriptionService?
+    private var prefetchTranscriber: PrefetchTranscriber?
     private var automaticTerminationDisabled = false
     private var activeAudioInterruption: ActiveAudioInterruption?
     private var pendingOverlayDismissToken: UUID?
@@ -679,6 +694,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let keepDictationInClipboardHistory = UserDefaults.standard.bool(forKey: keepDictationInClipboardHistoryStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
+        let prefetchTranscriptionEnabled = UserDefaults.standard.bool(forKey: prefetchTranscriptionEnabledStorageKey)
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
@@ -753,6 +769,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.keepDictationInClipboardHistory = keepDictationInClipboardHistory
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
+        self.prefetchTranscriptionEnabled = prefetchTranscriptionEnabled
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
@@ -2192,6 +2209,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         startRealtimeStreamingIfEnabled()
+        startPrefetchTranscriberIfEnabled()
 
         // Start engine on background thread so UI isn't blocked
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -2500,12 +2518,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    /// Await the realtime WebSocket's final transcript. If it errors out (or
-    /// was never started) fall back to the file-based POST so the user still
-    /// gets a transcript. Runs the realtime commit and file upload in that
-    /// strict order to avoid paying for both when realtime succeeds.
+    /// Resolve the final transcript, trying sources in priority order:
+    ///   1. realtime WebSocket (`realtimeService`) — lowest latency when available
+    ///   2. HTTP pre-fetch (`prefetchTranscriber`) — background chunks already done
+    ///   3. plain file upload (`fileService`) — universal fallback
     private static func resolveRawTranscript(
         realtimeService: RealtimeTranscriptionService?,
+        prefetchTranscriber: PrefetchTranscriber?,
         fileService: TranscriptionService,
         fileURL: URL
     ) async throws -> String {
@@ -2521,8 +2540,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 throw CancellationError()
             } catch {
                 try Task.checkCancellation()
-                return try await fileService.transcribe(fileURL: fileURL)
+                // Realtime failed; fall through to prefetch or file upload.
             }
+        }
+        if let prefetchTranscriber {
+            try Task.checkCancellation()
+            let merged = await prefetchTranscriber.commitAndAwaitFinal()
+            if !merged.isEmpty { return merged }
+            // Empty result: fall through to file upload.
         }
         return try await fileService.transcribe(fileURL: fileURL)
     }
@@ -2593,6 +2618,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
             let activeRealtime = self.realtimeService
             self.realtimeService = nil
+            let activePrefetch = self.prefetchTranscriber
+            self.prefetchTranscriber = nil
             self.audioRecorder.onPCM16Samples = nil
             self.transcriptionTask?.cancel()
             guard self.isTranscribing else {
@@ -2614,6 +2641,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     let transcriptionService = try self.makeTranscriptionService()
                     async let transcript = Self.resolveRawTranscript(
                         realtimeService: activeRealtime,
+                        prefetchTranscriber: activePrefetch,
                         fileService: transcriptionService,
                         fileURL: transcriptionFileURL
                     )
@@ -2873,6 +2901,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioRecorder.onPCM16Samples = nil
         realtimeService?.cancel()
         realtimeService = nil
+        prefetchTranscriber = nil   // discard any in-progress accumulation
+    }
+
+    /// Start background HTTP pre-transcription if enabled and realtime is off.
+    /// PCM16 samples (24 kHz mono) are accumulated and transcribed in 28-second
+    /// chunks in the background, so the majority of a long recording is already
+    /// processed by the time the user presses stop.
+    private func startPrefetchTranscriberIfEnabled() {
+        guard prefetchTranscriptionEnabled, !realtimeStreamingEnabled else { return }
+        guard let service = try? makeTranscriptionService() else { return }
+        let transcriber = PrefetchTranscriber(service: service)
+        prefetchTranscriber = transcriber
+        audioRecorder.onPCM16Samples = { [weak transcriber] data in
+            transcriber?.appendPCM16(data)
+        }
+    }
+
+    private func tearDownPrefetchTranscriber() {
+        audioRecorder.onPCM16Samples = nil
+        prefetchTranscriber = nil
     }
 
     private func startContextCapture() {

--- a/Sources/PrefetchTranscriber.swift
+++ b/Sources/PrefetchTranscriber.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Transcribes audio in the background while recording is still in progress.
+///
+/// Audio is accumulated as raw PCM16 samples (24 kHz mono, matching
+/// `AudioRecorder.onPCM16Samples`).  Every 28 seconds a WAV file is
+/// written to a temporary location and submitted to the configured
+/// transcription service.  Chunks are processed *serially* so upstream
+/// API rate limits are respected.
+///
+/// Call `appendPCM16(_:)` from any thread while recording, then
+/// `commitAndAwaitFinal()` from an async context when recording stops.
+/// The full merged transcript is returned; individual chunk results are
+/// combined in order.  Falls back gracefully: if a chunk fails, it is
+/// skipped rather than aborting the session.
+final class PrefetchTranscriber: @unchecked Sendable {
+
+    // MARK: Configuration
+
+    private let service: TranscriptionService
+    private static let chunkSeconds: Int = 28
+    private static let sampleRate: Int = 24_000   // matches pcm16TargetFormat
+    private static let bytesPerSample: Int = 2     // PCM16
+    private static let chunkBytes: Int = chunkSeconds * sampleRate * bytesPerSample
+
+    // MARK: State (guarded by lock)
+
+    private let lock = NSLock()
+    private var buffer = Data()
+    private var segments: [String] = []
+
+    /// Serial chain of chunk-transcription Tasks.  Each new chunk task
+    /// awaits the completion of the previous one before starting.
+    private var chainTail: Task<String?, Never> = Task { nil }
+
+    // MARK: Init
+
+    init(service: TranscriptionService) {
+        self.service = service
+    }
+
+    // MARK: Public API
+
+    /// Append raw PCM16 samples. Safe to call from any thread or queue.
+    func appendPCM16(_ data: Data) {
+        let chunk: Data? = lock.withLock {
+            buffer.append(data)
+            guard buffer.count >= Self.chunkBytes else { return nil }
+            let c = Data(buffer.prefix(Self.chunkBytes))
+            buffer = Data(buffer.dropFirst(Self.chunkBytes))
+            return c
+        }
+        guard let chunk else { return }
+        enqueueChunk(chunk, label: "background chunk")
+    }
+
+    /// Wait for all in-flight chunks, transcribe the remaining tail, and
+    /// return the merged transcript.  Must be called from an async context.
+    func commitAndAwaitFinal() async -> String {
+        // Wait for the last enqueued chunk to complete.
+        _ = await chainTail.value
+
+        // Transcribe the tail (< 28 s remaining in the buffer).
+        let tail: Data = lock.withLock {
+            let t = buffer
+            buffer = Data()
+            return t
+        }
+        if !tail.isEmpty {
+            if let text = await transcribeWAV(Self.buildWAV(from: tail)), !text.isEmpty {
+                lock.withLock { segments.append(text) }
+            }
+        }
+
+        return lock.withLock { segments.joined(separator: " ") }
+    }
+
+    // MARK: Private helpers
+
+    private func enqueueChunk(_ chunk: Data, label: String) {
+        let prev = chainTail
+        let newTask: Task<String?, Never> = Task { [weak self] in
+            guard let self else { return nil }
+            // Ensure serial execution: wait for the preceding chunk.
+            _ = await prev.value
+            let wav = Self.buildWAV(from: chunk)
+            return await self.transcribeWAV(wav)
+        }
+        chainTail = newTask
+
+        // Collect the result into `segments` once done.
+        Task { [weak self] in
+            guard let self else { return }
+            if let text = await newTask.value, !text.isEmpty {
+                self.lock.withLock { self.segments.append(text) }
+            }
+        }
+    }
+
+    private func transcribeWAV(_ wav: Data) async -> String? {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("prefetch_\(UUID().uuidString).wav")
+        do {
+            try wav.write(to: url)
+            defer { try? FileManager.default.removeItem(at: url) }
+            return try await service.transcribe(fileURL: url)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Build a minimal WAV container around raw PCM16 mono data.
+    private static func buildWAV(from pcm: Data) -> Data {
+        var wav = Data()
+        func le<T: FixedWidthInteger>(_ v: T) {
+            var x = v.littleEndian
+            wav.append(Data(bytes: &x, count: MemoryLayout<T>.size))
+        }
+        let dataLen = UInt32(pcm.count)
+        wav += "RIFF".data(using: .ascii)!; le(dataLen + 36)
+        wav += "WAVEfmt ".data(using: .ascii)!
+        le(UInt32(16)); le(UInt16(1)); le(UInt16(1))   // fmt, PCM, mono
+        le(UInt32(sampleRate))
+        le(UInt32(sampleRate * bytesPerSample))        // byte rate
+        le(UInt16(bytesPerSample))                     // block align
+        le(UInt16(16))                                 // bits per sample
+        wav += "data".data(using: .ascii)!; le(dataLen)
+        wav += pcm
+        return wav
+    }
+}

--- a/Sources/PrefetchTranscriber.swift
+++ b/Sources/PrefetchTranscriber.swift
@@ -8,6 +8,10 @@ import Foundation
 /// transcription service.  Chunks are processed *serially* so upstream
 /// API rate limits are respected.
 ///
+/// If `saveURL` is provided, each completed chunk's transcript is appended
+/// to that file immediately after transcription — so a crash loses at most
+/// one in-flight chunk rather than the entire session.
+///
 /// Call `appendPCM16(_:)` from any thread while recording, then
 /// `commitAndAwaitFinal()` from an async context when recording stops.
 /// The full merged transcript is returned; individual chunk results are
@@ -23,6 +27,11 @@ final class PrefetchTranscriber: @unchecked Sendable {
     private static let bytesPerSample: Int = 2     // PCM16
     private static let chunkBytes: Int = chunkSeconds * sampleRate * bytesPerSample
 
+    /// Optional file that receives each chunk's transcript as it completes.
+    /// Created (or truncated) at init time; appended after every chunk so
+    /// partial transcripts survive an app crash.
+    private let saveURL: URL?
+
     // MARK: State (guarded by lock)
 
     private let lock = NSLock()
@@ -35,8 +44,12 @@ final class PrefetchTranscriber: @unchecked Sendable {
 
     // MARK: Init
 
-    init(service: TranscriptionService) {
+    init(service: TranscriptionService, saveURL: URL? = nil) {
         self.service = service
+        self.saveURL = saveURL
+        if let url = saveURL {
+            FileManager.default.createFile(atPath: url.path, contents: nil)
+        }
     }
 
     // MARK: Public API
@@ -69,6 +82,7 @@ final class PrefetchTranscriber: @unchecked Sendable {
         if !tail.isEmpty {
             if let text = await transcribeWAV(Self.buildWAV(from: tail)), !text.isEmpty {
                 lock.withLock { segments.append(text) }
+                appendToSaveFile(text)
             }
         }
 
@@ -88,12 +102,26 @@ final class PrefetchTranscriber: @unchecked Sendable {
         }
         chainTail = newTask
 
-        // Collect the result into `segments` once done.
+        // Collect the result into `segments` once done and persist to disk.
         Task { [weak self] in
             guard let self else { return }
             if let text = await newTask.value, !text.isEmpty {
                 self.lock.withLock { self.segments.append(text) }
+                self.appendToSaveFile(text)
             }
+        }
+    }
+
+    /// Appends one chunk's text to the durable save file.
+    /// Uses `FileHandle` for atomic append without reading the whole file.
+    private func appendToSaveFile(_ text: String) {
+        guard let url = saveURL else { return }
+        let line = text + "\n\n"
+        guard let data = line.data(using: .utf8) else { return }
+        if let handle = try? FileHandle(forWritingTo: url) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            handle.write(data)
         }
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -273,10 +273,20 @@ struct ProviderSettingsFields: View {
             Divider()
 
             Toggle(
-                "Stream audio while recording (realtime)",
+                "Begin transcribing while recording",
+                isOn: $appState.prefetchTranscriptionEnabled
+            )
+            Text("Submits audio to the transcription provider in 28-second background chunks while you speak. By the time you press stop, most of the transcript is already ready. Works with any HTTP transcription provider — no special server required.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            Toggle(
+                "Stream audio while recording (realtime, requires WebSocket)",
                 isOn: $appState.realtimeStreamingEnabled
             )
-            Text("Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket so transcription runs while you speak.")
+            Text("Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket. Takes priority over background transcription when both are enabled.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 


### PR DESCRIPTION
## Summary

- Adds a new **"Begin transcribing while recording"** setting that submits audio to the transcription provider in **28-second background chunks** while the user speaks
- By the time the user presses stop, the majority of the recording is already processed — only the trailing segment (< 28 s) needs transcribing on stop, dramatically reducing perceived latency for long dictations
- Works with **any standard HTTP transcription endpoint** (Groq, local Whisper, faster-whisper, etc.) — no WebSocket or special server required, unlike the existing realtime mode
- Each completed chunk's transcript is **appended to a durable `.txt` file** in the audio directory immediately after transcription — an app crash loses at most one 28-second chunk
- The setting **defaults to enabled** on first launch (same nil-check pattern as the Press Enter voice command), so users benefit immediately without manual configuration

### How it works

A new `PrefetchTranscriber` class accumulates the raw PCM16 audio stream (`AudioRecorder.onPCM16Samples`, 24 kHz mono). Every 28 seconds it writes a temporary WAV file and submits it to the configured `TranscriptionService` endpoint in a serial background task chain. When recording stops, `commitAndAwaitFinal()` waits for any in-flight chunk, transcribes the remaining tail, and returns the joined transcript. If the merged result is empty (network error, etc.) it falls back to the regular full-file upload path.

Each chunk's transcript is appended via `FileHandle` to a timestamped `.txt` file in `~/Library/Application Support/FreeFlow Dev/audio/`. In a 3-hour session the transcriber holds at most ~2 × 1.35 MB of PCM16 in RAM at any time (one chunk being transcribed + partial next chunk buffer).

The existing **realtime WebSocket mode** (`realtimeStreamingEnabled`) takes priority when both settings are enabled, so the two paths are non-conflicting.

### Files changed

| File | Change |
|------|--------|
| `PrefetchTranscriber.swift` | New class: PCM16 accumulation, 28-second chunking, serial task chain, durable file append |
| `AppState.swift` | New `prefetchTranscriptionEnabled` property (default: on); recording start/stop/cancel wiring; durable save-URL generation |
| `SettingsView.swift` | New "Begin transcribing while recording" toggle above existing realtime toggle |

Relates to #250 (URLSession timeout fixes for local LLM inference).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to transcribe in background while recording by prefetching audio chunks so results are ready sooner.
* **Bug Fixes**
  * Improved transcript selection on stop: realtime transcription is preferred, with background prefetch used as fallback before file-based transcription.
  * Ensured background prefetch processing is correctly started, torn down, and discarded when realtime is disabled or recording ends.
* **Documentation**
  * Updated the settings text to clarify background transcription behavior and that realtime takes priority when both are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->