### PR TITLE
Keep context screenshots within the active app

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -526,7 +526,9 @@ Selected text: \(selectedText ?? "None")
 
         let candidateWindows = windows.compactMap { windowInfo -> ScreenshotWindowCandidate? in
             guard let ownerPID = windowInfo[ownerPIDKey] as? Int else { return nil }
-            guard let isOnScreen = windowInfo[onScreenKey] as? Bool, isOnScreen else { return nil }
+            // The list is fetched with .optionOnScreenOnly, and kCGWindowIsOnscreen
+            // is an optional key, so a missing key still means onscreen.
+            if let isOnScreen = windowInfo[onScreenKey] as? Bool, !isOnScreen { return nil }
             guard let windowIDValue = windowInfo[windowIDKey] as? Int else { return nil }
             let layer = (windowInfo[layerKey] as? Int) ?? 0
             let bounds = boundsRect(windowInfo[boundsKey])

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -26,6 +26,14 @@ struct AppContext {
     }
 }
 
+struct ScreenshotWindowCandidate {
+    let id: Int
+    let processIdentifier: Int
+    let layer: Int
+    let bounds: CGRect?
+    let title: String?
+}
+
 final class AppContextService {
     static let defaultContextModel = "qwen/qwen3.6-27b"
     static let defaultContextPrompt = """
@@ -70,6 +78,77 @@ Return only two sentences, no labels, no markdown, no extra commentary.
     private func resolveContextPrompt() -> String {
         let trimmedPrompt = customContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedPrompt.isEmpty ? Self.defaultContextPrompt : trimmedPrompt
+    }
+
+    static func screenshotWindowID(
+        processIdentifier: Int,
+        focusedWindowBounds: CGRect?,
+        focusedWindowTitle: String?,
+        candidates: [ScreenshotWindowCandidate]
+    ) -> Int? {
+        let processCandidates = candidates.filter {
+            $0.processIdentifier == processIdentifier
+        }
+        guard !processCandidates.isEmpty else { return nil }
+
+        if let focusedWindowBounds, !focusedWindowBounds.isNull {
+            let overlappingCandidates = processCandidates.compactMap { candidate -> (ScreenshotWindowCandidate, CGFloat)? in
+                guard let candidateBounds = candidate.bounds else { return nil }
+                let intersection = candidateBounds.intersection(focusedWindowBounds)
+                guard !intersection.isNull else { return nil }
+                return (candidate, intersection.width * intersection.height)
+            }
+
+            if let focusedCandidate = overlappingCandidates.sorted(by: { lhs, rhs in
+                if lhs.0.layer == rhs.0.layer {
+                    if lhs.1 != rhs.1 {
+                        return lhs.1 > rhs.1
+                    }
+                    let lhsArea = (lhs.0.bounds?.width ?? 1) * (lhs.0.bounds?.height ?? 1)
+                    let rhsArea = (rhs.0.bounds?.width ?? 1) * (rhs.0.bounds?.height ?? 1)
+                    return lhsArea < rhsArea
+                }
+                return lhs.0.layer < rhs.0.layer
+            }).first?.0 {
+                return focusedCandidate.id
+            }
+        }
+
+        let normalizedFocusedTitle = focusedWindowTitle?
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let normalizedFocusedTitle, !normalizedFocusedTitle.isEmpty {
+            let titleMatches = processCandidates.filter { candidate in
+                guard let normalizedTitle = candidate.title?
+                    .lowercased()
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                      !normalizedTitle.isEmpty else {
+                    return false
+                }
+                return normalizedTitle == normalizedFocusedTitle
+                    || normalizedTitle.contains(normalizedFocusedTitle)
+            }
+
+            if let focusedCandidate = sortedScreenshotCandidates(titleMatches).first {
+                return focusedCandidate.id
+            }
+        }
+
+        return sortedScreenshotCandidates(processCandidates).first?.id
+    }
+
+    private static func sortedScreenshotCandidates(
+        _ candidates: [ScreenshotWindowCandidate]
+    ) -> [ScreenshotWindowCandidate] {
+        candidates.sorted { lhs, rhs in
+            if lhs.layer != rhs.layer {
+                return lhs.layer < rhs.layer
+            }
+
+            let lhsArea = (lhs.bounds?.width ?? 1) * (lhs.bounds?.height ?? 1)
+            let rhsArea = (rhs.bounds?.width ?? 1) * (rhs.bounds?.height ?? 1)
+            return lhsArea > rhsArea
+        }
     }
 
     func collectSelectionSnapshot() -> AppSelectionSnapshot {
@@ -445,120 +524,42 @@ Selected text: \(selectedText ?? "None")
         let boundsKey = kCGWindowBounds as String
         let nameKey = kCGWindowName as String
 
-        struct CandidateWindow {
-            let id: CGWindowID
-            let layer: Int
-            let area: Int
-            let bounds: CGRect?
-            let name: String?
-        }
-
-        let candidateWindows = windows.compactMap { windowInfo -> CandidateWindow? in
-            guard let ownerPID = windowInfo[ownerPIDKey] as? Int,
-                  ownerPID == processIdentifier else {
-                return nil
-            }
+        let candidateWindows = windows.compactMap { windowInfo -> ScreenshotWindowCandidate? in
+            guard let ownerPID = windowInfo[ownerPIDKey] as? Int else { return nil }
             guard let isOnScreen = windowInfo[onScreenKey] as? Bool, isOnScreen else { return nil }
             guard let windowIDValue = windowInfo[windowIDKey] as? Int else { return nil }
             let layer = (windowInfo[layerKey] as? Int) ?? 0
             let bounds = boundsRect(windowInfo[boundsKey])
-            let width = bounds?.width ?? 1
-            let height = bounds?.height ?? 1
-            let area = Int(width * height)
-            let name = trimmedText(windowInfo[nameKey] as? String)
 
-            return CandidateWindow(
-                id: CGWindowID(windowIDValue),
+            return ScreenshotWindowCandidate(
+                id: windowIDValue,
+                processIdentifier: ownerPID,
                 layer: layer,
-                area: area,
                 bounds: bounds,
-                name: name
+                title: trimmedText(windowInfo[nameKey] as? String)
             )
         }
 
-        if let focusedWindowBounds = focusedWindowBounds(from: appElement), !focusedWindowBounds.isNull {
-            if let activeWindow = candidateWindows
-                .compactMap({ candidate -> (CandidateWindow, CGFloat)? in
-                    guard let candidateBounds = candidate.bounds else { return nil }
-                    let intersection = candidateBounds.intersection(focusedWindowBounds)
-                    guard !intersection.isNull else { return nil }
-                    let overlap = intersection.width * intersection.height
-                    return (candidate, overlap)
-                })
-                .sorted(by: { lhs, rhs in
-                    if lhs.0.layer == rhs.0.layer {
-                        return lhs.1 > rhs.1
-                    }
-                    return lhs.0.layer < rhs.0.layer
-                })
-                    .first?.0 {
-                if let dataURL = captureWindowImage(
-                    windowID: activeWindow.id,
-                    fileType: .jpeg,
-                    mimeType: "image/jpeg",
-                    compression: screenshotCompressionPrimary,
-                    maxDimension: screenshotMaxDimension
-                ) {
-                    return (dataURL, "image/jpeg", nil)
-                }
-            }
-
-            if let focusedWindowTitle,
-               let activeWindow = candidateWindows
-                   .filter({ candidate in
-                       let normalizedName = candidate.name?
-                           .lowercased()
-                           .trimmingCharacters(in: .whitespacesAndNewlines)
-                       let normalizedTarget = focusedWindowTitle
-                           .lowercased()
-                           .trimmingCharacters(in: .whitespacesAndNewlines)
-                       guard let normalizedName, !normalizedName.isEmpty,
-                             !normalizedTarget.isEmpty else {
-                           return false
-                       }
-
-                       return normalizedName == normalizedTarget || normalizedName.contains(normalizedTarget)
-                   })
-                   .sorted(by: { lhs, rhs in
-                       if lhs.layer == rhs.layer {
-                           return lhs.area > rhs.area
-                       }
-                       return lhs.layer < rhs.layer
-                   })
-                   .first {
-                if let dataURL = captureWindowImage(
-                    windowID: activeWindow.id,
-                    fileType: .jpeg,
-                    mimeType: "image/jpeg",
-                    compression: screenshotCompressionPrimary,
-                    maxDimension: screenshotMaxDimension
-                ) {
-                    return (dataURL, "image/jpeg", nil)
-                }
-            }
-        }
-
-        guard let fullScreenImage = CGWindowListCreateImage(
-            CGRect.infinite,
-            .optionOnScreenOnly,
-            kCGNullWindowID,
-            [.bestResolution]
+        guard let windowID = Self.screenshotWindowID(
+            processIdentifier: Int(processIdentifier),
+            focusedWindowBounds: focusedWindowBounds(from: appElement),
+            focusedWindowTitle: focusedWindowTitle,
+            candidates: candidateWindows
         ) else {
-            return (nil, nil, "Could not capture screenshot from the active window")
+            return (nil, nil, "Could not find an on-screen window for the active application")
         }
 
-        if let croppedImage = croppedWhitespaceImage(from: fullScreenImage),
-           let dataURL = convertImageToDataURL(
-            croppedImage,
-            mimeType: "image/jpeg",
+        if let dataURL = captureWindowImage(
+            windowID: CGWindowID(windowID),
             fileType: .jpeg,
+            mimeType: "image/jpeg",
             compression: screenshotCompressionPrimary,
             maxDimension: screenshotMaxDimension
         ) {
             return (dataURL, "image/jpeg", nil)
         }
 
-        return (nil, nil, "Could not capture screenshot within size limits")
+        return (nil, nil, "Could not capture screenshot from the active window within size limits")
     }
 
     private func captureWindowImage(
@@ -661,74 +662,6 @@ Selected text: \(selectedText ?? "None")
         }
 
         return nil
-    }
-
-    private func croppedWhitespaceImage(from image: CGImage) -> CGImage? {
-        let width = image.width
-        let height = image.height
-        guard width > 0, height > 0 else { return nil }
-
-        let bytesPerPixel = 4
-        let bytesPerRow = width * bytesPerPixel
-        let byteCount = bytesPerRow * height
-        var pixelData = Array(repeating: UInt8(0), count: byteCount)
-
-        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
-              let context = CGContext(
-                data: &pixelData,
-                width: width,
-                height: height,
-                bitsPerComponent: 8,
-                bytesPerRow: bytesPerRow,
-                space: colorSpace,
-                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-              ) else {
-            return image
-        }
-
-        let drawRect = CGRect(origin: .zero, size: CGSize(width: width, height: height))
-        context.draw(image, in: drawRect)
-
-        let whiteThreshold: UInt8 = 245
-        let alphaThreshold: UInt8 = 5
-        var minX = width
-        var minY = height
-        var maxX: Int = -1
-        var maxY: Int = -1
-        var hasContent = false
-
-        for y in 0..<height {
-            let rowOffset = y * bytesPerRow
-            for x in 0..<width {
-                let offset = rowOffset + x * bytesPerPixel
-                let r = pixelData[offset]
-                let g = pixelData[offset + 1]
-                let b = pixelData[offset + 2]
-                let a = pixelData[offset + 3]
-
-                if a <= alphaThreshold { continue }
-                if r >= whiteThreshold && g >= whiteThreshold && b >= whiteThreshold {
-                    continue
-                }
-
-                hasContent = true
-                minX = min(minX, x)
-                minY = min(minY, y)
-                maxX = max(maxX, x)
-                maxY = max(maxY, y)
-            }
-        }
-
-        guard hasContent else { return image }
-
-        let cropRect = CGRect(
-            x: CGFloat(minX),
-            y: CGFloat(minY),
-            width: CGFloat(maxX - minX + 1),
-            height: CGFloat(maxY - minY + 1)
-        )
-
-        return image.cropping(to: cropRect) ?? image
     }
 
     private func resizedImage(for image: CGImage, maxDimension: CGFloat) -> CGImage? {

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -2,11 +2,119 @@ import Foundation
 
 enum AppContextServiceTests {
     static func run() {
+        testScreenshotFallbackRejectsWindowsFromOtherProcesses()
+        testScreenshotSelectionPrefersFocusedWindowBounds()
+        testScreenshotSelectionUsesFocusedWindowTitleWhenBoundsAreUnavailable()
+        testScreenshotFallbackUsesBestFrontmostProcessWindow()
         testQwenRawOutputIsSummarized()
         testQwenReasoningOutputIsStripped()
         testNonStrippingModelPreservesExistingBehavior()
         testDeprecatedGroqModelsAreNotPredefined()
         testQwenCleanupDisablesReasoning()
+    }
+
+    private static func testScreenshotFallbackRejectsWindowsFromOtherProcesses() {
+        let selectedWindowID = AppContextService.screenshotWindowID(
+            processIdentifier: 42,
+            focusedWindowBounds: nil,
+            focusedWindowTitle: nil,
+            candidates: [
+                ScreenshotWindowCandidate(
+                    id: 9001,
+                    processIdentifier: 84,
+                    layer: 0,
+                    bounds: CGRect(x: 0, y: 0, width: 1280, height: 720),
+                    title: "Synthetic unrelated window"
+                )
+            ]
+        )
+
+        TestSupport.expectEqual(selectedWindowID, nil)
+    }
+
+    private static func testScreenshotSelectionPrefersFocusedWindowBounds() {
+        let selectedWindowID = AppContextService.screenshotWindowID(
+            processIdentifier: 42,
+            focusedWindowBounds: CGRect(x: 500, y: 100, width: 400, height: 300),
+            focusedWindowTitle: nil,
+            candidates: [
+                ScreenshotWindowCandidate(
+                    id: 100,
+                    processIdentifier: 42,
+                    layer: 0,
+                    bounds: CGRect(x: 0, y: 0, width: 1600, height: 900),
+                    title: "Synthetic background window"
+                ),
+                ScreenshotWindowCandidate(
+                    id: 101,
+                    processIdentifier: 42,
+                    layer: 0,
+                    bounds: CGRect(x: 500, y: 100, width: 400, height: 300),
+                    title: "Synthetic focused window"
+                )
+            ]
+        )
+
+        TestSupport.expectEqual(selectedWindowID, 101)
+    }
+
+    private static func testScreenshotSelectionUsesFocusedWindowTitleWhenBoundsAreUnavailable() {
+        let selectedWindowID = AppContextService.screenshotWindowID(
+            processIdentifier: 42,
+            focusedWindowBounds: nil,
+            focusedWindowTitle: "Synthetic focused document",
+            candidates: [
+                ScreenshotWindowCandidate(
+                    id: 200,
+                    processIdentifier: 42,
+                    layer: 0,
+                    bounds: CGRect(x: 0, y: 0, width: 1400, height: 900),
+                    title: "Synthetic unrelated document"
+                ),
+                ScreenshotWindowCandidate(
+                    id: 201,
+                    processIdentifier: 42,
+                    layer: 0,
+                    bounds: CGRect(x: 100, y: 100, width: 800, height: 600),
+                    title: "Synthetic focused document — Edited"
+                )
+            ]
+        )
+
+        TestSupport.expectEqual(selectedWindowID, 201)
+    }
+
+    private static func testScreenshotFallbackUsesBestFrontmostProcessWindow() {
+        let selectedWindowID = AppContextService.screenshotWindowID(
+            processIdentifier: 42,
+            focusedWindowBounds: nil,
+            focusedWindowTitle: nil,
+            candidates: [
+                ScreenshotWindowCandidate(
+                    id: 300,
+                    processIdentifier: 42,
+                    layer: 1,
+                    bounds: CGRect(x: 0, y: 0, width: 1200, height: 800),
+                    title: nil
+                ),
+                ScreenshotWindowCandidate(
+                    id: 301,
+                    processIdentifier: 42,
+                    layer: 0,
+                    bounds: CGRect(x: 20, y: 20, width: 900, height: 700),
+                    title: nil
+                ),
+                ScreenshotWindowCandidate(
+                    id: 302,
+                    processIdentifier: 84,
+                    layer: 0,
+                    bounds: CGRect(x: 0, y: 0, width: 1600, height: 1000),
+                    title: nil
+                )
+            ]
+        )
+
+        TestSupport.expectEqual(selectedWindowID, 301)
     }
 
     private static func testQwenRawOutputIsSummarized() {


### PR DESCRIPTION
## Summary

- Extract deterministic active-window selection while preserving focused bounds and title matching.
- Constrain the fallback candidate to an on-screen window owned by the frontmost process.
- Return no screenshot when the frontmost process has no candidate instead of capturing all on-screen windows.
- Remove the obsolete full-screen whitespace-cropping path.

## Why

When focused-window matching failed, context capture used `CGWindowListCreateImage` with `CGRect.infinite` and all on-screen windows. That could include visible content from unrelated applications in the screenshot later attached to the context request. The fallback now stays inside the frontmost process boundary.

No linked issue.

## Verification

- [x] `make check`
- [x] `git diff --check`
- [x] Focused regression test added or updated, or no-test reason documented below
- [ ] Manual app verification completed, if required

Automated regression coverage:

- [x] Candidates from other processes are rejected.
- [x] Focused bounds matching is preserved.
- [x] Focused title matching works when Accessibility bounds are unavailable.
- [x] Fallback chooses an on-screen candidate from the frontmost process.

Manual verification performed:

Not run. This draft intentionally has not exercised Screen Recording or changed system permissions.

Before merge, test with invented/non-sensitive window content and Screen Recording already granted:

- [ ] With two unrelated apps visible, force focused-window bounds/title matching to miss and verify context capture contains only a window from the frontmost app.
- [ ] With multiple windows in one app, verify bounds matching captures the focused window.
- [ ] With Accessibility bounds unavailable but a matching title available, verify title matching captures the focused window.
- [ ] With no on-screen window owned by the frontmost process, verify context collection continues without a screenshot and reports the screenshot error.
- [ ] With Screen Recording denied, verify the existing permission guidance remains unchanged and no permission prompt is triggered by collection.

## Risk and privacy

- [x] No real API keys, audio, transcripts, screenshots, selected text,
      clipboard contents, window titles, or private provider URLs are included
- [x] Data sent to providers is unchanged, or the change is explained below
- [x] Credential and Keychain behavior is unchanged, or explained below
- [x] macOS permissions and entitlements are unchanged, or explained below
- [x] Preferences and pipeline-history compatibility are unchanged, or
      explained below
- [x] Signing, notarization, updates, and GitHub workflows are unchanged, or
      explained below

Risk notes:

High-risk area: Screen Recording and screenshot transmission to the configured context provider.

This change narrows existing capture behavior. It adds no permissions, persistence, logging, telemetry, provider calls, or new data transmission. Window metadata is evaluated locally, and only a single window ID owned by the frontmost process can reach image capture. If no such window exists, no screenshot is produced. A same-process fallback can still select another window belonging to the active app when focused-window metadata is unavailable; the tests enforce that it cannot cross the process boundary.

The screenshot payload shape and provider request path are unchanged, but fallback payload content is deliberately narrowed from all visible applications to one window owned by the active process. There is no preferences, pipeline-history, migration, signing, release, or workflow impact.

Rollback is a revert of this commit, which would restore the prior full-screen fallback; because that fallback can capture unrelated apps, rollback should be reserved for a confirmed active-window regression.

## Screenshots

Not applicable; there are no UI changes, and no real screenshots were captured or added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved active-window screenshot selection to prioritize the focused window and matching window title.
  - Prevented screenshots from capturing windows belonging to other applications.
  - Added more reliable fallback selection for frontmost windows when focused-window details are unavailable.
  - Improved handling of windows missing visibility information.
  - When no suitable window can be identified, screenshot capture now reports an error instead of capturing the full screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->