### PR TITLE
Fix typing lag in Settings text editors by committing on focus loss

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -544,6 +544,7 @@ struct GeneralSettingsView: View {
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
+    @FocusState private var customVocabularyFocused: Bool
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
     @State private var copiedBuildInfo = false
@@ -764,6 +765,9 @@ struct GeneralSettingsView: View {
             checkMicPermission()
             appState.refreshLaunchAtLoginStatus()
             Task { await githubCache.fetchIfNeeded() }
+        }
+        .onDisappear {
+            commitCustomVocabulary()
         }
         .onChange(of: appState.transcriptionAPIURL) { value in
             if transcriptionAPIURLInput != value {
@@ -1385,6 +1389,13 @@ struct GeneralSettingsView: View {
 
     // MARK: Custom Vocabulary
 
+    private func commitCustomVocabulary() {
+        let trimmed = customVocabularyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        if appState.customVocabulary != trimmed {
+            appState.customVocabulary = trimmed
+        }
+    }
+
     private var vocabularySection: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Words and phrases to preserve during post-processing.")
@@ -1394,12 +1405,13 @@ struct GeneralSettingsView: View {
             TextEditor(text: $customVocabularyInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 80, maxHeight: 140)
+                .focused($customVocabularyFocused)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customVocabularyInput) { newValue in
-                    appState.customVocabulary = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                .onChange(of: customVocabularyFocused) { focused in
+                    if !focused { commitCustomVocabulary() }
                 }
 
             Text("Separate entries with commas, new lines, or semicolons.")
@@ -1508,6 +1520,8 @@ struct PromptsSettingsView: View {
     @EnvironmentObject var appState: AppState
     @State private var customSystemPromptInput: String = ""
     @State private var customContextPromptInput: String = ""
+    @FocusState private var customSystemPromptFocused: Bool
+    @FocusState private var customContextPromptFocused: Bool
     @State private var showDefaultSystemPrompt = false
     @State private var showDefaultContextPrompt = false
 
@@ -1546,6 +1560,38 @@ struct PromptsSettingsView: View {
             customContextPromptInput = appState.customContextPrompt.isEmpty
                 ? AppContextService.defaultContextPrompt
                 : appState.customContextPrompt
+        }
+        .onDisappear {
+            commitCustomSystemPrompt()
+            commitCustomContextPrompt()
+        }
+    }
+
+    private func commitCustomSystemPrompt() {
+        let trimmed = customSystemPromptInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == defaultTrimmed || trimmed.isEmpty {
+            if !appState.customSystemPrompt.isEmpty {
+                appState.customSystemPrompt = ""
+                appState.customSystemPromptLastModified = ""
+            }
+        } else if appState.customSystemPrompt != trimmed {
+            appState.customSystemPrompt = trimmed
+            appState.customSystemPromptLastModified = iso8601DayFormatter.string(from: Date())
+        }
+    }
+
+    private func commitCustomContextPrompt() {
+        let trimmed = customContextPromptInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == defaultTrimmed || trimmed.isEmpty {
+            if !appState.customContextPrompt.isEmpty {
+                appState.customContextPrompt = ""
+                appState.customContextPromptLastModified = ""
+            }
+        } else if appState.customContextPrompt != trimmed {
+            appState.customContextPrompt = trimmed
+            appState.customContextPromptLastModified = iso8601DayFormatter.string(from: Date())
         }
     }
 
@@ -1609,25 +1655,13 @@ struct PromptsSettingsView: View {
             TextEditor(text: $customSystemPromptInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 120, maxHeight: 200)
+                .focused($customSystemPromptFocused)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customSystemPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customSystemPrompt.isEmpty {
-                            appState.customSystemPrompt = ""
-                            appState.customSystemPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customSystemPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customSystemPromptLastModified != today {
-                            appState.customSystemPromptLastModified = today
-                        }
-                    }
+                .onChange(of: customSystemPromptFocused) { focused in
+                    if !focused { commitCustomSystemPrompt() }
                 }
 
             HStack {
@@ -1740,6 +1774,7 @@ struct PromptsSettingsView: View {
     }
 
     private func runSystemPromptTest() {
+        commitCustomSystemPrompt()
         systemTestRunning = true
         systemTestOutput = nil
         systemTestError = nil
@@ -1851,25 +1886,13 @@ struct PromptsSettingsView: View {
             TextEditor(text: $customContextPromptInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 120, maxHeight: 200)
+                .focused($customContextPromptFocused)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customContextPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customContextPrompt.isEmpty {
-                            appState.customContextPrompt = ""
-                            appState.customContextPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customContextPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customContextPromptLastModified != today {
-                            appState.customContextPromptLastModified = today
-                        }
-                    }
+                .onChange(of: customContextPromptFocused) { focused in
+                    if !focused { commitCustomContextPrompt() }
                 }
 
             HStack {
@@ -1999,6 +2022,7 @@ struct PromptsSettingsView: View {
     }
 
     private func runContextPromptTest() {
+        commitCustomContextPrompt()
         contextTestRunning = true
         contextTestOutput = nil
         contextTestError = nil


### PR DESCRIPTION
## What

Typing in the Custom Vocabulary, System Prompt, and Context Prompt fields in Settings is laggy. Each of these editors wrote its value into the shared `AppState` on every keystroke, and since `AppState` is a single `ObservableObject` observed by the whole settings window and the menu bar, every character fired `objectWillChange` and rebuilt all of those views. On the macOS 13 target there is no per-property observation to scope that, so the whole thing re-rendered on each keystroke.

I measured it with a small timer around the affected views on a MacBook Air M1: each keystroke rebuilt 3 view bodies and took 80 to 170 ms of main-thread work before going idle, usually around 85 ms. One of the rebuilt views was the menu bar extra, which has nothing to do with the text box.

## Fix

These three editors now commit into `AppState` when the field loses focus instead of on every keystroke, which is the same pattern the API base URL and key fields already use. The live text stays in local `@State` while you type, so there is no per-character churn on the shared object.

To avoid losing anything typed, they also commit on `onDisappear` (in case the window is closed while a field is still focused), and the prompt test runners commit first so they still test the latest text.

## Testing

- Built and ran locally on macOS 13 target, arm64.
- Confirmed with the timer that typing no longer republishes `AppState` per keystroke.
- `make test` passes.
- Manually checked that vocabulary and both prompts still save, that reverting a prompt to the default still clears the custom value, and that the prompt test buttons use the current text.

Fixes #274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom vocabulary and prompt edits are now saved when leaving the editor or settings screen.
  * Prompt tests now use the latest text entered.
  * Empty or default prompt content is handled consistently.
  * Unchanged custom prompts no longer update their modification date unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->