### PR TITLE
Add MiniMax-M3 and MiniMax-M2.7 to the LLM model picker

### DIFF
--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -19,7 +19,9 @@ public struct ModelConfiguration {
         "canopylabs/orpheus-arabic-saudi",
         "canopylabs/orpheus-v1-english",
         "meta-llama/llama-prompt-guard-2-22m",
-        "meta-llama/llama-prompt-guard-2-86m"
+        "meta-llama/llama-prompt-guard-2-86m",
+        "MiniMax-M3",
+        "MiniMax-M2.7"
     ]
 
     public static let transcriptionModels = [
@@ -142,6 +144,23 @@ public struct ModelConfiguration {
                 reasoningEffort: nil,
                 includeReasoning: nil,
                 shouldStripThinkTags: false
+            )
+        } else if cleanModel == "minimax-m3" {
+            // MiniMax-M3 emits an adaptive thinking block; strip reasoning tags so the
+            // cleaned transcript never contains the model's chain of thought.
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: true
+            )
+        } else if cleanModel == "minimax-m2.7" {
+            // MiniMax-M2.7 always emits reasoning; strip its think tags from the output.
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: true
             )
         } else if cleanModel == "whisper-large-v3" {
             return ModelConfig(

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -8,6 +8,7 @@ struct AppContextServiceTests {
         testNonStrippingModelPreservesExistingBehavior()
         testDeprecatedGroqModelsAreNotPredefined()
         testQwenCleanupDisablesReasoning()
+        testMiniMaxModelsArePredefinedAndStripThinkTags()
         print("AppContextServiceTests passed")
     }
 
@@ -72,6 +73,26 @@ struct AppContextServiceTests {
 
         expect(config.reasoningEffort == "none", "Qwen cleanup should disable reasoning")
         expect(config.includeReasoning == false, "Qwen cleanup should exclude reasoning output")
+    }
+
+    private static func testMiniMaxModelsArePredefinedAndStripThinkTags() {
+        expect(ModelConfiguration.llmModels.contains("MiniMax-M3"), "MiniMax-M3 is missing from the picker")
+        expect(ModelConfiguration.llmModels.contains("MiniMax-M2.7"), "MiniMax-M2.7 is missing from the picker")
+
+        for model in ["MiniMax-M3", "MiniMax-M2.7"] {
+            let config = ModelConfiguration.config(for: model)
+            expect(config.shouldStripThinkTags, "MiniMax model should strip think tags: \(model)")
+        }
+
+        let reasoningOutput = """
+        <think>
+        Hidden reasoning should never reach the transcript.
+        </think>
+        Cleaned transcript text.
+        """
+        let summary = AppContextService.activitySummary(from: reasoningOutput, model: "MiniMax-M3")
+        expect(summary?.contains("Hidden reasoning") == false, "MiniMax reasoning leaked into summary")
+        expect(summary?.contains("Cleaned transcript text.") == true, "MiniMax summary dropped the transcript text")
     }
 
     private static func expectEqual(_ actual: String?, _ expected: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Reason: Add MiniMax-M3 and MiniMax-M2.7 to the predefined LLM model picker.

## Changes

- Add `MiniMax-M3` and `MiniMax-M2.7` to `ModelConfiguration.llmModels` so they appear in the post-processing, fallback, and context model dropdowns instead of requiring manual entry.
- Register per-model config entries for both models in `ModelConfiguration.config(for:)` with `shouldStripThinkTags: true`, so their reasoning/think blocks are stripped from cleaned transcripts the same way other reasoning models are handled.

## Why strip think tags

Both models emit reasoning content (MiniMax-M3 adaptively, MiniMax-M2.7 always on). Without stripping, the reasoning text would leak into the pasted transcript. FreeFlow already strips think tags for other reasoning models via `ModelConfiguration.stripThinkTags`, so the new entries reuse that existing path.

## Checks

The repo builds with `swiftc` on macOS (see `Makefile`); no Swift toolchain is available in this environment, so the change was validated by static checks: brace/paren balance, and the added test asserting the models are predefined and that think tags are stripped.

A new test `testMiniMaxModelsArePredefinedAndStripThinkTags` was added to `Tests/AppContextServiceTests.swift` covering:
- both model IDs are present in `ModelConfiguration.llmModels`,
- `config(for:)` returns `shouldStripThinkTags == true` for both,
- a reasoning block is stripped from an MiniMax-M3 activity summary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the MiniMax-M3 and MiniMax-M2.7 language models.
  * Enabled automatic removal of think tags from responses for these models.
  * Configured model behavior to preserve cleaned transcript text.

* **Tests**
  * Added coverage validating model registration, configuration, and response cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->