### PR TITLE
Bound realtime finalization before file fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ TEST_PRODUCTION_SOURCES = \
 	Sources/LLMAPITransport.swift \
 	Sources/LLMCooldownManager.swift \
 	Sources/ModelConfiguration.swift \
+	Sources/RealtimeFinalizationAwaiter.swift \
 	Sources/TranscriptTextCore.swift \
 	Sources/UpdateManager.swift \
 	Sources/ShortcutCore/DictationShortcutSessionController.swift \

--- a/Sources/RealtimeFinalizationAwaiter.swift
+++ b/Sources/RealtimeFinalizationAwaiter.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+enum RealtimeFinalizationError: LocalizedError, Equatable {
+    case timedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .timedOut:
+            return "Realtime transcription timed out while waiting for the final transcript"
+        }
+    }
+}
+
+final class RealtimeFinalizationAwaiter {
+    private let timeoutNanoseconds: UInt64
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<String, Error>?
+    private var completedResult: Result<String, Error>?
+    private var deadlineTask: Task<Void, Never>?
+
+    init(timeoutNanoseconds: UInt64) {
+        self.timeoutNanoseconds = timeoutNanoseconds
+    }
+
+    func wait() async throws -> String {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                var immediateResult: Result<String, Error>?
+
+                lock.lock()
+                if let completedResult {
+                    immediateResult = completedResult
+                } else {
+                    self.continuation = continuation
+                    deadlineTask = Task { [weak self] in
+                        do {
+                            try await Task.sleep(nanoseconds: self?.timeoutNanoseconds ?? 0)
+                        } catch {
+                            return
+                        }
+                        self?.resolve(.failure(RealtimeFinalizationError.timedOut))
+                    }
+                }
+                lock.unlock()
+
+                if let immediateResult {
+                    continuation.resume(with: immediateResult)
+                }
+            }
+        } onCancel: {
+            resolve(.failure(CancellationError()))
+        }
+    }
+
+    func resolve(_ result: Result<String, Error>) {
+        let pendingContinuation: CheckedContinuation<String, Error>?
+        let pendingDeadline: Task<Void, Never>?
+
+        lock.lock()
+        guard completedResult == nil else {
+            lock.unlock()
+            return
+        }
+        completedResult = result
+        pendingContinuation = continuation
+        continuation = nil
+        pendingDeadline = deadlineTask
+        deadlineTask = nil
+        lock.unlock()
+
+        pendingDeadline?.cancel()
+        pendingContinuation?.resume(with: result)
+    }
+}

--- a/Sources/RealtimeTranscriptionService.swift
+++ b/Sources/RealtimeTranscriptionService.swift
@@ -29,13 +29,14 @@ final class RealtimeTranscriptionService {
 
     private let config: Configuration
     private let session: URLSession
+    private let finalizationTimeoutNanoseconds: UInt64
     private var task: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?
 
     private let stateQueue = DispatchQueue(label: "com.zachlatta.freeflow.realtime.state")
     private var finalText: String = ""
     private var partialText: String = ""
-    private var finalContinuation: CheckedContinuation<String, Error>?
+    private var finalAwaiter: RealtimeFinalizationAwaiter?
     private var commitSent: Bool = false
     private var closed: Bool = false
     private var terminalError: Error?
@@ -49,9 +50,14 @@ final class RealtimeTranscriptionService {
     /// events — useful for a live overlay readout.
     var onPartialUpdate: ((String) -> Void)?
 
-    init(config: Configuration, session: URLSession = .shared) {
+    init(
+        config: Configuration,
+        session: URLSession = .shared,
+        finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000
+    ) {
         self.config = config
         self.session = session
+        self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
     }
 
     // MARK: Lifecycle
@@ -85,19 +91,19 @@ final class RealtimeTranscriptionService {
 
     /// Cancel the socket and any in-flight receive. Safe to call multiple times.
     func cancel() {
-        let currentTask: URLSessionWebSocketTask? = stateQueue.sync {
+        let (currentTask, pendingAwaiter): (
+            URLSessionWebSocketTask?,
+            RealtimeFinalizationAwaiter?
+        ) = stateQueue.sync {
             let currentTask = task
             task = nil
-            return currentTask
-        }
-        stateQueue.sync {
-            guard !closed else { return }
+            guard !closed else { return (currentTask, nil) }
             closed = true
-            if let cont = finalContinuation {
-                finalContinuation = nil
-                cont.resume(throwing: CancellationError())
-            }
+            let pendingAwaiter = finalAwaiter
+            finalAwaiter = nil
+            return (currentTask, pendingAwaiter)
         }
+        pendingAwaiter?.resolve(.failure(CancellationError()))
         receiveTask?.cancel()
         currentTask?.cancel(with: .normalClosure, reason: nil)
     }
@@ -139,28 +145,51 @@ final class RealtimeTranscriptionService {
             send(["type": "input_audio_buffer.commit"], over: currentTask)
         }
 
-        return try await withCheckedThrowingContinuation { continuation in
-            var immediateResult: Result<String, Error>?
+        let awaiter = RealtimeFinalizationAwaiter(
+            timeoutNanoseconds: finalizationTimeoutNanoseconds
+        )
+        var immediateResult: Result<String, Error>?
+        stateQueue.sync {
+            if let terminalError {
+                immediateResult = .failure(terminalError)
+                return
+            }
+            if closed {
+                immediateResult = .failure(RealtimeTranscriptionError.closedBeforeFinal)
+                return
+            }
+            if let finalText = readyCommittedTranscriptLocked() {
+                closed = true
+                immediateResult = .success(finalText)
+                return
+            }
+            finalAwaiter = awaiter
+        }
+        if let immediateResult {
+            currentTask.cancel(with: .normalClosure, reason: nil)
+            return try immediateResult.get()
+        }
+
+        do {
+            return try await awaiter.wait()
+        } catch {
+            let shouldCancelSocket = error is RealtimeFinalizationError || error is CancellationError
             stateQueue.sync {
-                if let terminalError {
-                    immediateResult = .failure(terminalError)
-                    return
+                if finalAwaiter === awaiter {
+                    finalAwaiter = nil
                 }
-                if closed {
-                    immediateResult = .failure(RealtimeTranscriptionError.closedBeforeFinal)
-                    return
-                }
-                if let finalText = readyCommittedTranscriptLocked() {
+                if shouldCancelSocket {
                     closed = true
-                    immediateResult = .success(finalText)
-                    return
+                    task = nil
+                    if error is RealtimeFinalizationError {
+                        terminalError = error
+                    }
                 }
-                finalContinuation = continuation
             }
-            if let immediateResult {
+            if shouldCancelSocket {
                 currentTask.cancel(with: .normalClosure, reason: nil)
-                continuation.resume(with: immediateResult)
             }
+            throw error
         }
     }
 
@@ -193,16 +222,17 @@ final class RealtimeTranscriptionService {
     }
 
     private func finishWithClose() {
-        stateQueue.sync {
+        let pendingResult: (RealtimeFinalizationAwaiter, Result<String, Error>)? = stateQueue.sync {
             closed = true
-            if let cont = finalContinuation {
-                finalContinuation = nil
-                if postCommitCompleted {
-                    cont.resume(returning: finalText)
-                } else {
-                    cont.resume(throwing: RealtimeTranscriptionError.closedBeforeFinal)
-                }
+            guard let finalAwaiter else { return nil }
+            self.finalAwaiter = nil
+            if postCommitCompleted {
+                return (finalAwaiter, .success(finalText))
             }
+            return (finalAwaiter, .failure(RealtimeTranscriptionError.closedBeforeFinal))
+        }
+        if let (awaiter, result) = pendingResult {
+            awaiter.resolve(result)
         }
     }
 
@@ -257,14 +287,14 @@ final class RealtimeTranscriptionService {
             let message = errObj?["message"] as? String ?? "unknown realtime error"
             os_log(.error, log: realtimeLog, "server error [%{public}@]: %{public}@", code, message)
             let error = RealtimeTranscriptionError.serverError(code: code, message: message)
-            stateQueue.sync {
+            let pendingAwaiter: RealtimeFinalizationAwaiter? = stateQueue.sync {
                 terminalError = error
                 closed = true
-                if let cont = finalContinuation {
-                    finalContinuation = nil
-                    cont.resume(throwing: error)
-                }
+                let pendingAwaiter = finalAwaiter
+                finalAwaiter = nil
+                return pendingAwaiter
             }
+            pendingAwaiter?.resolve(.failure(error))
         default:
             resumeIfReadyAfterCommit()
             break
@@ -381,22 +411,22 @@ final class RealtimeTranscriptionService {
     }
 
     private func resumeIfReadyAfterCommit() {
-        var pendingResume: (CheckedContinuation<String, Error>, String)?
+        var pendingResume: (RealtimeFinalizationAwaiter, String)?
         stateQueue.sync {
-            guard let cont = finalContinuation,
+            guard let finalAwaiter,
                   let finalText = readyCommittedTranscriptLocked() else {
                 return
             }
-            finalContinuation = nil
+            self.finalAwaiter = nil
             closed = true
-            pendingResume = (cont, finalText)
+            pendingResume = (finalAwaiter, finalText)
         }
-        if let (cont, text) = pendingResume {
+        if let (awaiter, text) = pendingResume {
             let currentTask: URLSessionWebSocketTask? = stateQueue.sync {
                 task
             }
             currentTask?.cancel(with: .normalClosure, reason: nil)
-            cont.resume(returning: text)
+            awaiter.resolve(.success(text))
         }
     }
 

--- a/Tests/RealtimeFinalizationAwaiterTests.swift
+++ b/Tests/RealtimeFinalizationAwaiterTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum RealtimeFinalizationAwaiterTests {
+    static func run() {
+        let finished = DispatchSemaphore(value: 0)
+        Task {
+            await testWaitTimesOutWhenNoFinalResultArrives()
+            await testResolvedResultWinsBeforeDeadline()
+            await testCancellationRemainsCancellation()
+            finished.signal()
+        }
+        finished.wait()
+    }
+
+    private static func testWaitTimesOutWhenNoFinalResultArrives() async {
+        let awaiter = RealtimeFinalizationAwaiter(timeoutNanoseconds: 1_000_000)
+
+        do {
+            _ = try await awaiter.wait()
+            TestSupport.expect(false, "Expected an idle finalization wait to time out")
+        } catch let error as RealtimeFinalizationError {
+            TestSupport.expectEqual(error, .timedOut)
+        } catch {
+            TestSupport.expect(false, "Expected a realtime finalization timeout, got \(error)")
+        }
+    }
+
+    private static func testResolvedResultWinsBeforeDeadline() async {
+        let awaiter = RealtimeFinalizationAwaiter(timeoutNanoseconds: 100_000_000)
+        Task {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            awaiter.resolve(.success("synthetic final transcript"))
+        }
+
+        do {
+            let result = try await awaiter.wait()
+            TestSupport.expectEqual(result, "synthetic final transcript")
+            try? await Task.sleep(nanoseconds: 120_000_000)
+        } catch {
+            TestSupport.expect(false, "Expected the resolved transcript, got \(error)")
+        }
+    }
+
+    private static func testCancellationRemainsCancellation() async {
+        let awaiter = RealtimeFinalizationAwaiter(timeoutNanoseconds: 1_000_000_000)
+        let waitTask = Task {
+            try await awaiter.wait()
+        }
+        waitTask.cancel()
+
+        do {
+            _ = try await waitTask.value
+            TestSupport.expect(false, "Expected the cancelled wait to throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            TestSupport.expect(false, "Expected CancellationError, got \(error)")
+        }
+    }
+}

--- a/Tests/TestMain.swift
+++ b/Tests/TestMain.swift
@@ -8,6 +8,7 @@ struct FreeFlowTests {
         ShortcutCoreTests.run()
         SemanticVersionTests.run()
         LLMCooldownManagerTests.run()
+        RealtimeFinalizationAwaiterTests.run()
         TranscriptTextCoreTests.run()
         print("FreeFlowTests passed")
     }


### PR DESCRIPTION
## Summary

- Bound realtime transcript finalization to 10 seconds after commit.
- Throw a distinct timeout error so AppState's existing file-transcription fallback can continue the pipeline.
- Coordinate success, timeout, socket failure, and cancellation through a one-shot awaiter so racing terminal events cannot resume a continuation twice.

## Why

A realtime WebSocket can remain open without sending a final transcription event. In that state, `commitAndAwaitFinal()` previously waited forever, so the existing file-transcription fallback never ran and dictation never completed.

## Verification

- [x] `make check`
- [x] `git diff --check`
- [x] Focused regression test added or updated, or no-test reason documented below
- [ ] Manual app verification completed, if required

Manual verification performed:

Not run. Realtime provider verification is pending before merge because it requires live provider credentials and microphone input. The draft should be exercised with:

1. A normal realtime dictation that receives a final event and does not invoke file fallback.
2. A test endpoint that keeps the WebSocket open without a final event, confirming file transcription starts after 10 seconds and returns the transcript.
3. Cancellation during finalization, confirming it remains cancellation and does not invoke file fallback.

## Risk and privacy

- [x] No real API keys, audio, transcripts, screenshots, selected text,
      clipboard contents, window titles, or private provider URLs are included
- [x] Data sent to providers is unchanged, or the change is explained below
- [x] Credential and Keychain behavior is unchanged, or explained below
- [x] macOS permissions and entitlements are unchanged, or explained below
- [x] Preferences and pipeline-history compatibility are unchanged, or
      explained below
- [x] Signing, notarization, updates, and GitHub workflows are unchanged, or
      explained below

Risk notes:

This changes the realtime provider request lifecycle. Request payloads and provider selection are unchanged. If finalization times out, the realtime socket is cancelled and the existing fallback may send the already-recorded audio to the configured file-transcription endpoint. No new content is logged, persisted, or transmitted, and no telemetry is added. The timeout is internal and introduces no migration. Rollback is a revert of this PR.

## Screenshots

Not required; there are no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable finalization timeout support for realtime transcription, defaulting to 10 seconds.
  - Added clear handling for successful results, cancellation, and timed-out finalization attempts.

- **Bug Fixes**
  - Realtime transcription sessions now close cleanly when finalization times out or is cancelled.
  - Timeout failures are recorded as terminal errors, providing more reliable session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->