### PR TITLE
fix: keep non-English dictation in its own language during cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,14 @@ endif
 test: $(TEST_RUNNER)
 	@$(TEST_RUNNER)
 
-$(TEST_RUNNER): Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Tests/AppContextServiceTests.swift
+$(TEST_RUNNER): Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Sources/LLMCooldownManager.swift Sources/PostProcessingService.swift Tests/AppContextServiceTests.swift
 	@mkdir -p "$(BUILD_DIR)"
 	swiftc \
 		-parse-as-library \
 		-o "$(TEST_RUNNER)" \
 		-sdk $(shell xcrun --show-sdk-path) \
 		-target $(ARCH)-apple-macosx13.0 \
-		Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Tests/AppContextServiceTests.swift
+		Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Sources/LLMCooldownManager.swift Sources/PostProcessingService.swift Tests/AppContextServiceTests.swift
 
 icon: $(ICON_ICNS)
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1013,6 +1013,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return stored.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// English name of the selected dictation language, for the cleanup prompt to
+    /// name explicitly. Empty on Auto-detect, because there is nothing to name, and
+    /// empty for English, because the prompt's own examples are already English and
+    /// English dictation never drifts.
+    static func dictationLanguageName(for language: String) -> String {
+        let normalized = normalizeTranscriptionLanguage(language)
+        guard !normalized.isEmpty, normalized != "en" else { return "" }
+        return transcriptionLanguageOptions.first { $0.code == normalized }?.name ?? ""
+    }
+
     private static func normalizeTranscriptionLanguage(_ language: String) -> String {
         let normalized = language.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard transcriptionLanguageOptions.contains(where: { $0.code == normalized }) else {
@@ -2573,7 +2583,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 context: context,
                 customVocabulary: customVocabulary,
                 customSystemPrompt: customSystemPrompt,
-                outputLanguage: outputLanguage
+                outputLanguage: outputLanguage,
+                dictationLanguage: Self.dictationLanguageName(for: transcriptionLanguage)
             )
             return (result.transcript, .postProcessingSucceeded, result.prompt)
         } catch {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -165,7 +165,8 @@ Behavior:
         context: AppContext,
         customVocabulary: String,
         customSystemPrompt: String = "",
-        outputLanguage: String = ""
+        outputLanguage: String = "",
+        dictationLanguage: String = ""
     ) async throws -> PostProcessingResult {
         let vocabularyTerms = mergedVocabularyTerms(rawVocabulary: customVocabulary)
 
@@ -180,7 +181,8 @@ Behavior:
                     contextSummary: context.contextSummary,
                     customVocabulary: vocabularyTerms,
                     customSystemPrompt: customSystemPrompt,
-                    outputLanguage: outputLanguage
+                    outputLanguage: outputLanguage,
+                    dictationLanguage: dictationLanguage
                 )
             }
 
@@ -310,7 +312,8 @@ Behavior:
         contextSummary: String,
         customVocabulary: [String],
         customSystemPrompt: String = "",
-        outputLanguage: String = ""
+        outputLanguage: String = "",
+        dictationLanguage: String = ""
     ) async throws -> PostProcessingResult {
         var primaryModel = resolvedPrimaryModel()
         let retryModel = resolvedRetryModel(for: primaryModel)
@@ -330,7 +333,8 @@ Behavior:
                 model: primaryModel,
                 customVocabulary: customVocabulary,
                 customSystemPrompt: customSystemPrompt,
-                outputLanguage: outputLanguage
+                outputLanguage: outputLanguage,
+                dictationLanguage: dictationLanguage
             )
         } catch let error as PostProcessingError {
             // Unified fallback policy: decide whether to retry on the other model.
@@ -377,7 +381,8 @@ Behavior:
                     model: retryModel,
                     customVocabulary: customVocabulary,
                     customSystemPrompt: customSystemPrompt,
-                    outputLanguage: outputLanguage
+                    outputLanguage: outputLanguage,
+                    dictationLanguage: dictationLanguage
                 )
             } catch PostProcessingError.suspectedInstructionExecution {
                 return PostProcessingResult(
@@ -472,7 +477,8 @@ Behavior:
         model: String,
         customVocabulary: [String],
         customSystemPrompt: String = "",
-        outputLanguage: String = ""
+        outputLanguage: String = "",
+        dictationLanguage: String = ""
     ) async throws -> PostProcessingResult {
         var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
         request.httpMethod = "POST"
@@ -495,8 +501,11 @@ Use these spellings exactly in the output when relevant:
             ? Self.defaultSystemPrompt
             : customSystemPrompt
         let trimmedOutputLanguage = outputLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDictationLanguage = dictationLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedOutputLanguage.isEmpty {
             systemPrompt = Self.applyOutputLanguage(systemPrompt, language: trimmedOutputLanguage)
+        } else if !trimmedDictationLanguage.isEmpty {
+            systemPrompt = Self.applyDictationLanguage(systemPrompt, language: trimmedDictationLanguage)
         }
         if !vocabularyPrompt.isEmpty {
             systemPrompt += "\n\n" + vocabularyPrompt
@@ -739,6 +748,15 @@ Model: \(model)
 
     static func applyOutputLanguage(_ prompt: String, language: String) -> String {
         prompt + "\n\nIMPORTANT: Translate the final cleaned text into \(language). Output ONLY in \(language), regardless of the original spoken language."
+    }
+
+    /// Counterpart to `applyOutputLanguage` for when no output language is set: name
+    /// the language the user dictates in so cleanup keeps it. Every example in the
+    /// system prompt is English, and smaller models follow the examples over the
+    /// "Preserve the speaker's ... language" rule, returning English for non-English
+    /// dictation. Naming the language is what stops that; generic wording does not.
+    static func applyDictationLanguage(_ prompt: String, language: String) -> String {
+        prompt + "\n\nIMPORTANT: The dictation is in \(language). Output ONLY in \(language); never translate it into another language."
     }
 
     /// System prompt used for verbatim translation. Deliberately

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -755,8 +755,10 @@ Model: \(model)
     /// system prompt is English, and smaller models follow the examples over the
     /// "Preserve the speaker's ... language" rule, returning English for non-English
     /// dictation. Naming the language is what stops that; generic wording does not.
+    /// "Primarily" and the explicit carve-out keep this consistent with the prompt's
+    /// own "Preserve mixed-language text exactly as mixed" rule.
     static func applyDictationLanguage(_ prompt: String, language: String) -> String {
-        prompt + "\n\nIMPORTANT: The dictation is in \(language). Output ONLY in \(language); never translate it into another language."
+        prompt + "\n\nIMPORTANT: The dictation is primarily in \(language). Write the cleaned text in \(language). Preserve mixed-language words and spans in their original languages."
     }
 
     /// System prompt used for verbatim translation. Deliberately

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -80,8 +80,11 @@ struct AppContextServiceTests {
         let prompt = PostProcessingService.applyDictationLanguage("PROMPT", language: "Russian")
 
         expect(prompt.hasPrefix("PROMPT"), "Directive must be appended, not replace the prompt")
-        expect(prompt.contains("The dictation is in Russian"), "Language must be named explicitly")
-        expect(prompt.contains("Output ONLY in Russian"), "Output language must be named explicitly")
+        expect(prompt.contains("primarily in Russian"), "Language must be named explicitly")
+        expect(prompt.contains("Write the cleaned text in Russian"),
+               "Output language must be named explicitly")
+        expect(prompt.contains("Preserve mixed-language words and spans in their original languages"),
+               "Naming a language must not override mixed-language preservation")
     }
 
     private static func testDictationLanguageLeavesPromptBodyIntact() {

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -8,6 +8,8 @@ struct AppContextServiceTests {
         testNonStrippingModelPreservesExistingBehavior()
         testDeprecatedGroqModelsAreNotPredefined()
         testQwenCleanupDisablesReasoning()
+        testDictationLanguageIsNamedInPrompt()
+        testDictationLanguageLeavesPromptBodyIntact()
         print("AppContextServiceTests passed")
     }
 
@@ -72,6 +74,27 @@ struct AppContextServiceTests {
 
         expect(config.reasoningEffort == "none", "Qwen cleanup should disable reasoning")
         expect(config.includeReasoning == false, "Qwen cleanup should exclude reasoning output")
+    }
+
+    private static func testDictationLanguageIsNamedInPrompt() {
+        let prompt = PostProcessingService.applyDictationLanguage("PROMPT", language: "Russian")
+
+        expect(prompt.hasPrefix("PROMPT"), "Directive must be appended, not replace the prompt")
+        expect(prompt.contains("The dictation is in Russian"), "Language must be named explicitly")
+        expect(prompt.contains("Output ONLY in Russian"), "Output language must be named explicitly")
+    }
+
+    private static func testDictationLanguageLeavesPromptBodyIntact() {
+        // applyOutputLanguage asks for a translation, applyDictationLanguage asks for the
+        // opposite; neither may edit the prompt body, only append to it.
+        let body = PostProcessingService.defaultSystemPrompt
+        let translated = PostProcessingService.applyOutputLanguage(body, language: "German")
+        let preserved = PostProcessingService.applyDictationLanguage(body, language: "German")
+
+        expect(translated.hasPrefix(body), "applyOutputLanguage must only append")
+        expect(preserved.hasPrefix(body), "applyDictationLanguage must only append")
+        expect(!preserved.contains("Translate the final cleaned text"),
+               "Preserving a language must not ask for a translation")
     }
 
     private static func expectEqual(_ actual: String?, _ expected: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
The cleanup prompt says "No translation" and "Preserve the speaker's final intended meaning, tone, and language", but every example in it is written in English and models follow the examples over the rule. Dictating German at the default cleanup model comes back in English: "benenne user id in user unterstrich id um" returns as "rename user id to user_id". On smaller local models the whole transcript flips, greeting and all.

FreeFlow already knows the language being dictated — TranscriptionService sends it to the transcription API as the `language` field — and it already has the machinery for naming a language inside the cleanup prompt, in applyOutputLanguage. This adds the counterpart: when no output language is set, name the dictation language so cleanup preserves it instead of translating it.

Wording alone does not fix this, which is why the change rides the existing applyOutputLanguage shape rather than adding more prompt text. A generic rule ("write the output in the language of RAW_TRANSCRIPTION") had no measurable effect in three different placements, a clause scoped to the offending rule had none either, and adding a counterpart example in a different non-English language did not transfer to a third language. Naming the language explicitly is what works.

Auto-detect and English are skipped. There is nothing to name in the first case, and in the second the prompt's own examples are already English and English dictation never drifted in any measurement, so English-only users get a byte-identical request.

Measured at temperature 0 with 5 repeats, scoring the output language separately from the rule each case also exercises, because a model that cannot join "user underscore id" into "user_id" otherwise reads as a translation failure:

  openai/gpt-oss-20b (default cleanup model)
    German developer instruction   2/5 -> 4/5 kept in German
    Russian                        5/5 -> 5/5, never drifted
  meta-llama/llama-3.1-8b-instruct   (two runs pooled; see note)
    Russian greeting               3/10 -> 10/10
    Russian developer instruction   3/9 -> 9/9
    German developer instruction    4/5 -> 4/5, already mostly fine
  qwen/qwen3.6-27b (default fallback and context model)
    unaffected, 5/5 -> 5/5 on every case
  Qwen3-VL-8B-Instruct via a local OpenAI-compatible server
    Russian and German             0/3 -> 3/3

gpt-oss-20b improves rather than fully recovers on German, 4/5 instead of 5/5. The effect is largest on small models, which is also where the app's support for a custom base URL puts it.

llama-3.1-8b is pooled across two runs because it was inconsistent between them even at temperature 0 — the Russian greeting scored 3/5 in one run and 0/5 in the other before the change, and 5/5 in both after it. The direction was the same every time; the absolute baseline was not, so quoting a single run would overstate the precision.

Deliberately mixed-language dictation stays mixed: "надо добавить retry на flaky тесты и запустить с флагом дэш дэш fix" keeps retry, flaky and --fix, which the prompt requires and a language directive could plausibly have flattened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transcript post-processing to preserve the selected dictation language when no output language is specified.
  * Added language-specific instructions to cleanup processing for more accurate transcription results.

* **Bug Fixes**
  * Fixed transcript cleanup behavior so it no longer implicitly defaults to English when the dictation language differs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->