### PR TITLE
Make dictation aware of the text surrounding the cursor (fixes #200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATC
 - `MINOR` changes add user-visible features and improvements.
 - `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
 
+## [Unreleased]
+
+### Added
+
+- Dictation is now aware of the text surrounding the cursor: cleanup matches the sentence flow when inserting mid-sentence (no stray leading capitals or trailing periods), a separating space is added automatically when inserting directly after a word, and the trailing space after sentence punctuation is skipped when the following text already provides one.
+
 ## [1.1.0] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ FreeFlow is a free Mac dictation app inspired by [Wispr Flow](https://wisprflow.
 ## Features
 
 - **Custom shortcuts:** Customize both hold-to-talk and toggle dictation shortcuts. If your toggle shortcut extends your hold shortcut, you can start in hold mode and press the extra modifier keys to latch into tap mode without stopping the recording.
-- **Context-aware cleanup:** FreeFlow can read nearby app context so names, terms, and phrases are spelled correctly when you dictate into email, terminals, docs, and other apps.
+- **Context-aware cleanup:** FreeFlow can read nearby app context so names, terms, and phrases are spelled correctly when you dictate into email, terminals, docs, and other apps. It also reads the text around your cursor, so dictating into the middle of a sentence continues the sentence naturally with correct capitalization, punctuation, and spacing.
 - **Custom vocabulary:** Add names, jargon, and project-specific words that FreeFlow should preserve during cleanup.
 - **OpenAI-compatible providers:** Use Groq by default, or configure a custom model and API URL in settings.
 

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -20,9 +20,21 @@ struct AppContext {
     let screenshotDataURL: String?
     let screenshotMimeType: String?
     let screenshotError: String?
+    /// Text immediately surrounding the insertion point in the focused
+    /// element, so cleanup can match capitalization, punctuation, and
+    /// sentence flow when dictating into the middle of existing text.
+    var textBeforeCursor: String? = nil
+    var textAfterCursor: String? = nil
 
     var contextSummary: String {
-        currentActivity
+        var summary = currentActivity
+        if let textBeforeCursor, !textBeforeCursor.isEmpty {
+            summary += "\nText immediately before the cursor: \"\(textBeforeCursor)\""
+        }
+        if let textAfterCursor, !textAfterCursor.isEmpty {
+            summary += "\nText immediately after the cursor: \"\(textAfterCursor)\""
+        }
+        return summary
     }
 }
 
@@ -114,6 +126,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
 
         let windowTitle = focusedWindowTitle(from: appElement) ?? appName
         let selectedText = selectedText(from: appElement)
+        let cursorContext = cursorTextContext(from: appElement)
         let screenshot = captureActiveWindowScreenshot(
             processIdentifier: frontmostApp.processIdentifier,
             appElement: appElement,
@@ -163,7 +176,9 @@ Return only two sentences, no labels, no markdown, no extra commentary.
             contextPrompt: contextPrompt,
             screenshotDataURL: screenshot.dataURL,
             screenshotMimeType: screenshot.mimeType,
-            screenshotError: screenshot.error
+            screenshotError: screenshot.error,
+            textBeforeCursor: cursorContext?.before,
+            textAfterCursor: cursorContext?.after
         )
     }
 
@@ -324,6 +339,110 @@ Selected text: \(selectedText ?? "None")
         }
 
         return nil
+    }
+
+    // MARK: - Cursor text context (issue #200)
+
+    struct CursorTextContext {
+        let before: String
+        let after: String
+    }
+
+    private static let cursorContextBeforeLimit = 200
+    private static let cursorContextAfterLimit = 80
+    /// Skip the whole-value fallback for huge documents; the parameterized
+    /// range read does not have this problem.
+    private static let cursorContextMaxFallbackLength = 1_000_000
+
+    /// Reads the text immediately surrounding the insertion point of the
+    /// focused element. Returns nil when the element does not expose a
+    /// selection range (or is a secure field, which is never read).
+    func cursorTextContext(from appElement: AXUIElement) -> CursorTextContext? {
+        guard let focused = accessibilityElement(from: appElement, attribute: kAXFocusedUIElementAttribute as CFString) else {
+            return nil
+        }
+        if let role = accessibilityRawString(from: focused, attribute: kAXRoleAttribute as CFString),
+           role == "AXSecureTextField" {
+            return nil
+        }
+        guard let selectedRange = accessibilityRange(from: focused, attribute: kAXSelectedTextRangeAttribute as CFString),
+              selectedRange.location != kCFNotFound,
+              selectedRange.location >= 0 else {
+            return nil
+        }
+
+        let caret = selectedRange.location
+        let beforeStart = max(0, caret - Self.cursorContextBeforeLimit)
+        let beforeRange = CFRange(location: beforeStart, length: caret - beforeStart)
+
+        let afterStart = caret + selectedRange.length
+        var afterLength = Self.cursorContextAfterLimit
+        if let totalLength = accessibilityInt(from: focused, attribute: "AXNumberOfCharacters" as CFString) {
+            afterLength = max(0, min(afterLength, totalLength - afterStart))
+        }
+        let afterRange = CFRange(location: afterStart, length: afterLength)
+
+        let before = accessibilityString(from: focused, range: beforeRange)
+            ?? fallbackSlice(from: focused, range: beforeRange)
+        let after = accessibilityString(from: focused, range: afterRange)
+            ?? fallbackSlice(from: focused, range: afterRange)
+
+        guard before != nil || after != nil else { return nil }
+        return CursorTextContext(before: before ?? "", after: after ?? "")
+    }
+
+    private func accessibilityString(from element: AXUIElement, range: CFRange) -> String? {
+        guard range.length > 0 else { return "" }
+        var mutableRange = range
+        guard let rangeValue = AXValueCreate(.cfRange, &mutableRange) else { return nil }
+        var value: CFTypeRef?
+        let result = AXUIElementCopyParameterizedAttributeValue(
+            element,
+            kAXStringForRangeParameterizedAttribute as CFString,
+            rangeValue,
+            &value
+        )
+        guard result == .success, let stringValue = value as? String else { return nil }
+        return stringValue
+    }
+
+    /// Some elements do not implement AXStringForRange; slice the full value
+    /// instead, using UTF-16 offsets to match accessibility range semantics.
+    private func fallbackSlice(from element: AXUIElement, range: CFRange) -> String? {
+        guard range.length > 0 else { return "" }
+        guard let fullValue = accessibilityRawString(from: element, attribute: kAXValueAttribute as CFString),
+              fullValue.utf16.count <= Self.cursorContextMaxFallbackLength else {
+            return nil
+        }
+        let utf16 = fullValue.utf16
+        guard range.location <= utf16.count else { return nil }
+        let start = utf16.index(utf16.startIndex, offsetBy: range.location)
+        let end = utf16.index(start, offsetBy: min(range.length, utf16.count - range.location))
+        return String(fullValue[start..<end])
+    }
+
+    private func accessibilityRange(from element: AXUIElement, attribute: CFString) -> CFRange? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success,
+              let rawValue = value,
+              CFGetTypeID(rawValue) == AXValueGetTypeID() else {
+            return nil
+        }
+        let axValue = unsafeBitCast(rawValue, to: AXValue.self)
+        var range = CFRange()
+        guard AXValueGetType(axValue) == .cfRange, AXValueGetValue(axValue, .cfRange, &range) else {
+            return nil
+        }
+        return range
+    }
+
+    private func accessibilityInt(from element: AXUIElement, attribute: CFString) -> Int? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success,
+              let number = value as? NSNumber else {
+            return nil
+        }
+        return number.intValue
     }
 
     private func selectedText(from appElement: AXUIElement) -> String? {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2725,7 +2725,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                                 }
                             }
 
-                            let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
+                            let pasteText = Self.applyingSmartLeadingSpace(
+                                to: trimmedFinalTranscript,
+                                textBeforeCursor: appContext.textBeforeCursor,
+                                isCommandMode: sessionIntent.isCommandMode
+                            )
+                            let pendingClipboardRestore = self.writeTranscriptToPasteboard(
+                                pasteText,
+                                textAfterCursor: appContext.textAfterCursor
+                            )
                             self.pasteAtCursorWhenShortcutReleased {
                                 if shouldPressEnterAfterPaste {
                                     self.pressEnterAfterPaste {
@@ -3197,19 +3205,45 @@ final class AppState: ObservableObject, @unchecked Sendable {
         keyUp?.post(tap: .cgSessionEventTap)
     }
 
+    /// Prepends a space when the dictation is inserted directly after a
+    /// word character or closing punctuation, so mid-text insertions do not
+    /// jam against the existing text (issue #200). Skipped for Edit Mode,
+    /// where the pasted text replaces the selection in place.
+    static func applyingSmartLeadingSpace(
+        to transcript: String,
+        textBeforeCursor: String?,
+        isCommandMode: Bool
+    ) -> String {
+        guard !isCommandMode,
+              let before = textBeforeCursor,
+              let lastChar = before.last,
+              let firstChar = transcript.first else {
+            return transcript
+        }
+        guard !lastChar.isWhitespace else { return transcript }
+        let joinable = lastChar.isLetter || lastChar.isNumber || ".!?,:;)]}\"'".contains(lastChar)
+        guard joinable, firstChar.isLetter || firstChar.isNumber else { return transcript }
+        return " " + transcript
+    }
+
     /// Writes the final transcript to the system pasteboard.
     /// Also handles appending necessary trailing spaces, declaring transient
     /// types for clipboard managers, and saving the clipboard state for later restoration.
     /// - Parameter transcript: The text to be pasted.
     /// - Returns: A `PendingClipboardRestore` object if clipboard preservation is enabled, otherwise nil.
-    private func writeTranscriptToPasteboard(_ transcript: String) -> PendingClipboardRestore? {
+    private func writeTranscriptToPasteboard(
+        _ transcript: String,
+        textAfterCursor: String? = nil
+    ) -> PendingClipboardRestore? {
         let pasteboard = NSPasteboard.general
         let snapshot = preserveClipboard ? PreservedPasteboardSnapshot(pasteboard: pasteboard) : nil
 
         // Append a space when ending with sentence-ending punctuation so the
-        // next dictation does not jam against the prior period.
+        // next dictation does not jam against the prior period — unless the
+        // text already at the cursor provides that separation.
         let textToWrite: String
-        if let last = transcript.last, ".!?".contains(last) {
+        if let last = transcript.last, ".!?".contains(last),
+           !(textAfterCursor?.first.map { $0.isWhitespace || ".,;:!?)".contains($0) } ?? false) {
             textToWrite = transcript + " "
         } else {
             textToWrite = transcript

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -53,6 +53,8 @@ Core behavior:
 - Preserve mixed-language text exactly as mixed.
 - Preserve commands, file paths, flags, identifiers, acronyms, and vocabulary terms exactly.
 - Use context only as a formatting hint and spelling reference for words already spoken.
+- If the context includes "Text immediately before the cursor", the cleaned text will be inserted at exactly that position. Match the sentence flow: when the preceding text ends mid-sentence, continue in lowercase without a leading capital, and do not repeat words that already appear before the cursor.
+- If the context includes "Text immediately after the cursor" and it continues the same sentence, do not end the cleaned text with sentence-ending punctuation.
 - If the context clearly shows email recipients or participants, use those visible names as a strong spelling reference for close phonetic or near-miss versions of names that were actually spoken.
 - In email greetings or body text, correct a near-match like "Aisha" to the visible recipient spelling "Aysha" when it is clearly the same intended person.
 - Do not introduce a recipient or participant name that was not spoken at all.
@@ -105,7 +107,7 @@ Output hygiene:
 - Never prepend boilerplate such as "Here is the clean transcript".
 - If the transcript is empty or only filler, return exactly: EMPTY
 """
-    static let defaultSystemPromptDate = "2026-05-13"
+    static let defaultSystemPromptDate = "2026-07-05"
     static let commandModeSystemPrompt = """
 You transform highlighted text according to a spoken editing command.
 


### PR DESCRIPTION
Split out from #254.

Dictating into the middle of a sentence used to produce a stray leading capital, a trailing period, and text jammed against existing words. FreeFlow now reads up to 200 chars before / 80 after the insertion point (via `AXStringForRange` with an `AXValue`-slice fallback; secure fields are never read) and uses it three ways:

- the cleanup prompt gets the surrounding text with rules to continue the sentence flow at the insertion point;
- a separating space is prepended deterministically when pasting directly after a word character or closing punctuation (skipped in Edit Mode);
- the auto trailing space after sentence punctuation is suppressed when the following text already provides separation.

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dictation now uses text around the cursor to continue sentences with appropriate capitalization, punctuation, and spacing.
  - Added smarter insertion spacing before and after dictated text, including improved handling of existing punctuation and whitespace.
  - Context-aware processing now supports more accurate cursor-adjacent text retrieval.

- **Documentation**
  - Updated the README and changelog to describe context-aware cleanup and cursor-aware dictation insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->