### PR TITLE
Give the EMPTY sentinel a concrete example in the cleanup prompt

### DIFF
--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -109,8 +109,9 @@ Developer syntax:
 Output hygiene:
 - Never prepend boilerplate such as "Here is the clean transcript".
 - If the transcript is empty or only filler, return exactly: EMPTY
+  - Filler-only means hesitation sounds and discourse particles with no content, in any language. Example: "um uh so yeah" -> EMPTY.
 """
-    static let defaultSystemPromptDate = "2026-05-13"
+    static let defaultSystemPromptDate = "2026-08-05"
     static let commandModeSystemPrompt = """
 You transform highlighted text according to a spoken editing command.
 


### PR DESCRIPTION
Filler-only dictation is supposed to produce nothing, but several supported models return the filler verbatim instead of the EMPTY sentinel, so FreeFlow types "ähm also ja" into the focused app. On the current default prompt, openai/gpt-oss-20b — the default cleanup model — returned EMPTY 0/8 times for German filler while getting English and Russian right 8/8, and openai/gpt-oss-safeguard-20b returned it 0/8 for German, 7/8 for English and 6/8 for Russian.

Add one concrete example to the existing rule instead of restating it. This mirrors the reasoning already recorded for "Instruction preservation is strict": models follow concrete examples far more reliably than abstract rules. The rule keeps its "in any language" wording, so the example does not narrow it to English.

With the example, gpt-oss-20b returns EMPTY 8/8 in German, English and Russian, and safeguard-20b goes to 6/8 German, 8/8 English, 8/8 Russian. A control set of ordinary sentences that merely start with a discourse particle ("so lets move the call to tomorrow", "also lass uns den termin verschieben") was never swallowed into EMPTY in any run.

Bump defaultSystemPromptDate so users with customized prompts see the "default has changed" indicator.

Measured through OpenRouter rather than against Groq directly, at temperature 0, using this prompt verbatim and the same request envelope PostProcessingService builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript cleanup guidance to better handle filler-only content, helping produce cleaner results.
  * Updated the default system prompt date to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->