### PR TITLE
Distinguish lost transcription connections from offline state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ TEST_PRODUCTION_SOURCES = \
 	Sources/LLMAPITransport.swift \
 	Sources/LLMCooldownManager.swift \
 	Sources/ModelConfiguration.swift \
+	Sources/TranscriptionErrorPresentationCore.swift \
 	Sources/TranscriptTextCore.swift \
 	Sources/UpdateManager.swift \
 	Sources/ShortcutCore/DictationShortcutSessionController.swift \

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2309,55 +2309,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return "Failed to start recording: \(error.localizedDescription)"
     }
 
-    /// Turn a transcription failure into a concise, user-facing message,
-    /// classifying by the locale-independent `URLError.Code` rather than the
-    /// system's English description (which varies across releases and locales).
     private func formattedTranscriptionError(_ error: Error) -> String {
-        if let code = Self.urlErrorCode(in: error) {
-            switch code {
-            case .notConnectedToInternet, .networkConnectionLost,
-                 .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed:
-                return "No internet — check connection"
-            case .timedOut:
-                return NetworkMonitor.shared.isOnline
-                    ? "Request timed out — try again"
-                    : "No internet — check connection"
-            default:
-                break
-            }
-        }
-
-        let lower = error.localizedDescription.lowercased()
-        if lower.contains("timed out") || lower.contains("timeout") {
-            return NetworkMonitor.shared.isOnline
-                ? "Request timed out — try again"
-                : "No internet — check connection"
-        }
-        if lower.contains("offline") || lower.contains("internet connection")
-            || lower.contains("not connected") || lower.contains("network")
-            || lower.contains("cannot find host") {
-            return "No internet — check connection"
-        }
-        return error.localizedDescription
-    }
-
-    /// Find a `URLError.Code` anywhere in the error's underlying-error chain,
-    /// so a wrapped transport error is still classified by its root cause.
-    private static func urlErrorCode(in error: Error) -> URLError.Code? {
-        var current: Error? = error
-        var depth = 0
-        while let err = current, depth < 8 {
-            if let urlError = err as? URLError {
-                return urlError.code
-            }
-            let nsError = err as NSError
-            if nsError.domain == NSURLErrorDomain {
-                return URLError.Code(rawValue: nsError.code)
-            }
-            current = nsError.userInfo[NSUnderlyingErrorKey] as? Error
-            depth += 1
-        }
-        return nil
+        TranscriptionErrorPresentationCore.message(
+            for: error,
+            isOnline: NetworkMonitor.shared.isOnline
+        )
     }
 
     func showMicrophonePermissionAlert() {

--- a/Sources/TranscriptionErrorPresentationCore.swift
+++ b/Sources/TranscriptionErrorPresentationCore.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum TranscriptionErrorPresentationCore {
+    /// Classifies transcription failures by locale-independent error codes
+    /// before falling back to the system's localized description.
+    static func message(for error: Error, isOnline: Bool) -> String {
+        if let code = urlErrorCode(in: error) {
+            switch code {
+            case .networkConnectionLost:
+                return "Connection lost — retry or try another network"
+            case .notConnectedToInternet, .cannotConnectToHost,
+                 .cannotFindHost, .dnsLookupFailed:
+                return "No internet — check connection"
+            case .timedOut:
+                return isOnline
+                    ? "Request timed out — try again"
+                    : "No internet — check connection"
+            default:
+                break
+            }
+        }
+
+        let lower = error.localizedDescription.lowercased()
+        if lower.contains("timed out") || lower.contains("timeout") {
+            return isOnline
+                ? "Request timed out — try again"
+                : "No internet — check connection"
+        }
+        if lower.contains("offline") || lower.contains("internet connection")
+            || lower.contains("not connected") || lower.contains("network")
+            || lower.contains("cannot find host") {
+            return "No internet — check connection"
+        }
+        return error.localizedDescription
+    }
+
+    /// Finds a URL error in wrappers used by provider transports.
+    private static func urlErrorCode(in error: Error) -> URLError.Code? {
+        var current: Error? = error
+        var depth = 0
+        while let err = current, depth < 8 {
+            if let urlError = err as? URLError {
+                return urlError.code
+            }
+            let nsError = err as NSError
+            if nsError.domain == NSURLErrorDomain {
+                return URLError.Code(rawValue: nsError.code)
+            }
+            current = nsError.userInfo[NSUnderlyingErrorKey] as? Error
+            depth += 1
+        }
+        return nil
+    }
+}

--- a/Tests/TestMain.swift
+++ b/Tests/TestMain.swift
@@ -8,6 +8,7 @@ struct FreeFlowTests {
         ShortcutCoreTests.run()
         SemanticVersionTests.run()
         LLMCooldownManagerTests.run()
+        TranscriptionErrorPresentationCoreTests.run()
         TranscriptTextCoreTests.run()
         print("FreeFlowTests passed")
     }

--- a/Tests/TranscriptionErrorPresentationCoreTests.swift
+++ b/Tests/TranscriptionErrorPresentationCoreTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum TranscriptionErrorPresentationCoreTests {
+    static func run() {
+        testConnectionLostOffersRetryAndNetworkGuidance()
+        testOfflineFailuresRemainClassifiedAsNoInternet()
+    }
+
+    private static func testConnectionLostOffersRetryAndNetworkGuidance() {
+        TestSupport.expectEqual(
+            TranscriptionErrorPresentationCore.message(
+                for: URLError(.networkConnectionLost),
+                isOnline: true
+            ),
+            "Connection lost — retry or try another network"
+        )
+    }
+
+    private static func testOfflineFailuresRemainClassifiedAsNoInternet() {
+        let offlineCodes: [URLError.Code] = [
+            .notConnectedToInternet,
+            .cannotConnectToHost,
+            .cannotFindHost,
+            .dnsLookupFailed
+        ]
+
+        for code in offlineCodes {
+            TestSupport.expectEqual(
+                TranscriptionErrorPresentationCore.message(
+                    for: URLError(code),
+                    isOnline: true
+                ),
+                "No internet — check connection"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- show `URLError.networkConnectionLost` as "Connection lost — retry or try another network"
- keep true offline, host, DNS, and timeout classifications unchanged
- extract transcription error presentation into a dependency-free core with regression coverage

## Why

A connection can be lost mid-request while macOS still has a working network path. Classifying that failure as "No internet" sends users toward the wrong diagnosis, including for network paths where HTTP/3/QUIC fails while other traffic remains available.

Addresses #255.

This intentionally does not change provider transport or retry behavior; it makes the existing failure actionable and accurately distinct from offline errors.

## Verification

- [x] `make check`
- [x] `git diff --check`
- [x] Focused regression test added or updated, or no-test reason documented below
- [x] Manual app verification completed, if required

Manual verification performed:

Not required. The change is a pure error-presentation mapping covered with synthetic `URLError` fixtures; no live provider call or permission prompt was used.

## Risk and privacy

- [x] No real API keys, audio, transcripts, screenshots, selected text,
      clipboard contents, window titles, or private provider URLs are included
- [x] Data sent to providers is unchanged, or the change is explained below
- [x] Credential and Keychain behavior is unchanged, or explained below
- [x] macOS permissions and entitlements are unchanged, or explained below
- [x] Preferences and pipeline-history compatibility are unchanged, or
      explained below
- [x] Signing, notarization, updates, and GitHub workflows are unchanged, or
      explained below

Risk notes:

Low risk. The provider request, stored diagnostics, and network behavior are unchanged. Only the user-facing classification for URL error `-1005` changes. The rest of the existing formatter was moved unchanged into a small pure core so its behavior can be tested. Rollback is a single commit.

## Screenshots

Not included. This changes transient error copy and is covered by the focused regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription error messages for connection loss, unavailable internet, and timeouts.
  * Added more reliable handling of nested network errors to provide clearer retry guidance.

* **Tests**
  * Added coverage for offline and connection-related transcription error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->