### PR TITLE
Let macOS Globe actions work when hold-to-talk is Fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATC
 - `MINOR` changes add user-visible features and improvements.
 - `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
 
+## [Unreleased]
+
+### Fixed
+
+- Fn/Globe hold-to-talk no longer swallows the Fn key: Fn events pass through
+  to macOS, so the system Globe action (e.g. "Press globe to: Change Input
+  Source") works on quick taps while sustained holds still drive dictation.
+  Hold-to-talk on Fn also gains a 200 ms minimum hold time so brief taps
+  don't start a recording. Toggle bindings on Fn are unchanged.
+
 ## [1.2.1] - 2026-08-11
 
 ### Improved

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1849,6 +1849,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Minimum hold time before an Fn/Globe hold-to-talk press starts
+    /// dictation. Fn events pass through to macOS (see ShortcutMatcher), so a
+    /// quick tap can perform the system Globe action (e.g. Change Input
+    /// Source). A short floor keeps brief taps from also starting a recording
+    /// on key-down; releasing before the floor cancels the pending start.
+    private static let minimumFnHoldStartDelay: TimeInterval = 0.2
+
+    private func effectiveShortcutStartDelay(for mode: RecordingTriggerMode) -> TimeInterval {
+        guard mode == .hold, activeShortcutConfiguration.hold.usesFnKey else {
+            return shortcutStartDelay
+        }
+        return max(shortcutStartDelay, Self.minimumFnHoldStartDelay)
+    }
+
     private func scheduleShortcutStart(mode: RecordingTriggerMode) {
         cancelPendingShortcutStart(resetMode: false)
         pendingSelectionSnapshot = contextService.collectSelectionSnapshot()
@@ -1856,7 +1870,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             commandModeManualModifier.shortcutModifier
         )
         pendingShortcutStartMode = mode
-        let delay = shortcutStartDelay
+        let delay = effectiveShortcutStartDelay(for: mode)
 
         guard delay > 0 else {
             pendingShortcutStartMode = nil

--- a/Sources/ModifierKeyEventState.swift
+++ b/Sources/ModifierKeyEventState.swift
@@ -29,7 +29,9 @@ enum ModifierKeyEventState {
         }
     }
 
-    static let fnKeyCode: UInt16 = 63
+    // Single source of truth lives on ShortcutBinding so event production
+    // and shortcut matching cannot diverge.
+    static let fnKeyCode = ShortcutBinding.fnKeyCode
 
     /// Reads the current system-wide Fn state. Useful for seeding a backend's
     /// tracked Fn state at start or after a tap reset, since flagsChanged events

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -84,10 +84,23 @@ enum ShortcutMatcher {
             nextState.pressedModifierKeyCodes = pressedModifierKeyCodes
 
             let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+
+            // GlobalShortcutBackend attaches this decision to the ordinary
+            // key event that carried the snapshot. If the snapshot merely
+            // repairs a missed Fn state (e.g. after the event tap was
+            // re-enabled), flipping Fn hold state must not swallow that key;
+            // macOS still needs unobstructed Fn handling for Globe actions.
+            // Toggle and non-Fn hold transitions keep consuming as before.
+            let onlyFnHoldTransitions =
+                configuration.hold.usesFnKey
+                && emittedEvents.allSatisfy { $0 == .holdActivated || $0 == .holdDeactivated }
+            let consumeDecision: ShortcutConsumeDecision =
+                emittedEvents.isEmpty || onlyFnHoldTransitions ? .passthrough : .consume
+
             return ShortcutMatchResult(
                 state: nextState,
                 emittedEvents: emittedEvents,
-                consumeDecision: emittedEvents.isEmpty ? .passthrough : .consume
+                consumeDecision: consumeDecision
             )
 
         case .modifierChanged(let keyCode, let isDown):

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -91,10 +91,24 @@ enum ShortcutMatcher {
             )
 
         case .modifierChanged(let keyCode, let isDown):
+            // Fn/Globe is the only modifier with a system-level tap action
+            // (e.g. "Press globe to: Change Input Source"). If a hold-to-talk
+            // binding consumes Fn events, macOS never sees the key at all and
+            // the Globe action can never fire, even for quick taps. macOS
+            // itself ignores long Fn holds, so hold bindings can safely
+            // observe Fn passively: quick taps reach the system Globe action,
+            // sustained holds still drive hold-to-talk. Toggle bindings keep
+            // consuming because a Fn tap is meaningful on both sides and the
+            // user chose Fn for it.
+            let consumeConfiguration =
+                keyCode == ShortcutBinding.fnKeyCode
+                ? configuration.withHoldBindingDisabled
+                : configuration
+
             let shouldConsumeBefore = shouldConsumeModifierEvent(
                 for: keyCode,
                 state: state,
-                configuration: configuration
+                configuration: consumeConfiguration
             )
 
             var nextState = state
@@ -107,7 +121,7 @@ enum ShortcutMatcher {
             let shouldConsumeAfter = shouldConsumeModifierEvent(
                 for: keyCode,
                 state: nextState,
-                configuration: configuration
+                configuration: consumeConfiguration
             )
             let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
             return ShortcutMatchResult(

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -93,6 +93,20 @@ struct ShortcutConfiguration: Equatable {
     }
 
     static let disabled = ShortcutConfiguration(hold: .disabled, toggle: .disabled, copyAgain: .disabled)
+
+    /// A copy of this configuration with the hold binding disabled. Used when
+    /// deciding whether Fn/Globe events may be consumed: hold-to-talk must not
+    /// consume Fn, otherwise macOS never sees the key and the system Globe
+    /// action (e.g. "Press globe to: Change Input Source") can never fire.
+    /// See `ShortcutMatcher.reduce` for the call site.
+    var withHoldBindingDisabled: ShortcutConfiguration {
+        ShortcutConfiguration(
+            hold: .disabled,
+            toggle: toggle,
+            copyAgain: copyAgain,
+            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+        )
+    }
 }
 
 enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
@@ -193,9 +207,11 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         modifierDisplayNames.count
     }
 
+    static let fnKeyCode: UInt16 = 63
+
     var usesFnKey: Bool {
         guard !isDisabled else { return false }
-        return keyCode == 63 || modifiers.contains(.function)
+        return keyCode == Self.fnKeyCode || modifiers.contains(.function)
     }
 
     var requiresExactModifierMatch: Bool {

--- a/Tests/ShortcutCoreTests.swift
+++ b/Tests/ShortcutCoreTests.swift
@@ -74,17 +74,22 @@ enum ShortcutCoreTests {
         TestSupport.expectEqual(fnDown.emittedEvents, [.holdActivated])
         TestSupport.expectEqual(fnDown.consumeDecision, .passthrough)
 
-        // With Cmd held, the Cmd+Fn toggle activates and Fn is consumed.
+        // With Cmd held, the Fn-down event activates the Cmd+Fn toggle and
+        // Fn is consumed. Cmd down alone activates nothing and passes through.
         let cmdDown = ShortcutMatcher.reduce(
             state: ShortcutInputState(),
             event: .modifierChanged(keyCode: 55, isDown: true),
             configuration: configuration
         )
+        TestSupport.expectEqual(cmdDown.emittedEvents, [])
+        TestSupport.expectEqual(cmdDown.consumeDecision, .passthrough)
+
         let fnDownWithCmd = ShortcutMatcher.reduce(
             state: cmdDown.state,
             event: .modifierChanged(keyCode: 63, isDown: true),
             configuration: configuration
         )
+        TestSupport.expectEqual(fnDownWithCmd.emittedEvents, [.toggleActivated, .holdActivated])
         TestSupport.expectEqual(fnDownWithCmd.consumeDecision, .consume)
     }
 

--- a/Tests/ShortcutCoreTests.swift
+++ b/Tests/ShortcutCoreTests.swift
@@ -3,6 +3,8 @@ import Foundation
 enum ShortcutCoreTests {
     static func run() {
         testBareFnHoldLifecycle()
+        testBareFnToggleStillConsumes()
+        testFnHoldPassthroughUnlessToggleComboActive()
         testDefaultShortcutSpecificityOrdering()
         testRightOptionPresetIsSideSpecific()
         testExactModifierMatching()
@@ -31,9 +33,58 @@ enum ShortcutCoreTests {
         )
 
         TestSupport.expectEqual(down.emittedEvents, [.holdActivated])
-        TestSupport.expectEqual(down.consumeDecision, .consume)
+        // Fn hold-to-talk must not consume the key: macOS needs to see Fn
+        // events for the system Globe action (e.g. Change Input Source).
+        TestSupport.expectEqual(down.consumeDecision, .passthrough)
         TestSupport.expectEqual(up.emittedEvents, [.holdDeactivated])
-        TestSupport.expectEqual(up.consumeDecision, .consume)
+        TestSupport.expectEqual(up.consumeDecision, .passthrough)
+    }
+
+    private static func testBareFnToggleStillConsumes() {
+        let configuration = ShortcutConfiguration(
+            hold: .disabled,
+            toggle: ShortcutPreset.fnKey.binding
+        )
+        let down = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierChanged(keyCode: 63, isDown: true),
+            configuration: configuration
+        )
+
+        // A Fn tap is meaningful to both FreeFlow (toggle dictation) and
+        // macOS (Globe action); the user chose Fn for the toggle binding, so
+        // FreeFlow keeps consuming it.
+        TestSupport.expectEqual(down.emittedEvents, [.toggleActivated])
+        TestSupport.expectEqual(down.consumeDecision, .consume)
+    }
+
+    private static func testFnHoldPassthroughUnlessToggleComboActive() {
+        let configuration = ShortcutConfiguration(
+            hold: .defaultHold,
+            toggle: .defaultToggle
+        )
+        // Bare Fn: hold binding is excluded from consume decisions, and the
+        // Cmd+Fn toggle is not active without Cmd, so the tap passes through.
+        let fnDown = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierChanged(keyCode: 63, isDown: true),
+            configuration: configuration
+        )
+        TestSupport.expectEqual(fnDown.emittedEvents, [.holdActivated])
+        TestSupport.expectEqual(fnDown.consumeDecision, .passthrough)
+
+        // With Cmd held, the Cmd+Fn toggle activates and Fn is consumed.
+        let cmdDown = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierChanged(keyCode: 55, isDown: true),
+            configuration: configuration
+        )
+        let fnDownWithCmd = ShortcutMatcher.reduce(
+            state: cmdDown.state,
+            event: .modifierChanged(keyCode: 63, isDown: true),
+            configuration: configuration
+        )
+        TestSupport.expectEqual(fnDownWithCmd.consumeDecision, .consume)
     }
 
     private static func testDefaultShortcutSpecificityOrdering() {

--- a/Tests/ShortcutCoreTests.swift
+++ b/Tests/ShortcutCoreTests.swift
@@ -5,6 +5,7 @@ enum ShortcutCoreTests {
         testBareFnHoldLifecycle()
         testBareFnToggleStillConsumes()
         testFnHoldPassthroughUnlessToggleComboActive()
+        testSnapshotRepairFnHoldDoesNotConsume()
         testDefaultShortcutSpecificityOrdering()
         testRightOptionPresetIsSideSpecific()
         testExactModifierMatching()
@@ -85,6 +86,33 @@ enum ShortcutCoreTests {
             configuration: configuration
         )
         TestSupport.expectEqual(fnDownWithCmd.consumeDecision, .consume)
+    }
+
+    private static func testSnapshotRepairFnHoldDoesNotConsume() {
+        // A snapshot that suddenly reports Fn as pressed (e.g. the event tap
+        // missed the Fn flagsChanged while disabled) repairs hold state; the
+        // ordinary key event carrying the snapshot must not be swallowed.
+        let configuration = ShortcutConfiguration(hold: .defaultHold, toggle: .disabled)
+        let repaired = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierSnapshot([63]),
+            configuration: configuration
+        )
+        TestSupport.expectEqual(repaired.emittedEvents, [.holdActivated])
+        TestSupport.expectEqual(repaired.consumeDecision, .passthrough)
+
+        // Non-Fn hold bindings keep their existing edge-consumption behavior.
+        let optionConfiguration = ShortcutConfiguration(
+            hold: ShortcutPreset.rightOption.binding,
+            toggle: .disabled
+        )
+        let optionRepaired = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierSnapshot([61]),
+            configuration: optionConfiguration
+        )
+        TestSupport.expectEqual(optionRepaired.emittedEvents, [.holdActivated])
+        TestSupport.expectEqual(optionRepaired.consumeDecision, .consume)
     }
 
     private static func testDefaultShortcutSpecificityOrdering() {


### PR DESCRIPTION
Fixes #303.

## Problem

When hold-to-talk is bound to **Fn**, FreeFlow consumed every Fn/Globe `flagsChanged` event at its CGEvent tap (`ShortcutMatcher` returned `.consume` whenever the hold binding was active). macOS therefore never saw the key at all, and **Press 🌐 key to → Change Input Source** (or any system Globe action) could never fire — even for quick taps far too short to be push-to-talk. This reproduced on genuine Apple built-in keyboards, so it wasn't keyboard-specific.

## Fix

Two narrowly-scoped changes:

1. **`ShortcutMatcher`** — Fn/Globe (keyCode 63) modifier events are no longer consumed on behalf of the **hold** binding. macOS itself ignores long Fn holds, so hold-to-talk keeps working identically by passive observation, while quick taps now pass through to the system Globe action. **Toggle bindings keep consuming** (e.g. the default Cmd+Fn toggle), because a Fn tap is meaningful on both sides there and the user explicitly chose Fn for it.

2. **`AppState`** — hold-to-talk on Fn gains a **200 ms minimum hold time** (`max(shortcutStartDelay, 0.2)`), so a quick tap released before the floor cancels the pending start (via the existing `cancelPendingShortcutStart` path) instead of briefly starting a recording. Users who set a longer Shortcut Start Delay keep their setting.

Resulting behavior with hold-to-talk = Fn and macOS "Press 🌐 to" = Change Input Source:

| Gesture | Before | After |
|---|---|---|
| Quick Fn tap | Recording starts (or nothing with delay set); input source never switches | macOS switches input source; no recording |
| Fn hold ≥ 200 ms | Dictation | Dictation (unchanged) |
| Cmd+Fn (default toggle) | Toggle dictation, event consumed | Unchanged |

## Notes

- The 200 ms floor only applies when the hold binding uses Fn (`ShortcutBinding.usesFnKey`); other hold keys (e.g. Right Option) are unaffected.
- `ShortcutBinding.fnKeyCode` replaces the magic `63` in `usesFnKey`.
- There is an inherent overlap window between macOS's (undocumented) Globe tap threshold and any hold-to-talk floor; 200 ms is a compromise between PTT responsiveness and tap reliability.

## Testing

- `make check` passes (typecheck with `-warnings-as-errors`, all tests, validate).
- Updated `testBareFnHoldLifecycle` for the new passthrough semantics; added `testBareFnToggleStillConsumes` and `testFnHoldPassthroughUnlessToggleComboActive` (default hold=Fn / toggle=Cmd+Fn interaction).
- Not yet tested on-device with the real macOS Globe action — would appreciate a maintainer try, happy to iterate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Fn/Globe key behavior: quick taps now pass through to macOS Globe actions.
  - Fn hold-to-talk requires a minimum 200 ms hold, preventing accidental recordings from brief taps.
  - Sustained Fn holds still activate dictation, while toggle shortcuts remain unchanged.

- **Tests**
  - Added coverage for Fn passthrough, hold-to-talk activation, and toggle shortcut behavior.

- **Documentation**
  - Added changelog details for the updated Fn/Globe shortcut behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->