### PR TITLE
Add Homebrew cask and document brew install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,24 +153,39 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           DMG_SHA="$(shasum -a 256 FreeFlow.dmg | cut -d ' ' -f 1)"
 
-          git checkout main
-          if [ ! -f Casks/freeflow.rb ]; then
-            echo "Casks/freeflow.rb missing on main, nothing to bump."
-            exit 0
-          fi
-
-          sed -i '' -E "s|^  version \".*\"$|  version \"$VERSION\"|" Casks/freeflow.rb
-          sed -i '' -E "s|^  sha256 \".*\"$|  sha256 \"$DMG_SHA\"|" Casks/freeflow.rb
-
-          if git diff --quiet -- Casks/freeflow.rb; then
-            echo "Cask already at $VERSION."
-            exit 0
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "Bump Homebrew cask to $VERSION" -- Casks/freeflow.rb
-          git push origin main
+
+          # Retry because main can move while the DMG is being notarized, which
+          # takes long enough for that to be a realistic race. Each attempt
+          # re-reads main so the bump always lands on its current tip. --force
+          # is needed because the earlier version-stamp step leaves Info.plist
+          # dirty, which otherwise blocks the branch switch.
+          for attempt in 1 2 3; do
+            git fetch --force origin main:refs/remotes/origin/main
+            git checkout --force -B main origin/main
+
+            if [ ! -f Casks/freeflow.rb ]; then
+              echo "::error::Casks/freeflow.rb is missing on main. Release $VERSION is published but Homebrew still serves the previous build."
+              exit 1
+            fi
+
+            sed -i '' -E "s|^  version \".*\"$|  version \"$VERSION\"|" Casks/freeflow.rb
+            sed -i '' -E "s|^  sha256 \".*\"$|  sha256 \"$DMG_SHA\"|" Casks/freeflow.rb
+
+            if git diff --quiet -- Casks/freeflow.rb; then
+              echo "Cask already at $VERSION."
+              exit 0
+            fi
+
+            git commit -m "Bump Homebrew cask to $VERSION" -- Casks/freeflow.rb
+            git push origin main && exit 0
+
+            echo "Push rejected, main moved. Retrying ($attempt/3)."
+          done
+
+          echo "::error::Could not push the cask bump for $VERSION after 3 attempts."
+          exit 1
 
       # --- Cleanup ---
       - name: Cleanup signing artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,34 @@ jobs:
           files: |
             FreeFlow.dmg
 
+      # --- Homebrew cask ---
+      # The cask in Casks/ pins an exact version and checksum, so it has to be
+      # bumped on every release or `brew upgrade` keeps serving the old build.
+      # Done here rather than by hand because a manual step gets forgotten.
+      - name: Bump Homebrew cask
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DMG_SHA="$(shasum -a 256 FreeFlow.dmg | cut -d ' ' -f 1)"
+
+          git checkout main
+          if [ ! -f Casks/freeflow.rb ]; then
+            echo "Casks/freeflow.rb missing on main, nothing to bump."
+            exit 0
+          fi
+
+          sed -i '' -E "s|^  version \".*\"$|  version \"$VERSION\"|" Casks/freeflow.rb
+          sed -i '' -E "s|^  sha256 \".*\"$|  sha256 \"$DMG_SHA\"|" Casks/freeflow.rb
+
+          if git diff --quiet -- Casks/freeflow.rb; then
+            echo "Cask already at $VERSION."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Bump Homebrew cask to $VERSION" -- Casks/freeflow.rb
+          git push origin main
+
       # --- Cleanup ---
       - name: Cleanup signing artifacts
         if: always()

--- a/Casks/freeflow.rb
+++ b/Casks/freeflow.rb
@@ -1,0 +1,29 @@
+cask "freeflow" do
+  version "1.2.0"
+  sha256 "f55e384d6da375e5c85d6cff40de5655dff8c1e8e14dd903a6c09703c7556da6"
+
+  url "https://github.com/zachlatta/freeflow/releases/download/v#{version}/FreeFlow.dmg"
+  name "FreeFlow"
+  desc "Dictation app with AI transcription and context-aware cleanup"
+  homepage "https://github.com/zachlatta/freeflow"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "FreeFlow.app"
+
+  uninstall quit:       "com.zachlatta.freeflow",
+            login_item: "FreeFlow"
+
+  zap trash: [
+    "~/Library/Application Support/FreeFlow",
+    "~/Library/Caches/com.zachlatta.freeflow",
+    "~/Library/HTTPStorages/com.zachlatta.freeflow",
+    "~/Library/Preferences/com.zachlatta.freeflow.plist",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ FreeFlow is a free Mac dictation app inspired by [Wispr Flow](https://wisprflow.
 
 ## Quick Start
 
-1. Download the app from above or [click here](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg)
+1. Install FreeFlow - download the app from above, [click here](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg), or use Homebrew:
+
+   ```sh
+   brew tap zachlatta/freeflow https://github.com/zachlatta/freeflow
+   brew install --cask freeflow
+   ```
+
+   FreeFlow updates itself, so Homebrew leaves it alone after install. To let Homebrew handle upgrades too, run `brew upgrade --cask --greedy freeflow`.
+
 2. Get a free Groq API key from [groq.com](https://groq.com/)
 3. Hold `Fn` to talk, or tap `Command-Fn` to start and stop dictation, and have whatever you say pasted into the current text field
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ FreeFlow is a free Mac dictation app inspired by [Wispr Flow](https://wisprflow.
 
 ## Quick Start
 
-1. Install FreeFlow - download the app from above, [click here](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg), or use Homebrew:
+1. Install FreeFlow - [download FreeFlow.dmg](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg), or use Homebrew:
 
    ```sh
    brew tap zachlatta/freeflow https://github.com/zachlatta/freeflow


### PR DESCRIPTION
Closes #185

Adds Homebrew as an install option:

```sh
brew tap zachlatta/freeflow https://github.com/zachlatta/freeflow
brew install --cask freeflow
```

The cask points at the notarized universal DMG this repo already publishes to GitHub Releases, so nothing about the build or signing setup changes.

Commits, each independently droppable:

1. **`Casks/freeflow.rb`** - the cask itself.
2. **Auto-bump step in `release.yml`** - the cask pins an exact `version` and `sha256`, so without this it goes stale on the next tag and Homebrew keeps serving the previous build. Uses the `contents: write` permission the workflow already has. No new secrets, no new actions.
3. **README** - documents the install.

### Why each stanza

| Stanza | Reason |
|---|---|
| `depends_on macos: :ventura` | matches `-target *-apple-macosx13.0` in the `Makefile` |
| `auto_updates true` | `UpdateManager` downloads and self-installs. Without this, `brew upgrade` and the in-app updater fight over `/Applications/FreeFlow.app` |
| `uninstall quit:` / `login_item:` | menu-bar app that registers itself for launch-at-login via `SMAppService.mainApp` |
| `zap trash:` | the four paths a release build actually writes - `Application Support/FreeFlow` plus the `Caches`, `HTTPStorages` and `Preferences` entries for `com.zachlatta.freeflow` |
| `livecheck` + `strategy :github_latest` | `/releases/latest` returns `v1.2.0` and correctly skips the `dev` prerelease |

### Verification

Cask:

- `brew fetch --cask` - checksum verified against the published v1.2.0 DMG
- `brew info --cask` - resolves to `1.2.0 (auto_updates)`, `Required: macOS >= 13`, `FreeFlow.app (App)`
- `brew install --cask --dry-run` - clean
- Tapped the repo from a local clone to confirm Homebrew discovers `Casks/freeflow.rb` at the repo root
- Published DMG independently confirmed `accepted / source=Notarized Developer ID` and stapled

Release step, exercised by extracting the step's shell body straight out of the YAML and running it against a scratch repo:

- `main` moved since the tag, `Info.plist` left dirty by the version-stamp step - switches and bumps correctly
- first push rejected to simulate a concurrent release - retries and succeeds, with `main`'s intervening commit preserved
- resulting cask carries the right `version` and a `sha256` matching the DMG byte for byte
- re-run against an already-bumped cask - no-op, exits 0
- cask file missing from `main` - exits 1 with an `::error::` annotation

One gap worth flagging: I could not run `brew style` / `brew audit` locally, because the Homebrew install on my machine is read-only and can't bootstrap its developer gems. The cask loads and resolves correctly through Homebrew's own DSL, and its stanza order and content follow the Cask Cookbook and existing GitHub-hosted casks, but it has not been through the official linters.

### Open question

This puts the cask in this repo, so the repo doubles as a tap. That works today, but it probably isn't the end state - `brew tap` has to clone 34.7 MB of app source to deliver a 29-line file.

I opened #283 to discuss in-repo tap vs a dedicated `homebrew-freeflow` tap vs submitting to `Homebrew/homebrew-cask`. FreeFlow clears the homebrew-cask notability bar comfortably. The cask file is identical in all three cases, so this PR isn't wasted work either way - happy to follow up with whichever you prefer.
