### PR TITLE
Switch default context model to qwen/qwen3.6-27b

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
 APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
 
 SOURCES = $(shell find Sources -name '*.swift' -type f | LC_ALL=C sort)
+TEST_RUNNER = $(BUILD_DIR)/FreeFlowTests
 RESOURCES = $(CONTENTS)/Resources
 ARCH ?= $(shell uname -m)
 
@@ -25,7 +26,7 @@ ICON_SOURCE = Resources/AppIcon-Source.png
 ICON_ICNS = Resources/AppIcon.icns
 endif
 
-.PHONY: all clean run icon dmg codesign-dmg notarize
+.PHONY: all clean run icon dmg codesign-dmg notarize test
 
 all: $(APP_EXECUTABLE_TARGET)
 
@@ -67,6 +68,18 @@ endif
 	@plutil -replace NSAccessibilityUsageDescription -string "$(APP_NAME) needs accessibility access to detect the text cursor position and paste transcribed text." "$(CONTENTS)/Info.plist"
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
+
+test: $(TEST_RUNNER)
+	@$(TEST_RUNNER)
+
+$(TEST_RUNNER): Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Tests/AppContextServiceTests.swift
+	@mkdir -p "$(BUILD_DIR)"
+	swiftc \
+		-parse-as-library \
+		-o "$(TEST_RUNNER)" \
+		-sdk $(shell xcrun --show-sdk-path) \
+		-target $(ARCH)-apple-macosx13.0 \
+		Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Tests/AppContextServiceTests.swift
 
 icon: $(ICON_ICNS)
 

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -27,6 +27,7 @@ struct AppContext {
 }
 
 final class AppContextService {
+    static let defaultContextModel = "qwen/qwen3.6-27b"
     static let defaultContextPrompt = """
 You are a context synthesis assistant for a speech-to-text pipeline.
 Given app/window metadata and an optional screenshot, output exactly two sentences that describe what the user is doing right now and the likely writing intent in the current window.
@@ -53,14 +54,14 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         apiKey: String,
         baseURL: String = "https://api.groq.com/openai/v1",
         customContextPrompt: String = "",
-        contextModel: String = "meta-llama/llama-4-scout-17b-16e-instruct",
+        contextModel: String = AppContextService.defaultContextModel,
         screenshotMaxDimension: CGFloat = AppContextService.defaultScreenshotMaxDimension
     ) {
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.customContextPrompt = customContextPrompt
         let trimmedModel = contextModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.contextModel = trimmedModel.isEmpty ? "meta-llama/llama-4-scout-17b-16e-instruct" : trimmedModel
+        self.contextModel = trimmedModel.isEmpty ? Self.defaultContextModel : trimmedModel
         self.screenshotMaxDimension = screenshotMaxDimension > 0
             ? screenshotMaxDimension
             : AppContextService.defaultScreenshotMaxDimension

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -279,15 +279,25 @@ Selected text: \(selectedText ?? "None")
                 return nil
             }
 
-            let cleaned = content.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !cleaned.isEmpty else { return nil }
-            return (activity: normalizedActivitySummary(cleaned), prompt: fullPrompt)
+            guard let activity = Self.activitySummary(from: content, model: model) else { return nil }
+            return (activity: activity, prompt: fullPrompt)
         } catch {
             return nil
         }
     }
 
-    private func normalizedActivitySummary(_ value: String) -> String {
+    static func activitySummary(from rawContent: String, model: String) -> String? {
+        var content = rawContent
+        if ModelConfiguration.config(for: model).shouldStripThinkTags {
+            content = ModelConfiguration.stripThinkTags(content)
+        }
+
+        let cleaned = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return nil }
+        return normalizedActivitySummary(cleaned)
+    }
+
+    private static func normalizedActivitySummary(_ value: String) -> String {
         let sentences = value
             .split(whereSeparator: { $0 == "." || $0 == "。" || $0 == "!" || $0 == "?" })
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -276,7 +276,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     ]
     static let defaultPostProcessingModel = "openai/gpt-oss-20b"
     static let defaultPostProcessingFallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
-    static let defaultContextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    static let defaultContextModel = "qwen/qwen3.6-27b"
+    private static let deprecatedDefaultContextModel = "meta-llama/llama-4-scout-17b-16e-instruct"
     private static let trailingPressEnterCommandPattern = try! NSRegularExpression(
         pattern: #"(?i)(?:^|[ \t\r\n,;:\-]+)press[ \t\r\n]+enter[\s\p{P}]*$"#
     )
@@ -627,7 +628,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let transcriptionAPIKey = Self.loadStoredAPIKey(account: transcriptionAPIKeyStorageKey)
         let postProcessingModel = UserDefaults.standard.string(forKey: postProcessingModelStorageKey) ?? Self.defaultPostProcessingModel
         let postProcessingFallbackModel = UserDefaults.standard.string(forKey: postProcessingFallbackModelStorageKey) ?? Self.defaultPostProcessingFallbackModel
-        let contextModel = UserDefaults.standard.string(forKey: contextModelStorageKey) ?? Self.defaultContextModel
+        let contextModel = Self.loadStoredContextModel(key: contextModelStorageKey)
         let shortcuts = Self.loadShortcutConfiguration(
             holdKey: holdShortcutStorageKey,
             toggleKey: toggleShortcutStorageKey,
@@ -858,6 +859,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return stored
         }
         return defaultAPIBaseURL
+    }
+
+    private static func loadStoredContextModel(key: String) -> String {
+        guard let stored = UserDefaults.standard.string(forKey: key) else {
+            return defaultContextModel
+        }
+
+        let trimmed = stored.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == deprecatedDefaultContextModel {
+            UserDefaults.standard.set(defaultContextModel, forKey: key)
+            return defaultContextModel
+        }
+
+        return trimmed.isEmpty ? defaultContextModel : trimmed
     }
 
     private static func loadShortcutConfiguration(

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -16,6 +16,7 @@ public struct ModelConfiguration {
         "openai/gpt-oss-120b",
         "openai/gpt-oss-safeguard-20b",
         "qwen/qwen3-32b",
+        "qwen/qwen3.6-27b",
         "allam-2-7b",
         "groq/compound",
         "groq/compound-mini",
@@ -35,6 +36,7 @@ public struct ModelConfiguration {
         
         // Normalize providerless aliases
         if cleanModel == "qwen3-32b" { cleanModel = "qwen/qwen3-32b" }
+        else if cleanModel == "qwen3.6-27b" { cleanModel = "qwen/qwen3.6-27b" }
         else if cleanModel == "gpt-oss-20b" { cleanModel = "openai/gpt-oss-20b" }
         else if cleanModel == "gpt-oss-120b" { cleanModel = "openai/gpt-oss-120b" }
         else if cleanModel == "gpt-oss-safeguard-20b" { cleanModel = "openai/gpt-oss-safeguard-20b" }
@@ -62,6 +64,13 @@ public struct ModelConfiguration {
             )
         } else if cleanModel == "qwen/qwen3-32b" {
  // Model that requires sanitization of thought tags
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: true
+            )
+        } else if cleanModel == "qwen/qwen3.6-27b" {
             return ModelConfig(
                 maxCompletionTokens: nil,
                 reasoningEffort: nil,

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+@main
+struct AppContextServiceTests {
+    static func main() {
+        testQwenRawOutputIsSummarized()
+        testQwenReasoningOutputIsStripped()
+        testNonStrippingModelPreservesExistingBehavior()
+        print("AppContextServiceTests passed")
+    }
+
+    private static func testQwenRawOutputIsSummarized() {
+        let output = """
+        The user is replying to an email about the product launch. They likely intend to confirm the next steps. This third sentence should be dropped.
+        """
+
+        let summary = AppContextService.activitySummary(from: output, model: "qwen/qwen3.6-27b")
+
+        expectEqual(
+            summary,
+            "The user is replying to an email about the product launch. They likely intend to confirm the next steps."
+        )
+    }
+
+    private static func testQwenReasoningOutputIsStripped() {
+        let output = """
+        <think>
+        Hidden chain of thought should never appear in context.
+        It contains misleading details.
+        </think>
+        The user is editing a project note in FreeFlow. They likely intend to tighten the release wording.
+        """
+
+        let summary = AppContextService.activitySummary(from: output, model: "qwen/qwen3.6-27b")
+
+        expectEqual(
+            summary,
+            "The user is editing a project note in FreeFlow. They likely intend to tighten the release wording."
+        )
+        expect(summary?.contains("Hidden chain of thought") == false, "Qwen reasoning leaked into summary")
+    }
+
+    private static func testNonStrippingModelPreservesExistingBehavior() {
+        let output = "<think>Visible for non-stripping models.</think> The user is writing a status update."
+
+        let summary = AppContextService.activitySummary(
+            from: output,
+            model: "meta-llama/llama-4-scout-17b-16e-instruct"
+        )
+
+        expectEqual(summary, output)
+    }
+
+    private static func expectEqual(_ actual: String?, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+        expect(actual == expected, "Expected \(expected.debugDescription), got \((actual ?? "nil").debugDescription)", file: file, line: line)
+    }
+
+    private static func expect(_ condition: Bool, _ message: String, file: StaticString = #file, line: UInt = #line) {
+        if !condition {
+            fatalError("\(file):\(line): \(message)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Update the default context synthesis model to `qwen/qwen3.6-27b`
- Preserve compatibility by normalizing the new alias in model configuration
- Migrate stored context model values away from the deprecated default on load

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Qwen 3.6 27B model as an available context model.
  * Added recognition of the `qwen3.6-27b` alias.
  * Improved activity summaries for Qwen by stripping optional “think” tags.
* **Bug Fixes**
  * Automatically migrate stored context-model preferences from the previous default.
  * Empty or whitespace-only model settings now correctly fall back to the default.
* **Tests**
  * Added automated coverage for context-model summary behavior, including tag stripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->