### PR TITLE
Activate lazy Chromium/Electron accessibility trees for Edit Mode (fixes #237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATC
 - `MINOR` changes add user-visible features and improvements.
 - `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed Edit Mode silently falling back to dictation (overwriting the selection) in VS Code, Gmail-in-Chrome, and other Electron/Chromium apps. Those apps build their accessibility tree lazily, so FreeFlow now asks them to activate it before reading the selection.
+
 ## [1.1.0] - 2026-06-03
 
 ### Added

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -82,12 +82,68 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         }
 
         let appElement = AXUIElementCreateApplication(frontmostApp.processIdentifier)
+        let firstActivation = activateAccessibilityTreeIfNeeded(
+            appElement: appElement,
+            processIdentifier: frontmostApp.processIdentifier,
+            bundleIdentifier: frontmostApp.bundleIdentifier
+        )
+        var selectedText = rawSelectedText(from: appElement)
+        if selectedText == nil && firstActivation {
+            // The app builds its accessibility tree asynchronously after
+            // activation; give it one brief chance on the first read so
+            // Edit Mode works on the very first dictation too.
+            usleep(100_000)
+            selectedText = rawSelectedText(from: appElement)
+        }
         return AppSelectionSnapshot(
             appName: frontmostApp.localizedName,
             bundleIdentifier: frontmostApp.bundleIdentifier,
             windowTitle: focusedWindowTitle(from: appElement) ?? frontmostApp.localizedName,
-            selectedText: rawSelectedText(from: appElement)
+            selectedText: selectedText
         )
+    }
+
+    // MARK: - Chromium/Electron accessibility activation
+
+    /// PIDs whose lazy accessibility trees we have already asked to
+    /// activate. Guarded by activatedAccessibilityPIDsLock.
+    private var activatedAccessibilityPIDs = Set<pid_t>()
+    private let activatedAccessibilityPIDsLock = NSLock()
+
+    private static let chromiumBrowserBundleIDPrefixes = [
+        "com.google.Chrome",
+        "com.microsoft.edgemac",
+        "com.brave.Browser",
+        "com.vivaldi.Vivaldi",
+        "org.chromium.Chromium",
+        "company.thebrowser.Browser",
+    ]
+
+    /// Chromium-based apps build their accessibility tree lazily: until a
+    /// client opts in, AXSelectedText reads fail, which made Edit Mode fall
+    /// back to dictation and overwrite selections in VS Code, Gmail-in-Chrome,
+    /// and other Electron apps (issue #237). AXManualAccessibility is
+    /// Electron's opt-in switch (unknown-attribute errors are harmless
+    /// elsewhere); AXEnhancedUserInterface is Chromium's, set only for known
+    /// browsers because it can interact badly with window-manager utilities.
+    /// Returns true the first time activation is attempted for this process.
+    @discardableResult
+    private func activateAccessibilityTreeIfNeeded(
+        appElement: AXUIElement,
+        processIdentifier: pid_t,
+        bundleIdentifier: String?
+    ) -> Bool {
+        activatedAccessibilityPIDsLock.lock()
+        let firstActivation = activatedAccessibilityPIDs.insert(processIdentifier).inserted
+        activatedAccessibilityPIDsLock.unlock()
+        guard firstActivation else { return false }
+
+        AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+        if let bundleIdentifier,
+           Self.chromiumBrowserBundleIDPrefixes.contains(where: bundleIdentifier.hasPrefix) {
+            AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
+        }
+        return true
     }
 
     func collectContext() async -> AppContext {
@@ -111,6 +167,11 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         let appName = frontmostApp.localizedName
         let bundleIdentifier = frontmostApp.bundleIdentifier
         let appElement = AXUIElementCreateApplication(frontmostApp.processIdentifier)
+        activateAccessibilityTreeIfNeeded(
+            appElement: appElement,
+            processIdentifier: frontmostApp.processIdentifier,
+            bundleIdentifier: bundleIdentifier
+        )
 
         let windowTitle = focusedWindowTitle(from: appElement) ?? appName
         let selectedText = selectedText(from: appElement)


### PR DESCRIPTION
Split out from #254.

Chromium-based apps build their accessibility tree lazily, so `AXSelectedText` reads failed and Edit Mode fell back to dictation — overwriting the user's selection in VS Code, Gmail-in-Chrome, etc. FreeFlow now sets Electron's `AXManualAccessibility` opt-in on the frontmost app before reading the selection (harmless no-op elsewhere), plus Chromium's `AXEnhancedUserInterface` for known browsers only (scoped narrowly since that attribute can interact badly with window-manager utilities). The first read after activation gets one 100 ms retry because the tree builds asynchronously.

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Edit Mode selection handling in VS Code, Gmail in Chrome, and other Electron/Chromium apps.
  * Prevented selected text from being silently replaced by dictation when accessibility data is initially unavailable.
  * Improved context detection by activating accessibility support before reading selected text and window details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->