### PR TITLE
fix: show only currently supported Groq models in the model dropdown picker

### DIFF
--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -13,13 +13,15 @@ public struct ModelConfiguration {
         "openai/gpt-oss-120b",
         "openai/gpt-oss-safeguard-20b",
         "qwen/qwen3.6-27b",
-        "allam-2-7b",
         "groq/compound",
-        "groq/compound-mini",
-        "canopylabs/orpheus-arabic-saudi",
-        "canopylabs/orpheus-v1-english",
-        "meta-llama/llama-prompt-guard-2-22m",
-        "meta-llama/llama-prompt-guard-2-86m"
+        "groq/compound-mini"
+    ]
+
+    // MARK: - Vision-capable models
+
+    /// Models that accept image input. The context model must support vision for screenshot analysis to work.
+    public static let visionModels = [
+        "qwen/qwen3.6-27b"
     ]
 
     public static let transcriptionModels = [
@@ -59,7 +61,7 @@ public struct ModelConfiguration {
                 shouldStripThinkTags: false
             )
         } else if cleanModel == "qwen/qwen3-32b" {
- // Model that requires sanitization of thought tags
+            // Model that requires sanitization of thought tags
             return ModelConfig(
                 maxCompletionTokens: nil,
                 reasoningEffort: nil,
@@ -159,7 +161,7 @@ public struct ModelConfiguration {
             )
         }
         
-        // Fallback genérico para qualquer outro modelo que não esteja na lista acima
+        // Generic fallback for any model not explicitly listed above
         return ModelConfig(
             maxCompletionTokens: nil,
             reasoningEffort: nil,

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -238,8 +238,8 @@ struct ProviderSettingsFields: View {
 
             ModelDropdownView(
                 title: "Context Model",
-                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails.",
-                predefinedModels: ModelConfiguration.llmModels,
+                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input.",
+                predefinedModels: ModelConfiguration.visionModels,
                 defaultModel: AppState.defaultContextModel,
                 textDraft: $contextModelDraft,
                 onCommit: commitContextModel,


### PR DESCRIPTION
## Summary

The model dropdown was displaying models that are either no longer available on groq and also displaying models that don't support vision (image input) in the Context Model field. This fix removes unavailable models, introduces a dedicated `visionModels` list, and wires the context model picker to that list so only models that can actually process screenshots are offered.

## Changes

| Component | Details |
|---|---|
| `ModelConfiguration.swift` | Removed unavailable Groq models (`allam-2-7b`, `canopylabs/orpheus-*`, `meta-llama/llama-prompt-guard-2-*`) from `llmModels`. Added `visionModels` array containing only models that accept image input (`qwen/qwen3.6-27b`). |
| `SettingsView.swift` | Context model picker now uses `ModelConfiguration.visionModels` instead of `llmModels`. Updated subtitle to clarify that screenshot analysis requires a vision-capable model. |

- **Custom model typed by user:** The picker still allows free-text input; users who type a vision-capable model not in `visionModels` will continue to work as before — the list is suggestive, not restrictive.
- **Existing user config with a now-removed model:** The stored model string is preserved unchanged; only the suggestions list shrinks. No data migration needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Context Model setting to clearly indicate that screenshot analysis requires an image-capable model.
  * The Context Model dropdown now lists vision-capable models, including newly supported options.

* **Improvements**
  * Refined the available vision model selection to provide a more focused set of compatible choices.
  * Improved fallback descriptions and model guidance for clearer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->