### PR TITLE
Menu bar panel redesign with live waveform icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATC
 - `MINOR` changes add user-visible features and improvements.
 - `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
 
+## [Unreleased]
+
+### Improved
+
+- Redesigned the menu bar extra as a window-style panel, and the menu bar icon now shows a live waveform driven by the input level while recording.
+
 ## [1.1.0] - 2026-06-03
 
 ### Added

--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -14,6 +14,7 @@ struct FreeFlowApp: App {
             MenuBarLabel()
                 .environmentObject(appDelegate.appState)
         }
+        .menuBarExtraStyle(.window)
     }
 }
 
@@ -22,25 +23,68 @@ struct MenuBarLabel: View {
     @EnvironmentObject var appState: AppState
     @ObservedObject var notificationManager = VocabularyNotificationManager.shared
 
-    private var iconName: String {
-        if appState.isRecording { return "record.circle" }
-        if appState.isTranscribing { return "ellipsis.circle" }
-        return "waveform"
-    }
+    /// Rolling window of recent input levels rendered as the live
+    /// menu bar waveform while recording.
+    @State private var levelHistory: [Float] = Array(repeating: 0, count: 5)
 
     var body: some View {
         HStack(spacing: 4) {
             if notificationManager.showCheckmark {
                 Image(systemName: "checkmark")
             }
-            if AppBuild.isDevBundle && !appState.isRecording && !appState.isTranscribing {
+            if appState.isRecording {
+                Image(nsImage: LiveWaveMenuBarIcon.image(levels: levelHistory))
+                    .renderingMode(.template)
+            } else if appState.isTranscribing {
+                Image(systemName: "ellipsis.circle")
+            } else if AppBuild.isDevBundle {
                 Image(nsImage: StampedMenuBarIcon.templateImage)
                     .renderingMode(.template)
             } else {
-                Image(systemName: iconName)
+                Image(systemName: "waveform")
+            }
+        }
+        .onChange(of: appState.menuBarAudioLevel) { level in
+            guard appState.isRecording else { return }
+            levelHistory.removeFirst()
+            levelHistory.append(level)
+        }
+        .onChange(of: appState.isRecording) { recording in
+            if !recording {
+                levelHistory = Array(repeating: 0, count: 5)
             }
         }
         .animation(.easeInOut(duration: 0.2), value: notificationManager.showCheckmark)
+    }
+}
+
+/// Renders the recording-state menu bar icon: a bar per recent level
+/// sample, so the icon itself moves with the user's voice. Template
+/// image, so it stays legible in light and dark menu bars.
+enum LiveWaveMenuBarIcon {
+    static func image(levels: [Float]) -> NSImage {
+        let size = NSSize(width: 18, height: 16)
+        let barWidth: CGFloat = 2
+        let spacing: CGFloat = 1.5
+        let image = NSImage(size: size, flipped: false) { rect in
+            let count = CGFloat(levels.count)
+            let totalWidth = count * barWidth + (count - 1) * spacing
+            var x = (rect.width - totalWidth) / 2
+            NSColor.black.setFill()
+            for level in levels {
+                let clamped = CGFloat(min(max(level, 0), 1))
+                let height = 3 + clamped * 10
+                let y = (rect.height - height) / 2
+                NSBezierPath(
+                    roundedRect: NSRect(x: x, y: y, width: barWidth, height: height),
+                    xRadius: barWidth / 2, yRadius: barWidth / 2
+                ).fill()
+                x += barWidth + spacing
+            }
+            return true
+        }
+        image.isTemplate = true
+        return image
     }
 }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -557,6 +557,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var selectedSettingsTab: SettingsTab? = .general
     @Published var pipelineHistory: [PipelineHistoryItem] = []
     @Published var debugStatusMessage = "Idle"
+    /// Live input level mirrored to the menu bar icon while recording.
+    @Published var menuBarAudioLevel: Float = 0
     @Published var debugShowsUpdateReminderAfterDictation = false
     @Published var lastRawTranscript = ""
     @Published var lastPostProcessedTranscript = ""
@@ -2207,6 +2209,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         .receive(on: DispatchQueue.main)
                         .sink { [weak self] level in
                             self?.overlayManager.updateAudioLevel(level)
+                            self?.menuBarAudioLevel = level
                         }
                 }
             } catch {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -1,15 +1,559 @@
 import SwiftUI
 
+// MARK: - Panel Dismissal
+
+/// Closes the window-style MenuBarExtra panel. SwiftUI provides no public
+/// dismissal API on macOS 13, so this matches the private panel class by
+/// name. Matching is intentionally narrow ("MenuBarExtra") so the status
+/// item's own NSStatusBarWindow is never touched.
+@MainActor
+func dismissMenuBarPanel() {
+    for window in NSApp.windows where window.className.contains("MenuBarExtra") {
+        window.close()
+    }
+}
+
+// MARK: - Menu Bar Panel
+
 struct MenuBarView: View {
     @EnvironmentObject var appState: AppState
     @ObservedObject private var updateManager = UpdateManager.shared
+
+    @State private var copiedItemID: UUID?
+    @State private var copiedLastTranscript = false
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
     }
 
     private var recentHistoryItems: [PipelineHistoryItem] {
-        Array(appState.pipelineHistory.filter { !transcriptText(for: $0).isEmpty }.prefix(10))
+        Array(appState.pipelineHistory.filter { !transcriptText(for: $0).isEmpty }.prefix(5))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 14)
+                .padding(.top, 12)
+                .padding(.bottom, 10)
+
+            permissionBanners
+
+            VStack(spacing: 10) {
+                dictateButton
+
+                if let hotkeyError = appState.hotkeyMonitoringErrorMessage {
+                    inlineError(hotkeyError)
+                }
+                if let error = appState.errorMessage {
+                    inlineError(error)
+                }
+
+                if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
+                    lastTranscriptCard
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 12)
+
+            if !recentHistoryItems.isEmpty {
+                sectionDivider
+                historySection
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+            }
+
+            sectionDivider
+            controlsSection
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+
+            updateBanner
+
+            sectionDivider
+            footer
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+        }
+        .frame(width: 320)
+    }
+
+    // MARK: Header
+
+    private var statusColor: Color {
+        if appState.isRecording { return .red }
+        if appState.isTranscribing { return .orange }
+        return .green
+    }
+
+    private var statusText: String {
+        if appState.isRecording { return "Recording…" }
+        if appState.isTranscribing { return appState.debugStatusMessage }
+        return appState.shortcutStatusText
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [Color.accentColor, Color.accentColor.opacity(0.65)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 30, height: 30)
+                Image(systemName: "waveform")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(AppName.displayName)
+                    .font(.system(size: 13, weight: .semibold))
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 6, height: 6)
+                    Text(statusText)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            Text("v\(appVersion)")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.tertiary)
+        }
+        .animation(.easeInOut(duration: 0.2), value: appState.isRecording)
+        .animation(.easeInOut(duration: 0.2), value: appState.isTranscribing)
+    }
+
+    // MARK: Permission Banners
+
+    @ViewBuilder
+    private var permissionBanners: some View {
+        VStack(spacing: 6) {
+            if !appState.hasScreenRecordingPermission {
+                PanelBannerButton(
+                    title: "Screen Recording permission needed",
+                    systemImage: "camera.viewfinder",
+                    tint: .orange
+                ) {
+                    appState.requestScreenCapturePermission()
+                }
+            }
+            if !appState.hasAccessibility {
+                PanelBannerButton(
+                    title: "Accessibility access required",
+                    systemImage: "exclamationmark.triangle.fill",
+                    tint: .red
+                ) {
+                    appState.showAccessibilityAlert()
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, appState.hasAccessibility && appState.hasScreenRecordingPermission ? 0 : 10)
+    }
+
+    // MARK: Primary Action
+
+    private var dictateHint: String? {
+        guard !appState.isRecording else { return nil }
+        if !appState.holdShortcut.isDisabled {
+            return "Hold \(appState.holdShortcut.displayName)"
+        }
+        if !appState.toggleShortcut.isDisabled {
+            return "Tap \(appState.toggleShortcut.displayName)"
+        }
+        return nil
+    }
+
+    private var dictateButton: some View {
+        Button {
+            let shouldStop = appState.isRecording
+            dismissMenuBarPanel()
+            if shouldStop {
+                appState.toggleRecording()
+            } else {
+                // Hand focus back to the previous app before recording so the
+                // transcript pastes where the user was typing, not into
+                // FreeFlow's own panel.
+                NSApp.hide(nil)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    appState.toggleRecording()
+                }
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: appState.isRecording ? "stop.fill" : "mic.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(appState.isRecording ? "Stop Recording" : "Start Dictating")
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                if let hint = dictateHint {
+                    Text(hint)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.75))
+                }
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .frame(maxWidth: .infinity)
+            .frame(height: 38)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: appState.isRecording
+                                ? [Color.red, Color.red.opacity(0.8)]
+                                : [Color.accentColor, Color.accentColor.opacity(0.8)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(appState.isTranscribing)
+        .opacity(appState.isTranscribing ? 0.5 : 1)
+    }
+
+    private func inlineError(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(.red)
+                .padding(.top, 1)
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.red.opacity(0.08))
+        )
+    }
+
+    // MARK: Last Transcript
+
+    private var lastTranscriptCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("LAST TRANSCRIPT")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .kerning(0.5)
+                Spacer()
+                Button {
+                    appState.copyLastTranscriptToPasteboard()
+                    withAnimation(.easeInOut(duration: 0.15)) { copiedLastTranscript = true }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                        withAnimation { copiedLastTranscript = false }
+                    }
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: copiedLastTranscript ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 9, weight: .semibold))
+                        Text(pasteAgainLabel)
+                            .font(.system(size: 10, weight: .medium))
+                    }
+                    .foregroundStyle(copiedLastTranscript ? Color.green : Color.accentColor)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Text(appState.lastTranscript)
+                .font(.system(size: 12))
+                .foregroundStyle(.primary)
+                .lineLimit(3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+    }
+
+    private var pasteAgainLabel: String {
+        if copiedLastTranscript { return "Copied" }
+        if appState.copyAgainShortcut.isDisabled { return "Paste Again" }
+        return "Paste Again  \(appState.copyAgainShortcut.displayName)"
+    }
+
+    // MARK: History
+
+    private var historySection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("RECENT")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .kerning(0.5)
+                Spacer()
+                Button("View All") {
+                    openSettingsTab(.runLog)
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+            }
+            .padding(.horizontal, 4)
+
+            ForEach(recentHistoryItems) { item in
+                HistoryRow(
+                    snippet: transcriptSnippet(for: item),
+                    detail: historyDetail(for: item),
+                    isCopied: copiedItemID == item.id
+                ) {
+                    copyToPasteboard(transcriptFull(for: item))
+                    withAnimation(.easeInOut(duration: 0.15)) { copiedItemID = item.id }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                        if copiedItemID == item.id {
+                            withAnimation { copiedItemID = nil }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func historyDetail(for item: PipelineHistoryItem) -> String {
+        let time = Self.relativeFormatter.localizedString(for: item.timestamp, relativeTo: Date())
+        if let app = item.contextAppName, !app.isEmpty {
+            return "\(time) · \(app)"
+        }
+        return time
+    }
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    // MARK: Controls
+
+    private var controlsSection: some View {
+        VStack(spacing: 2) {
+            microphoneRow
+            shortcutRow(role: .hold, icon: "hand.tap", current: appState.holdShortcut)
+            shortcutRow(role: .toggle, icon: "cursorarrow.click.2", current: appState.toggleShortcut)
+            shortcutRow(role: .copyAgain, icon: "doc.on.clipboard", current: appState.copyAgainShortcut)
+        }
+    }
+
+    private var selectedMicrophoneName: String {
+        if appState.selectedMicrophoneID == "default" || appState.selectedMicrophoneID.isEmpty {
+            return "System Default"
+        }
+        return appState.availableMicrophones.first { $0.uid == appState.selectedMicrophoneID }?.name
+            ?? "System Default"
+    }
+
+    private var microphoneRow: some View {
+        PanelControlRow(icon: "mic", title: "Microphone") {
+            Menu {
+                Button {
+                    appState.selectedMicrophoneID = "default"
+                } label: {
+                    menuChoiceLabel(
+                        "System Default",
+                        isSelected: appState.selectedMicrophoneID == "default"
+                            || appState.selectedMicrophoneID.isEmpty
+                    )
+                }
+                ForEach(appState.availableMicrophones) { device in
+                    Button {
+                        appState.selectedMicrophoneID = device.uid
+                    } label: {
+                        menuChoiceLabel(device.name, isSelected: appState.selectedMicrophoneID == device.uid)
+                    }
+                }
+            } label: {
+                Text(selectedMicrophoneName)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+        }
+    }
+
+    private func conflictingBinding(for role: ShortcutRole) -> [ShortcutBinding] {
+        switch role {
+        case .hold: return [appState.toggleShortcut]
+        case .toggle: return [appState.holdShortcut]
+        case .copyAgain: return [appState.holdShortcut, appState.toggleShortcut]
+        }
+    }
+
+    private func currentBinding(for role: ShortcutRole) -> ShortcutBinding {
+        switch role {
+        case .hold: return appState.holdShortcut
+        case .toggle: return appState.toggleShortcut
+        case .copyAgain: return appState.copyAgainShortcut
+        }
+    }
+
+    private func shortcutRow(role: ShortcutRole, icon: String, current: ShortcutBinding) -> some View {
+        PanelControlRow(icon: icon, title: role.title) {
+            Menu {
+                Button {
+                    _ = appState.setShortcut(.disabled, for: role)
+                } label: {
+                    menuChoiceLabel("Disabled", isSelected: current.isDisabled)
+                }
+
+                ForEach(ShortcutPreset.allCases) { preset in
+                    Button {
+                        _ = appState.setShortcut(preset.binding, for: role)
+                    } label: {
+                        menuChoiceLabel(preset.title, isSelected: current == preset.binding)
+                    }
+                    .disabled(conflictingBinding(for: role).contains(preset.binding))
+                }
+
+                if let custom = appState.savedCustomShortcut(for: role) {
+                    Divider()
+                    Button {
+                        _ = appState.setShortcut(custom, for: role)
+                    } label: {
+                        menuChoiceLabel("Custom: \(custom.displayName)", isSelected: current == custom)
+                    }
+                }
+
+                Divider()
+                Button("Customize…") {
+                    openSettingsTab(.general)
+                }
+            } label: {
+                Text(current.isDisabled ? "Off" : current.displayName)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+        }
+    }
+
+    @ViewBuilder
+    private func menuChoiceLabel(_ title: String, isSelected: Bool) -> some View {
+        if isSelected {
+            Label(title, systemImage: "checkmark")
+        } else {
+            Text(title)
+        }
+    }
+
+    // MARK: Update Banner
+
+    @ViewBuilder
+    private var updateBanner: some View {
+        if updateManager.updateAvailable {
+            sectionDivider
+            Group {
+                switch updateManager.updateStatus {
+                case .downloading:
+                    VStack(spacing: 4) {
+                        Text("Downloading update… \(Int((updateManager.downloadProgress ?? 0) * 100))%")
+                            .font(.system(size: 11, weight: .semibold))
+                        ProgressView(value: updateManager.downloadProgress ?? 0)
+                            .progressViewStyle(.linear)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+
+                case .installing, .readyToRelaunch:
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Installing update…")
+                            .font(.system(size: 11, weight: .semibold))
+                    }
+                    .padding(.vertical, 8)
+
+                default:
+                    PanelBannerButton(
+                        title: "Update available — install now",
+                        systemImage: "arrow.down.circle.fill",
+                        tint: .blue
+                    ) {
+                        dismissMenuBarPanel()
+                        updateManager.showUpdateAlert()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+            }
+        }
+    }
+
+    // MARK: Footer
+
+    private var footer: some View {
+        HStack(spacing: 2) {
+            PanelFooterButton(title: "Settings", systemImage: "gearshape") {
+                dismissMenuBarPanel()
+                NotificationCenter.default.post(name: .showSettings, object: nil)
+            }
+
+            Menu {
+                Button("Paste Custom Word to Vocabulary") {
+                    if appState.pasteWordToVocabulary() != nil {
+                        VocabularyNotificationManager.shared.flashCheckmark()
+                    }
+                }
+                Button("Re-run Setup…") {
+                    dismissMenuBarPanel()
+                    NotificationCenter.default.post(name: .showSetup, object: nil)
+                }
+                Divider()
+                Button(updateManager.isChecking ? "Checking for Updates…" : "Check for Updates") {
+                    Task {
+                        await updateManager.checkForUpdates(userInitiated: true)
+                    }
+                }
+                .disabled(updateManager.isChecking)
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28, height: 26)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+
+            Spacer()
+
+            PanelFooterButton(title: "Quit", systemImage: "power") {
+                NSApplication.shared.terminate(nil)
+            }
+            .keyboardShortcut("q")
+        }
+    }
+
+    // MARK: Helpers
+
+    private func openSettingsTab(_ tab: SettingsTab) {
+        appState.selectedSettingsTab = tab
+        dismissMenuBarPanel()
+        NotificationCenter.default.post(name: .showSettings, object: nil)
+    }
+
+    private var sectionDivider: some View {
+        Divider().opacity(0.5)
     }
 
     private func transcriptText(for item: PipelineHistoryItem) -> String {
@@ -32,394 +576,148 @@ struct MenuBarView: View {
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return "(no transcript)" }
-        return text.count > 48 ? String(text.prefix(48)) + "..." : text
+        return text.count > 60 ? String(text.prefix(60)) + "…" : text
     }
 
-    private func copyTranscriptToPasteboard(_ transcript: String) {
+    private func copyToPasteboard(_ transcript: String) {
         guard !transcript.isEmpty else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(transcript, forType: .string)
     }
+}
 
-    private func openRunLog() {
-        appState.selectedSettingsTab = .runLog
-        NotificationCenter.default.post(name: .showSettings, object: nil)
-    }
+// MARK: - Components
+
+/// Full-width tinted banner used for permission warnings and update prompts.
+private struct PanelBannerButton: View {
+    let title: String
+    let systemImage: String
+    let tint: Color
+    let action: () -> Void
+
+    @State private var isHovered = false
 
     var body: some View {
-        VStack(spacing: 4) {
-            Text("\(AppName.displayName) v\(appVersion)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 4)
-
-            Divider()
-
-            if !appState.hasScreenRecordingPermission {
-                Button {
-                    appState.requestScreenCapturePermission()
-                } label: {
-                    Label("Screen Recording Permission Needed", systemImage: "camera.viewfinder")
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.white)
-                .font(.caption.weight(.semibold))
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .frame(maxWidth: .infinity)
-                .background(Color.orange)
-
-                Divider()
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .opacity(0.6)
             }
-
-            // Accessibility warning
-            if !appState.hasAccessibility {
-                Button {
-                    appState.showAccessibilityAlert()
-                } label: {
-                    Label("Accessibility Required", systemImage: "exclamationmark.triangle.fill")
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.white)
-                .font(.caption.weight(.semibold))
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .frame(maxWidth: .infinity)
-                .background(Color.red)
-
-                Divider()
-            }
-
-            // Status
-            if appState.isRecording {
-                Label("Recording...", systemImage: "record.circle")
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 6)
-            } else if appState.isTranscribing {
-                Label(appState.debugStatusMessage, systemImage: "ellipsis.circle")
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 6)
-            } else {
-                Text(appState.shortcutStatusText)
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 6)
-            }
-
-            Divider()
-
-            // Manual toggle
-            Button(appState.isRecording ? "Stop Recording" : "Start Dictating") {
-                appState.toggleRecording()
-            }
-            .disabled(appState.isTranscribing)
-
-            if let hotkeyError = appState.hotkeyMonitoringErrorMessage {
-                Divider()
-                Text(hotkeyError)
-                    .foregroundStyle(.red)
-                    .font(.caption)
-                    .padding(.horizontal, 16)
-                    .lineLimit(3)
-            }
-
-            if let error = appState.errorMessage {
-                Divider()
-                Text(error)
-                    .foregroundStyle(.red)
-                    .font(.caption)
-                    .padding(.horizontal, 16)
-                    .lineLimit(3)
-            }
-
-            Divider()
-
-            if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
-                Button(appState.copyAgainShortcut.isDisabled
-                    ? "Paste Again"
-                    : "Paste Again  (\(appState.copyAgainShortcut.displayName))") {
-                    appState.copyLastTranscriptToPasteboard()
-                }
-
-                let truncatedTranscript = appState.lastTranscript.count > 35
-                    ? String(appState.lastTranscript.prefix(35)) + "…"
-                    : appState.lastTranscript
-                Text("\u{201C}\(truncatedTranscript)\u{201D}")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 16)
-                    .lineLimit(4)
-                    .frame(maxWidth: 280, alignment: .leading)
-            }
-
-            Menu("History") {
-                if recentHistoryItems.isEmpty {
-                    Text("No transcripts yet")
-                } else {
-                    ForEach(recentHistoryItems) { item in
-                        let transcript = transcriptText(for: item)
-                        Button {
-                            copyTranscriptToPasteboard(transcriptFull(for: item))
-                        } label: {
-                            Text(transcriptSnippet(for: item))
-                        }
-                        .disabled(transcript.isEmpty)
-                    }
-
-                    Divider()
-                }
-
-                Button("Open Run Log") {
-                    openRunLog()
-                }
-            }
-
-            Divider()
-
-            Button("Paste Custom Word to Vocabulary") {
-                if appState.pasteWordToVocabulary() != nil {
-                    VocabularyNotificationManager.shared.flashCheckmark()
-                }
-            }
-
-            Divider()
-
-            Menu("Hold Shortcut") {
-                Button {
-                    _ = appState.setShortcut(.disabled, for: .hold)
-                } label: {
-                    if appState.holdShortcut.isDisabled {
-                        Text("✓ Disabled")
-                    } else {
-                        Text("  Disabled")
-                    }
-                }
-
-                ForEach(ShortcutPreset.allCases) { preset in
-                    Button {
-                        _ = appState.setShortcut(preset.binding, for: .hold)
-                    } label: {
-                        if appState.holdShortcut == preset.binding {
-                            Text("✓ \(preset.title)")
-                        } else {
-                            Text("  \(preset.title)")
-                        }
-                    }
-                    .disabled(preset.binding == appState.toggleShortcut)
-                }
-
-                if let savedCustomShortcut = appState.savedCustomShortcut(for: .hold) {
-                    Divider()
-                    Button {
-                        _ = appState.setShortcut(savedCustomShortcut, for: .hold)
-                    } label: {
-                        if appState.holdShortcut == savedCustomShortcut {
-                            Text("✓ Custom: \(savedCustomShortcut.displayName)")
-                        } else {
-                            Text("  Custom: \(savedCustomShortcut.displayName)")
-                        }
-                    }
-                }
-
-                Divider()
-                Button("Customize…") {
-                    appState.selectedSettingsTab = .general
-                    NotificationCenter.default.post(name: .showSettings, object: nil)
-                }
-            }
-
-            Menu("Toggle Shortcut") {
-                Button {
-                    _ = appState.setShortcut(.disabled, for: .toggle)
-                } label: {
-                    if appState.toggleShortcut.isDisabled {
-                        Text("✓ Disabled")
-                    } else {
-                        Text("  Disabled")
-                    }
-                }
-
-                ForEach(ShortcutPreset.allCases) { preset in
-                    Button {
-                        _ = appState.setShortcut(preset.binding, for: .toggle)
-                    } label: {
-                        if appState.toggleShortcut == preset.binding {
-                            Text("✓ \(preset.title)")
-                        } else {
-                            Text("  \(preset.title)")
-                        }
-                    }
-                    .disabled(preset.binding == appState.holdShortcut)
-                }
-
-                if let savedCustomShortcut = appState.savedCustomShortcut(for: .toggle) {
-                    Divider()
-                    Button {
-                        _ = appState.setShortcut(savedCustomShortcut, for: .toggle)
-                    } label: {
-                        if appState.toggleShortcut == savedCustomShortcut {
-                            Text("✓ Custom: \(savedCustomShortcut.displayName)")
-                        } else {
-                            Text("  Custom: \(savedCustomShortcut.displayName)")
-                        }
-                    }
-                }
-
-                Divider()
-                Button("Customize…") {
-                    appState.selectedSettingsTab = .general
-                    NotificationCenter.default.post(name: .showSettings, object: nil)
-                }
-            }
-
-            Menu("Paste Again Shortcut") {
-                Button {
-                    _ = appState.setShortcut(.disabled, for: .copyAgain)
-                } label: {
-                    if appState.copyAgainShortcut.isDisabled {
-                        Text("✓ Disabled")
-                    } else {
-                        Text("  Disabled")
-                    }
-                }
-
-                ForEach(ShortcutPreset.allCases) { preset in
-                    Button {
-                        _ = appState.setShortcut(preset.binding, for: .copyAgain)
-                    } label: {
-                        if appState.copyAgainShortcut == preset.binding {
-                            Text("✓ \(preset.title)")
-                        } else {
-                            Text("  \(preset.title)")
-                        }
-                    }
-                    .disabled(preset.binding == appState.holdShortcut || preset.binding == appState.toggleShortcut)
-                }
-
-                if let savedCustomShortcut = appState.savedCustomShortcut(for: .copyAgain) {
-                    Divider()
-                    Button {
-                        _ = appState.setShortcut(savedCustomShortcut, for: .copyAgain)
-                    } label: {
-                        if appState.copyAgainShortcut == savedCustomShortcut {
-                            Text("✓ Custom: \(savedCustomShortcut.displayName)")
-                        } else {
-                            Text("  Custom: \(savedCustomShortcut.displayName)")
-                        }
-                    }
-                }
-
-                Divider()
-                Button("Customize…") {
-                    appState.selectedSettingsTab = .general
-                    NotificationCenter.default.post(name: .showSettings, object: nil)
-                }
-            }
-
-            Menu("Microphone") {
-                Button {
-                    appState.selectedMicrophoneID = "default"
-                } label: {
-                    if appState.selectedMicrophoneID == "default" || appState.selectedMicrophoneID.isEmpty {
-                        Text("✓ System Default")
-                    } else {
-                        Text("  System Default")
-                    }
-                }
-                ForEach(appState.availableMicrophones) { device in
-                    Button {
-                        appState.selectedMicrophoneID = device.uid
-                    } label: {
-                        if appState.selectedMicrophoneID == device.uid {
-                            Text("✓ \(device.name)")
-                        } else {
-                            Text("  \(device.name)")
-                        }
-                    }
-                }
-            }
-
-            Button("Re-run Setup...") {
-                NotificationCenter.default.post(name: .showSetup, object: nil)
-            }
-
-            Button("Settings") {
-                NotificationCenter.default.post(name: .showSettings, object: nil)
-            }
-
-            Button {
-                Task {
-                    await updateManager.checkForUpdates(userInitiated: true)
-                }
-            } label: {
-                HStack(spacing: 6) {
-                    if updateManager.isChecking {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                    Text(updateManager.isChecking ? "Checking for Updates..." : "Check for Updates")
-                }
-            }
-            .disabled(updateManager.isChecking)
-
-            if updateManager.updateAvailable {
-                Divider()
-
-                switch updateManager.updateStatus {
-                case .downloading:
-                    VStack(spacing: 4) {
-                        Text("Downloading update... \(Int((updateManager.downloadProgress ?? 0) * 100))%")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.white)
-                        ProgressView(value: updateManager.downloadProgress ?? 0)
-                            .progressViewStyle(.linear)
-                            .tint(.white)
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-
-                case .installing, .readyToRelaunch:
-                    HStack(spacing: 6) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Installing update...")
-                            .font(.caption.weight(.semibold))
-                    }
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-
-                default:
-                    Button {
-                        updateManager.showUpdateAlert()
-                    } label: {
-                        Label("Update available", systemImage: "arrow.down.circle.fill")
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.white)
-                    .font(.caption.weight(.semibold))
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-                }
-            }
-
-            Divider()
-
-            Button("Quit \(AppName.displayName)") {
-                NSApplication.shared.terminate(nil)
-            }
-            .keyboardShortcut("q")
+            .foregroundStyle(tint)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(tint.opacity(isHovered ? 0.18 : 0.12))
+            )
         }
-        .padding(4)
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+
+/// History row: snippet plus relative time, copies on click with hover affordance.
+private struct HistoryRow: View {
+    let snippet: String
+    let detail: String
+    let isCopied: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(snippet)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text(detail)
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 4)
+                if isCopied {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.green)
+                } else if isHovered {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(Color.primary.opacity(isHovered ? 0.06 : 0))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .help("Click to copy")
+    }
+}
+
+/// Labeled control row with a trailing menu/value.
+private struct PanelControlRow<Trailing: View>: View {
+    let icon: String
+    let title: String
+    @ViewBuilder let trailing: Trailing
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            Text(title)
+                .font(.system(size: 12))
+            Spacer()
+            trailing
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+    }
+}
+
+/// Compact footer button with hover highlight.
+private struct PanelFooterButton: View {
+    let title: String
+    let systemImage: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 10.5, weight: .medium))
+                Text(title)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .frame(height: 26)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.primary.opacity(isHovered ? 0.07 : 0))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
     }
 }


### PR DESCRIPTION
Split out from #254. Carries **only** the menu-bar work — the feedback sounds and settings-sidebar redesign that shared the original combined commit are now separate PRs.

The menu bar extra now uses a window-style panel, and while recording the menu bar icon renders a small live waveform driven by the input level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)