### PR TITLE
Start transcription before capture-session teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATC
 - `MINOR` changes add user-visible features and improvements.
 - `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
 
+## [Unreleased]
+
+### Improved
+
+- Faster stop-to-paste latency: the transcription upload now starts immediately when recording stops, instead of waiting for the audio capture session to finish tearing down.
+
 ## [1.1.0] - 2026-06-03
 
 ### Added

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -680,7 +680,12 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
         sessionQueue.async {
             self.cancelWatchdog()
-            self.teardownSessionLocked()
+            // Removing the delegate is the audio cut-off point (same as the
+            // full teardown used to be); the queued tail buffers are then
+            // drained into the file. The slow AVCaptureSession.stopRunning()
+            // is deferred until after the completion fires, so transcription
+            // starts without waiting on capture teardown.
+            self.audioDataOutput?.setSampleBufferDelegate(nil, queue: nil)
             let outputURL = self.finishAudioFileLocked(discard: false)
             self._recording.withLock { $0 = false }
             self.liveLevelNormalizerLock.withLock { $0.reset() }
@@ -689,6 +694,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
                 self.audioLevel = 0.0
                 completion(outputURL)
             }
+            self.teardownSessionLocked()
         }
     }
 


### PR DESCRIPTION
Split out from #254.

`AVCaptureSession.stopRunning()` can take 100–300 ms and ran before the stop completion fired. The audio cut-off point (sample-buffer delegate removal) and the queued-tail drain are byte-for-byte unchanged; only the slow teardown now happens after the completion, so the upload starts immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced stop-to-paste latency by beginning transcription upload immediately when recording stops.
  * Improved recording completion by preserving queued audio data before finalizing the recording and releasing capture resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->