### PR TITLE
Tap the hold shortcut twice to latch into toggle mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
 
 SOURCES = $(shell find Sources -name '*.swift' -type f | LC_ALL=C sort)
 TEST_RUNNER = $(BUILD_DIR)/FreeFlowTests
+SHORTCUT_TEST_RUNNER = $(BUILD_DIR)/FreeFlowShortcutTests
 RESOURCES = $(CONTENTS)/Resources
 ARCH ?= $(shell uname -m)
 
@@ -69,8 +70,9 @@ endif
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 
-test: $(TEST_RUNNER)
+test: $(TEST_RUNNER) $(SHORTCUT_TEST_RUNNER)
 	@$(TEST_RUNNER)
+	@$(SHORTCUT_TEST_RUNNER)
 
 $(TEST_RUNNER): Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Tests/AppContextServiceTests.swift
 	@mkdir -p "$(BUILD_DIR)"
@@ -80,6 +82,15 @@ $(TEST_RUNNER): Sources/AppContextService.swift Sources/LLMAPITransport.swift So
 		-sdk $(shell xcrun --show-sdk-path) \
 		-target $(ARCH)-apple-macosx13.0 \
 		Sources/AppContextService.swift Sources/LLMAPITransport.swift Sources/ModelConfiguration.swift Tests/AppContextServiceTests.swift
+
+$(SHORTCUT_TEST_RUNNER): Sources/ShortcutCore/DictationShortcutSessionController.swift Sources/ShortcutCore/ShortcutModels.swift Tests/DictationShortcutSessionControllerTests.swift
+	@mkdir -p "$(BUILD_DIR)"
+	swiftc \
+		-parse-as-library \
+		-o "$(SHORTCUT_TEST_RUNNER)" \
+		-sdk $(shell xcrun --show-sdk-path) \
+		-target $(ARCH)-apple-macosx13.0 \
+		Sources/ShortcutCore/DictationShortcutSessionController.swift Sources/ShortcutCore/ShortcutModels.swift Tests/DictationShortcutSessionControllerTests.swift
 
 icon: $(ICON_ICNS)
 

--- a/Sources/ShortcutCore/DictationShortcutSessionController.swift
+++ b/Sources/ShortcutCore/DictationShortcutSessionController.swift
@@ -7,8 +7,38 @@ enum DictationShortcutAction: Equatable {
 }
 
 final class DictationShortcutSessionController {
+    /// Tapping the hold shortcut twice in quick succession latches into toggle
+    /// mode, so a long dictation does not require holding the key down.
+    static let defaultDoubleTapWindow: TimeInterval = 0.4
+
+    var doubleTapLatchEnabled: Bool
+    var doubleTapWindow: TimeInterval
+
+    /// Injectable clock so the double-tap window is testable without sleeping.
+    private let now: () -> Date
+
     private(set) var activeMode: RecordingTriggerMode?
     private(set) var toggleStopArmed = false
+
+    /// When the hold shortcut was last released. Deliberately *not* cleared by
+    /// `reset()`: the gap that makes a double tap spans two sessions, and
+    /// `reset()` runs between them once the first tap's recording is committed.
+    private var lastHoldReleaseAt: Date?
+
+    /// True when toggle mode was entered by double-tapping the hold shortcut.
+    /// Such a session is also stopped by the hold shortcut, since that is the
+    /// only key the speaker touched.
+    private(set) var toggleEnteredFromHold = false
+
+    init(
+        doubleTapLatchEnabled: Bool = true,
+        doubleTapWindow: TimeInterval = DictationShortcutSessionController.defaultDoubleTapWindow,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.doubleTapLatchEnabled = doubleTapLatchEnabled
+        self.doubleTapWindow = doubleTapWindow
+        self.now = now
+    }
 
     func handle(event: ShortcutEvent, isTranscribing: Bool) -> DictationShortcutAction? {
         // Paste Again is handled before this controller runs; if it ever
@@ -16,10 +46,22 @@ final class DictationShortcutSessionController {
         if event == .copyAgainTriggered { return nil }
 
         if activeMode == nil {
+            // A double tap is allowed to latch even while the first tap's
+            // (near-empty) clip is still transcribing. Blocking it there would
+            // swallow the second tap and leave the speaker with nothing.
+            if event == .holdActivated, isDoubleTap() {
+                activeMode = .toggle
+                toggleEnteredFromHold = true
+                toggleStopArmed = false
+                lastHoldReleaseAt = nil
+                return .start(.toggle)
+            }
+
             guard !isTranscribing else { return nil }
             switch event {
             case .toggleActivated:
                 activeMode = .toggle
+                toggleEnteredFromHold = false
                 toggleStopArmed = false
                 return .start(.toggle)
             case .holdActivated:
@@ -40,10 +82,12 @@ final class DictationShortcutSessionController {
             switch event {
             case .toggleActivated:
                 activeMode = .toggle
+                toggleEnteredFromHold = false
                 toggleStopArmed = false
                 return .switchedToToggle
             case .holdDeactivated:
                 reset()
+                lastHoldReleaseAt = now()
                 return .stop
             case .holdActivated, .toggleDeactivated:
                 return nil
@@ -60,8 +104,16 @@ final class DictationShortcutSessionController {
                 guard toggleStopArmed else { return nil }
                 reset()
                 return .stop
-            case .holdActivated, .holdDeactivated:
+            case .holdDeactivated:
+                // Releasing the second tap must not end the session; it arms
+                // the next press to end it.
+                guard toggleEnteredFromHold else { return nil }
+                toggleStopArmed = true
                 return nil
+            case .holdActivated:
+                guard toggleEnteredFromHold, toggleStopArmed else { return nil }
+                reset()
+                return .stop
             case .copyAgainTriggered:
                 return nil
             }
@@ -70,16 +122,24 @@ final class DictationShortcutSessionController {
 
     func beginManual(mode: RecordingTriggerMode) {
         activeMode = mode
+        toggleEnteredFromHold = false
         toggleStopArmed = false
     }
 
     func forceToggleMode() {
         activeMode = .toggle
+        toggleEnteredFromHold = false
         toggleStopArmed = false
     }
 
     func reset() {
         activeMode = nil
+        toggleEnteredFromHold = false
         toggleStopArmed = false
+    }
+
+    private func isDoubleTap() -> Bool {
+        guard doubleTapLatchEnabled, let last = lastHoldReleaseAt else { return false }
+        return now().timeIntervalSince(last) <= doubleTapWindow
     }
 }

--- a/Tests/DictationShortcutSessionControllerTests.swift
+++ b/Tests/DictationShortcutSessionControllerTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+@main
+struct DictationShortcutSessionControllerTests {
+    static func main() {
+        testSingleHoldStillStartsAndStopsOnRelease()
+        testDoubleTapLatchesIntoToggle()
+        testDoubleTapLatchSurvivesTranscriptionOfTheFirstTap()
+        testLatchedSessionIsStoppedByTheNextTap()
+        testReleaseOfTheSecondTapDoesNotStop()
+        testSlowSecondTapIsAnOrdinaryHold()
+        testDoubleTapCanBeDisabled()
+        testToggleShortcutSessionIsUnaffectedByHoldEvents()
+        testHoldThenToggleStillSwitchesToToggle()
+        print("DictationShortcutSessionControllerTests passed")
+    }
+
+    // MARK: - Existing behaviour must not change
+
+    private static func testSingleHoldStillStartsAndStopsOnRelease() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .start(.hold))
+        clock.advance(1.0)
+        expectEqual(controller.handle(event: .holdDeactivated, isTranscribing: false), .stop)
+        expect(controller.activeMode == nil, "Session should be over after the key is released")
+    }
+
+    private static func testToggleShortcutSessionIsUnaffectedByHoldEvents() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        expectEqual(controller.handle(event: .toggleActivated, isTranscribing: false), .start(.toggle))
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), nil)
+        expectEqual(controller.handle(event: .holdDeactivated, isTranscribing: false), nil)
+        expect(controller.activeMode == .toggle, "A toggle session must ignore hold events")
+
+        expectEqual(controller.handle(event: .toggleDeactivated, isTranscribing: false), nil)
+        expectEqual(controller.handle(event: .toggleActivated, isTranscribing: false), .stop)
+    }
+
+    private static func testHoldThenToggleStillSwitchesToToggle() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .start(.hold))
+        expectEqual(controller.handle(event: .toggleActivated, isTranscribing: false), .switchedToToggle)
+        // Entered from the toggle shortcut, so the hold key must not end it.
+        expectEqual(controller.handle(event: .holdDeactivated, isTranscribing: false), nil)
+        expect(controller.activeMode == .toggle, "Latched session should still be running")
+    }
+
+    // MARK: - Double tap
+
+    private static func testDoubleTapLatchesIntoToggle() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .start(.hold))
+        clock.advance(0.09)
+        expectEqual(controller.handle(event: .holdDeactivated, isTranscribing: false), .stop)
+        clock.advance(0.15)
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .start(.toggle))
+        expect(controller.activeMode == .toggle, "The second tap should latch")
+    }
+
+    private static func testDoubleTapLatchSurvivesTranscriptionOfTheFirstTap() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        _ = controller.handle(event: .holdActivated, isTranscribing: false)
+        clock.advance(0.08)
+        _ = controller.handle(event: .holdDeactivated, isTranscribing: false)
+        // The first tap's near-empty clip is still in flight. The second tap
+        // must not be swallowed, or the speaker gets nothing at all.
+        clock.advance(0.12)
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: true), .start(.toggle))
+    }
+
+    private static func testLatchedSessionIsStoppedByTheNextTap() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        _ = controller.handle(event: .holdActivated, isTranscribing: false)
+        clock.advance(0.08)
+        _ = controller.handle(event: .holdDeactivated, isTranscribing: false)
+        clock.advance(0.12)
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .start(.toggle))
+
+        clock.advance(0.05)
+        expectEqual(controller.handle(event: .holdDeactivated, isTranscribing: false), nil)
+        clock.advance(12.0)
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .stop)
+        expect(controller.activeMode == nil, "The third tap should end the latched session")
+    }
+
+    private static func testReleaseOfTheSecondTapDoesNotStop() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        _ = controller.handle(event: .holdActivated, isTranscribing: false)
+        clock.advance(0.08)
+        _ = controller.handle(event: .holdDeactivated, isTranscribing: false)
+        clock.advance(0.12)
+        _ = controller.handle(event: .holdActivated, isTranscribing: false)
+
+        clock.advance(0.06)
+        expectEqual(controller.handle(event: .holdDeactivated, isTranscribing: false), nil)
+        expect(controller.activeMode == .toggle, "Letting go of the second tap must keep recording")
+    }
+
+    private static func testSlowSecondTapIsAnOrdinaryHold() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock)
+
+        _ = controller.handle(event: .holdActivated, isTranscribing: false)
+        clock.advance(0.5)
+        _ = controller.handle(event: .holdDeactivated, isTranscribing: false)
+        clock.advance(0.9)
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .start(.hold))
+        expect(controller.activeMode == .hold, "A slow second press is just another hold")
+    }
+
+    private static func testDoubleTapCanBeDisabled() {
+        let clock = TestClock()
+        let controller = makeController(clock: clock, enabled: false)
+
+        _ = controller.handle(event: .holdActivated, isTranscribing: false)
+        clock.advance(0.08)
+        _ = controller.handle(event: .holdDeactivated, isTranscribing: false)
+        clock.advance(0.12)
+        expectEqual(controller.handle(event: .holdActivated, isTranscribing: false), .start(.hold))
+    }
+
+    // MARK: - Helpers
+
+    private final class TestClock {
+        private var current = Date(timeIntervalSince1970: 1_000_000)
+        func advance(_ seconds: TimeInterval) { current = current.addingTimeInterval(seconds) }
+        func now() -> Date { current }
+    }
+
+    private static func makeController(clock: TestClock, enabled: Bool = true) -> DictationShortcutSessionController {
+        DictationShortcutSessionController(
+            doubleTapLatchEnabled: enabled,
+            doubleTapWindow: 0.4,
+            now: { clock.now() }
+        )
+    }
+
+    private static func expectEqual(
+        _ actual: DictationShortcutAction?,
+        _ expected: DictationShortcutAction?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            actual == expected,
+            "Expected \(String(describing: expected)), got \(String(describing: actual))",
+            file: file,
+            line: line
+        )
+    }
+
+    private static func expect(_ condition: Bool, _ message: String, file: StaticString = #file, line: UInt = #line) {
+        if !condition {
+            fatalError("\(file):\(line): \(message)")
+        }
+    }
+}


### PR DESCRIPTION
## Why

Holding a key down for a long dictation is uncomfortable, and the existing way to latch — press the extra modifier of the toggle shortcut while still holding the hold shortcut — is hard to discover. On a modifier-only hold key such as Fn it is also awkward to perform.

Two quick taps of the hold shortcut now start a latched (toggle) session instead of a second hold, so the whole gesture uses one key: **tap tap, speak, tap**.

## What changed

All of it is in `DictationShortcutSessionController`, so both the runtime path in `AppState` and the setup wizard's `SetupTestHotkeyHarness` get it without changes.

- The gap is measured between the **release** of the first tap and the **press** of the second. Default window 400 ms, exposed as `defaultDoubleTapWindow`, with an injectable clock so the window is testable without sleeping.
- `lastHoldReleaseAt` deliberately survives `reset()`. The gap spans two sessions and `reset()` runs between them when the first tap's clip is committed, so clearing it there would make the second tap unreachable.
- The latch is allowed **while the first tap's near-empty clip is still transcribing**. Without that exception the `isTranscribing` guard swallows the second tap and the speaker gets nothing at all. The stray clip is sub-100 ms and already lands in the existing empty-transcript path.
- A session latched this way is also **stopped by the hold shortcut**, since that is the only key the speaker touched. Releasing the second tap arms the stop; the next press ends it.
- Sessions entered through the toggle shortcut keep their existing behaviour exactly, including ignoring hold events.
- `doubleTapLatchEnabled` defaults to true and is a plain property, so gating it behind a setting later is a one-line change in `AppState`.

## Tests

New `Tests/DictationShortcutSessionControllerTests.swift`, wired into `make test` as a second runner. Nine cases: the double tap itself, the latch surviving the first tap's transcription, the third tap stopping, the second tap's release *not* stopping, a slow second tap staying an ordinary hold, and the disabled path — plus three that pin the current behaviour of plain hold, plain toggle, and hold-then-toggle so this cannot regress.

Built and tested on macOS 15 (Apple silicon).

## Note

Written for a user who dictates with Fn and found holding the key uncomfortable over long passages. Happy to put it behind a setting, change the default window, or rename anything to fit your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added double-tap latching for the dictation hold shortcut.
  - Users can switch from a hold gesture to toggle mode while dictation is active.
  - Hold-based toggle sessions now provide clearer release-and-activate controls for stopping dictation.

- **Bug Fixes**
  - Improved handling of overlapping transcription sessions, release actions, timing boundaries, and feature-disabled states.
  - Ensured shortcut state resets cleanly after sessions end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->