### PR TITLE
Add Gemini transcription: batch and live streaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TEST_RUNNER = $(BUILD_DIR)/FreeFlowTests
 TEST_PRODUCTION_SOURCES = \
 	Sources/AppContextService.swift \
 	Sources/AppName.swift \
+	Sources/GeminiLiveTranscription.swift \
 	Sources/GeminiTranscription.swift \
 	Sources/LLMAPITransport.swift \
 	Sources/LLMCooldownManager.swift \

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,12 @@ TEST_RUNNER = $(BUILD_DIR)/FreeFlowTests
 TEST_PRODUCTION_SOURCES = \
 	Sources/AppContextService.swift \
 	Sources/AppName.swift \
+	Sources/GeminiTranscription.swift \
 	Sources/LLMAPITransport.swift \
 	Sources/LLMCooldownManager.swift \
 	Sources/ModelConfiguration.swift \
 	Sources/TranscriptTextCore.swift \
+	Sources/TranscriptionService.swift \
 	Sources/UpdateManager.swift \
 	Sources/ShortcutCore/DictationShortcutSessionController.swift \
 	Sources/ShortcutCore/ShortcutMatcher.swift \

--- a/README.md
+++ b/README.md
@@ -78,31 +78,45 @@ Then your response would be ONLY the cleaned up text, so here your response is O
 
 ## Using Gemini Transcribe
 
-Google's `gemini-3.5-transcribe` is available as a transcription model alongside
-the Whisper options. It is not OpenAI-compatible — it runs on Google's
-Interactions API — so FreeFlow talks to it directly rather than through the
-provider URL.
+Google's Gemini transcription models are available alongside the Whisper
+options. They are not OpenAI-compatible, so FreeFlow talks to Google directly
+rather than through the provider URL. Both transcribe in smart mode, which
+removes filler words and false starts and repairs punctuation as part of
+transcription, and both accept your custom vocabulary as recognition biasing.
 
-To use it, open settings and:
+There are two models, and the difference that matters for daily dictation is
+quota, not quality:
 
-1. Set the transcription model to `gemini-3.5-transcribe`.
-2. Set the transcription API key to a [Google AI Studio](https://aistudio.google.com/apikey) key.
+| Model | API | Free-tier quota |
+| --- | --- | --- |
+| `gemini-3.5-transcribe` | file upload after recording | ~25 requests per day |
+| `gemini-3.5-transcribe-live` | streams while you speak | limited by tokens per minute |
+
+At roughly one request per dictation, the batch model's daily allowance runs out
+quickly. The live model is limited by audio throughput instead, which a single
+speaker will not reach, so prefer it unless you have a paid tier. Check your own
+limits in [AI Studio](https://aistudio.google.com/rate-limit).
+
+To use the live model, open settings and:
+
+1. Set the transcription API key to a [Google AI Studio](https://aistudio.google.com/apikey) key.
    Leave the transcription API URL empty; FreeFlow routes Gemini to Google for you.
+2. Enable realtime streaming and set the realtime model to
+   `gemini-3.5-transcribe-live`.
+3. Optionally set the transcription model to `gemini-3.5-transcribe`, which is
+   then used only as the fallback if the socket fails mid-dictation.
 
-The model transcribes in its smart mode, which removes filler words and false
-starts and repairs punctuation as part of transcription. Your custom vocabulary
-is sent along as recognition biasing, so names and jargon are more likely to
-come back spelled the way you wrote them.
+To use the batch model on its own, set the transcription model to
+`gemini-3.5-transcribe` and leave realtime streaming off.
 
 Because the transcript arrives already cleaned, you can turn on **preserve exact
 wording** to skip the separate cleanup model entirely and get a one-call
 dictation. Leave it off if you still want the cleanup pass to adapt the text to
 the app you are dictating into.
 
-Two limits are worth knowing: the language is auto-detected rather than pinned
-(pinning a language drops the model out of smart mode), and realtime streaming
-is skipped while a Gemini model is selected, since Gemini streams over its own
-endpoint.
+One limit is worth knowing: the language is auto-detected rather than pinned,
+because pinning a language drops both models out of smart mode. The
+transcription-language setting therefore has no effect on the Gemini paths.
 
 ## Using a Local Model
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,34 @@ Then your response would be ONLY the cleaned up text, so here your response is O
 "Hey, I just wanted to follow up on the meeting from yesterday. I think we should definitely move the deadline to next Friday because the design team still needs more time to finish the mockups. Let me know if that works for you. Thanks."</code></pre>
 </details>
 
+## Using Gemini Transcribe
+
+Google's `gemini-3.5-transcribe` is available as a transcription model alongside
+the Whisper options. It is not OpenAI-compatible — it runs on Google's
+Interactions API — so FreeFlow talks to it directly rather than through the
+provider URL.
+
+To use it, open settings and:
+
+1. Set the transcription model to `gemini-3.5-transcribe`.
+2. Set the transcription API key to a [Google AI Studio](https://aistudio.google.com/apikey) key.
+   Leave the transcription API URL empty; FreeFlow routes Gemini to Google for you.
+
+The model transcribes in its smart mode, which removes filler words and false
+starts and repairs punctuation as part of transcription. Your custom vocabulary
+is sent along as recognition biasing, so names and jargon are more likely to
+come back spelled the way you wrote them.
+
+Because the transcript arrives already cleaned, you can turn on **preserve exact
+wording** to skip the separate cleanup model entirely and get a one-call
+dictation. Leave it off if you still want the cleanup pass to adapt the text to
+the app you are dictating into.
+
+Two limits are worth knowing: the language is auto-detected rather than pinned
+(pinning a language drops the model out of smart mode), and realtime streaming
+is skipped while a Gemini model is selected, since Gemini streams over its own
+endpoint.
+
 ## Using a Local Model
 
 FreeFlow can use OpenAI-compatible local or self-hosted providers instead of Groq. In settings, configure the API base URL and model IDs for your local LLM provider, such as Ollama, LM Studio, or another OpenAI-compatible server. If your transcription backend uses a different endpoint from your LLM backend, set the transcription API URL separately.

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -614,7 +614,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingManualCommandInvocation = false
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
-    private var realtimeService: RealtimeTranscriptionService?
+    private var realtimeService: (any RealtimeTranscriptBackend)?
     private var automaticTerminationDisabled = false
     private var activeAudioInterruption: ActiveAudioInterruption?
     private var pendingOverlayDismissToken: UUID?
@@ -2588,7 +2588,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     /// gets a transcript. Runs the realtime commit and file upload in that
     /// strict order to avoid paying for both when realtime succeeds.
     private static func resolveRawTranscript(
-        realtimeService: RealtimeTranscriptionService?,
+        realtimeService: (any RealtimeTranscriptBackend)?,
         fileService: TranscriptionService,
         fileURL: URL
     ) async throws -> String {
@@ -2929,9 +2929,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func startRealtimeStreamingIfEnabled() {
         guard realtimeStreamingEnabled else { return }
-        // Gemini transcription is file-based here: it streams over its own
-        // bidirectional endpoint, and its key cannot authenticate the realtime
-        // socket. Skip streaming rather than opening a doomed connection.
+        let model = realtimeStreamingModel.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Gemini's live model is the one worth streaming to: its quota is
+        // measured in tokens per minute rather than requests per day, unlike
+        // the batch transcribe model.
+        if GeminiLiveTranscription.handlesModel(model) {
+            startGeminiLiveStreaming(model: model)
+            return
+        }
+
+        // An OpenAI-compatible socket cannot authenticate with a Gemini
+        // transcription key, so skip rather than opening a doomed connection.
         guard !GeminiTranscription.handlesModel(transcriptionModel) else {
             os_log(.info, log: recordingLog, "realtime streaming skipped — Gemini transcription is file-based")
             return
@@ -2941,14 +2950,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
             os_log(.info, log: recordingLog, "realtime streaming requested but base URL is empty — skipping")
             return
         }
-        let model = realtimeStreamingModel.trimmingCharacters(in: .whitespacesAndNewlines)
         let config = RealtimeTranscriptionService.Configuration(
             baseURL: trimmedBase,
             apiKey: resolvedTranscriptionAPIKey,
             model: model,
             language: resolvedTranscriptionLanguage
         )
-        let service = RealtimeTranscriptionService(config: config)
+        start(service: RealtimeTranscriptionService(config: config))
+    }
+
+    private func startGeminiLiveStreaming(model: String) {
+        let config = GeminiLiveTranscriptionService.Configuration(
+            baseURL: resolvedTranscriptionBaseURL,
+            apiKey: resolvedTranscriptionAPIKey,
+            model: model,
+            customVocabulary: customVocabulary,
+            sampleRate: AudioRecorder.realtimeSampleRate
+        )
+        start(service: GeminiLiveTranscriptionService(config: config))
+    }
+
+    private func start(service: any RealtimeTranscriptBackend) {
         do {
             try service.start()
         } catch {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1036,7 +1036,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             apiKey: resolvedTranscriptionAPIKey,
             baseURL: resolvedTranscriptionBaseURL,
             transcriptionModel: transcriptionModel,
-            language: resolvedTranscriptionLanguage
+            language: resolvedTranscriptionLanguage,
+            customVocabulary: customVocabulary
         )
     }
 
@@ -2928,6 +2929,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func startRealtimeStreamingIfEnabled() {
         guard realtimeStreamingEnabled else { return }
+        // Gemini transcription is file-based here: it streams over its own
+        // bidirectional endpoint, and its key cannot authenticate the realtime
+        // socket. Skip streaming rather than opening a doomed connection.
+        guard !GeminiTranscription.handlesModel(transcriptionModel) else {
+            os_log(.info, log: recordingLog, "realtime streaming skipped — Gemini transcription is file-based")
+            return
+        }
         let trimmedBase = resolvedTranscriptionBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedBase.isEmpty else {
             os_log(.info, log: recordingLog, "realtime streaming requested but base URL is empty — skipping")

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -111,10 +111,14 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             interleaved: true
         )!
     }()
+    /// Sample rate of the out-of-band PCM stream handed to realtime sockets.
+    /// Exposed so a provider can declare the real rate in its own frames.
+    static let realtimeSampleRate = 24_000
+
     private let pcm16TargetFormat: AVAudioFormat = {
         AVAudioFormat(
             commonFormat: .pcmFormatInt16,
-            sampleRate: 24_000,
+            sampleRate: Double(AudioRecorder.realtimeSampleRate),
             channels: 1,
             interleaved: true
         )!

--- a/Sources/GeminiLiveTranscription.swift
+++ b/Sources/GeminiLiveTranscription.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// Wire format for `gemini-3.5-transcribe-live`, which streams over the Live
+/// API's bidirectional socket rather than the Interactions API used by
+/// ``GeminiTranscription``.
+///
+/// The live model matters for dictation because its free-tier quota is orders
+/// of magnitude larger: the batch model allows a couple of dozen requests a
+/// day, while the live model is limited by tokens per minute, which a single
+/// speaker cannot realistically exhaust.
+enum GeminiLiveTranscription {
+    static let defaultBaseURL = "wss://generativelanguage.googleapis.com"
+
+    private static let servicePath =
+        "/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+
+    /// Smart mode is spelled in upper case here, unlike the Interactions API.
+    private static let smartMode = "SMART"
+
+    static func handlesModel(_ model: String) -> Bool {
+        let normalized = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.hasPrefix("gemini-") && normalized.hasSuffix("-transcribe-live")
+    }
+
+    static func socketURL(baseURL: String) -> URL? {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source = trimmed.isEmpty ? defaultBaseURL : trimmed
+        guard var components = URLComponents(string: source) else { return nil }
+
+        // Accept an https base and upgrade it, so a Gemini provider URL copied
+        // from the REST docs still works here.
+        switch components.scheme?.lowercased() {
+        case "https", "wss": components.scheme = "wss"
+        case "http", "ws": components.scheme = "ws"
+        default: return nil
+        }
+        guard let host = components.host, !host.isEmpty else { return nil }
+
+        // Anything other than a Google host cannot serve this protocol, so fall
+        // back rather than opening a socket that will never speak it.
+        let isGoogleHost = host.lowercased().hasSuffix("googleapis.com")
+        if !isGoogleHost {
+            return URL(string: defaultBaseURL + servicePath)
+        }
+
+        components.path = servicePath
+        components.query = nil
+        return components.url
+    }
+
+    static func setupMessage(model: String, customVocabulary: String) throws -> String {
+        var transcription: [String: Any] = ["mode": smartMode]
+        let terms = GeminiTranscription.vocabularyTerms(from: customVocabulary)
+        if !terms.isEmpty {
+            transcription["custom_vocabulary"] = terms
+        }
+        // Language is deliberately left to auto-detection, matching the batch
+        // path: pinning it drops the model out of smart mode.
+        let payload: [String: Any] = [
+            "setup": [
+                "model": normalizedModelPath(model),
+                "generationConfig": ["responseModalities": ["TEXT"]],
+                "inputAudioTranscription": transcription
+            ]
+        ]
+        return try encode(payload)
+    }
+
+    static func audioMessage(pcm16: Data, sampleRate: Int) throws -> String {
+        try encode([
+            "realtimeInput": [
+                "audio": [
+                    "mimeType": "audio/pcm;rate=\(sampleRate)",
+                    "data": pcm16.base64EncodedString()
+                ]
+            ]
+        ])
+    }
+
+    static func audioStreamEndMessage() throws -> String {
+        try encode(["realtimeInput": ["audioStreamEnd": true]])
+    }
+
+    /// The Live API namespaces models under `models/`; accept either spelling.
+    static func normalizedModelPath(_ model: String) -> String {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("models/") ? trimmed : "models/\(trimmed)"
+    }
+
+    // MARK: - Server frames
+
+    struct ServerFrame {
+        var transcript: String?
+        var isComplete: Bool
+        var errorMessage: String?
+        var isSetupComplete: Bool
+    }
+
+    static func parseServerFrame(_ text: String) -> ServerFrame {
+        guard let data = text.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return ServerFrame(transcript: nil, isComplete: false, errorMessage: nil, isSetupComplete: false)
+        }
+
+        if let error = root["error"] as? [String: Any] {
+            let message = error["message"] as? String ?? "Gemini live transcription failed."
+            return ServerFrame(transcript: nil, isComplete: true, errorMessage: message, isSetupComplete: false)
+        }
+
+        if root["setupComplete"] != nil {
+            return ServerFrame(transcript: nil, isComplete: false, errorMessage: nil, isSetupComplete: true)
+        }
+
+        guard let server = root["serverContent"] as? [String: Any] else {
+            return ServerFrame(transcript: nil, isComplete: false, errorMessage: nil, isSetupComplete: false)
+        }
+
+        var transcript: String?
+        if let text = (server["inputTranscription"] as? [String: Any])?["text"] as? String {
+            transcript = text
+        } else if let turn = server["modelTurn"] as? [String: Any],
+                  let parts = turn["parts"] as? [[String: Any]] {
+            let joined = parts.compactMap { $0["text"] as? String }.joined()
+            transcript = joined.isEmpty ? nil : joined
+        }
+
+        let complete = (server["turnComplete"] as? Bool ?? false)
+            || (server["generationComplete"] as? Bool ?? false)
+
+        return ServerFrame(
+            transcript: transcript,
+            isComplete: complete,
+            errorMessage: nil,
+            isSetupComplete: false
+        )
+    }
+
+    private static func encode(_ payload: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw TranscriptionError.transcriptionFailed("Could not encode Gemini live message.")
+        }
+        return text
+    }
+}

--- a/Sources/GeminiLiveTranscriptionService.swift
+++ b/Sources/GeminiLiveTranscriptionService.swift
@@ -1,0 +1,233 @@
+import Foundation
+import os.log
+
+private let geminiLiveLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "GeminiLiveTranscription")
+
+/// Streams microphone audio to `gemini-3.5-transcribe-live` over the Live API
+/// socket and returns the transcript when the dictation ends.
+///
+/// This is a sibling of ``RealtimeTranscriptionService`` rather than a variant
+/// of it: that service speaks the OpenAI realtime protocol, while the Live API
+/// exchanges `setup` / `realtimeInput` / `serverContent` frames. The surface is
+/// kept identical so ``AppState`` can hold either behind
+/// ``RealtimeTranscriptBackend``.
+final class GeminiLiveTranscriptionService: RealtimeTranscriptBackend {
+    struct Configuration {
+        let baseURL: String
+        let apiKey: String
+        let model: String
+        let customVocabulary: String
+        /// Matches what ``AudioRecorder`` streams. The model accepts rates
+        /// other than 16 kHz as long as the frames declare the real one.
+        let sampleRate: Int
+    }
+
+    private let config: Configuration
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+
+    private let stateQueue = DispatchQueue(label: "com.zachlatta.freeflow.geminilive.state")
+    private var transcript: String = ""
+    private var finalContinuation: CheckedContinuation<String, Error>?
+    private var streamEnded: Bool = false
+    private var closed: Bool = false
+    private var setupCompleted: Bool = false
+    private var terminalError: Error?
+
+    var onPartialUpdate: ((String) -> Void)?
+
+    init(config: Configuration, session: URLSession = .shared) {
+        self.config = config
+        self.session = session
+    }
+
+    // MARK: Lifecycle
+
+    func start() throws {
+        guard let url = GeminiLiveTranscription.socketURL(baseURL: config.baseURL) else {
+            throw RealtimeTranscriptionError.invalidBaseURL(config.baseURL)
+        }
+
+        var request = URLRequest(url: url)
+        // The key rides in a header so it never lands in a URL or a log line.
+        request.setValue(config.apiKey, forHTTPHeaderField: "x-goog-api-key")
+
+        let socket = session.webSocketTask(with: request)
+        stateQueue.sync { task = socket }
+        socket.resume()
+
+        let setup = try GeminiLiveTranscription.setupMessage(
+            model: config.model,
+            customVocabulary: config.customVocabulary
+        )
+        send(setup, over: socket)
+
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+    }
+
+    func cancel() {
+        let socket: URLSessionWebSocketTask? = stateQueue.sync {
+            closed = true
+            let current = task
+            task = nil
+            return current
+        }
+        receiveTask?.cancel()
+        receiveTask = nil
+        socket?.cancel(with: .goingAway, reason: nil)
+        resume(with: .failure(CancellationError()))
+    }
+
+    func appendPCM16(_ data: Data) {
+        let socket: URLSessionWebSocketTask? = stateQueue.sync { closed ? nil : task }
+        guard let socket else { return }
+        guard let message = try? GeminiLiveTranscription.audioMessage(
+            pcm16: data,
+            sampleRate: config.sampleRate
+        ) else { return }
+        send(message, over: socket)
+    }
+
+    /// Close the audio stream and wait for the model to finish the turn.
+    func commitAndAwaitFinal() async throws -> String {
+        let socket: URLSessionWebSocketTask? = stateQueue.sync { closed ? nil : task }
+        guard let socket else {
+            throw RealtimeTranscriptionError.notConnected
+        }
+
+        if let error = stateQueue.sync(execute: { terminalError }) {
+            throw error
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let alreadyDone: String? = stateQueue.sync {
+                if let error = terminalError {
+                    continuation.resume(throwing: error)
+                    return nil
+                }
+                guard !streamEnded else { return transcript }
+                streamEnded = true
+                finalContinuation = continuation
+                return nil
+            }
+            if let alreadyDone {
+                continuation.resume(returning: alreadyDone)
+                return
+            }
+            guard stateQueue.sync(execute: { finalContinuation != nil }) else { return }
+            guard let end = try? GeminiLiveTranscription.audioStreamEndMessage() else {
+                resume(with: .failure(RealtimeTranscriptionError.notConnected))
+                return
+            }
+            send(end, over: socket)
+        }
+    }
+
+    // MARK: Socket plumbing
+
+    private func send(_ text: String, over socket: URLSessionWebSocketTask) {
+        socket.send(.string(text)) { error in
+            if let error {
+                os_log(.error, log: geminiLiveLog, "send failed: %{public}@", error.localizedDescription)
+            }
+        }
+    }
+
+    private func receiveLoop() async {
+        while !Task.isCancelled {
+            let socket: URLSessionWebSocketTask? = stateQueue.sync { closed ? nil : task }
+            guard let socket else { return }
+
+            do {
+                let message = try await socket.receive()
+                guard let text = Self.text(from: message) else { continue }
+                handle(frame: GeminiLiveTranscription.parseServerFrame(text))
+            } catch {
+                if Task.isCancelled { return }
+                let resolved = Self.describe(error, setupCompleted: stateQueue.sync { setupCompleted })
+                let pending: Bool = stateQueue.sync { finalContinuation != nil }
+                if pending {
+                    resume(with: .failure(resolved))
+                } else {
+                    stateQueue.sync { terminalError = resolved }
+                }
+                return
+            }
+        }
+    }
+
+    private func handle(frame: GeminiLiveTranscription.ServerFrame) {
+        if frame.isSetupComplete {
+            stateQueue.sync { setupCompleted = true }
+            return
+        }
+
+        if let message = frame.errorMessage {
+            os_log(.error, log: geminiLiveLog, "server error: %{public}@", message)
+            let error = RealtimeTranscriptionError.serverError(code: "live", message: message)
+            let pending: Bool = stateQueue.sync { finalContinuation != nil }
+            if pending {
+                resume(with: .failure(error))
+            } else {
+                stateQueue.sync { terminalError = error }
+            }
+            return
+        }
+
+        if let text = frame.transcript, !text.isEmpty {
+            let snapshot: String = stateQueue.sync {
+                transcript += text
+                return transcript
+            }
+            if let onPartialUpdate {
+                DispatchQueue.main.async { onPartialUpdate(snapshot) }
+            }
+        }
+
+        guard frame.isComplete else { return }
+        let snapshot: String = stateQueue.sync { transcript }
+        let trimmed = snapshot.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            resume(with: .failure(RealtimeTranscriptionError.closedBeforeFinal))
+            return
+        }
+        resume(with: .success(trimmed))
+    }
+
+    private func resume(with result: Result<String, Error>) {
+        let continuation: CheckedContinuation<String, Error>? = stateQueue.sync {
+            let pending = finalContinuation
+            finalContinuation = nil
+            return pending
+        }
+        guard let continuation else { return }
+        switch result {
+        case .success(let text): continuation.resume(returning: text)
+        case .failure(let error): continuation.resume(throwing: error)
+        }
+    }
+
+    /// The Live API rejects a bad key during the HTTP upgrade, so the socket
+    /// simply fails to connect and no error frame ever arrives. Turn that into
+    /// something a user can act on instead of "Socket is not connected".
+    private static func describe(_ error: Error, setupCompleted: Bool) -> Error {
+        // Any failure before the handshake means the session never established,
+        // whether it surfaces as a URLError or a raw POSIX socket error.
+        guard !setupCompleted else { return error }
+        return RealtimeTranscriptionError.serverError(
+            code: "live",
+            message: "Could not connect to Gemini live transcription. Check the transcription API key."
+        )
+    }
+
+    private static func text(from message: URLSessionWebSocketTask.Message) -> String? {
+        switch message {
+        case .string(let text): return text
+        case .data(let data): return String(data: data, encoding: .utf8)
+        @unknown default: return nil
+        }
+    }
+}

--- a/Sources/GeminiTranscription.swift
+++ b/Sources/GeminiTranscription.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+/// Google's Gemini 3.5 Transcribe models do not speak the OpenAI-compatible
+/// `/audio/transcriptions` protocol the Groq path uses. They run on the
+/// Interactions API, authenticate with `x-goog-api-key` instead of a bearer
+/// token, and take audio inline as base64 rather than as multipart form data.
+///
+/// The payoff is that smart mode folds cleanup into transcription: fillers and
+/// false starts are dropped and punctuation is repaired inside the same request,
+/// so a Gemini dictation needs one API round trip where Groq needs two.
+enum GeminiTranscription {
+    /// Interactions lives under the Gemini base path, not the Groq provider URL.
+    static let defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+
+    /// Smart mode cannot be combined with word timestamps or diarization, and
+    /// FreeFlow needs neither — it wants clean prose to paste at the cursor.
+    private static let smartMode = "smart"
+
+    /// The API caps biasing terms; send the first ones and drop the rest rather
+    /// than letting the whole request fail on an oversized vocabulary.
+    private static let customVocabularyLimit = 1000
+
+    /// True for models that transcribe over the Interactions API. The `-live`
+    /// variant streams over a bidirectional socket instead, so it is excluded:
+    /// routing it here would build a request the endpoint cannot answer.
+    static func handlesModel(_ model: String) -> Bool {
+        let normalized = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalized.hasPrefix("gemini-"), normalized.contains("transcribe") else { return false }
+        return !normalized.hasSuffix("-live")
+    }
+
+    /// Gemini requests must reach Google even when the surrounding settings
+    /// still hold a Groq provider URL, which is the default for every existing
+    /// install. Keep an explicitly configured Gemini host, replace anything else.
+    static func resolvedBaseURL(from configuredBaseURL: String) -> String {
+        let trimmed = configuredBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let host = URLComponents(string: trimmed)?.host?.lowercased() else {
+            return defaultBaseURL
+        }
+        let isGoogleHost = host == "generativelanguage.googleapis.com"
+            || host.hasSuffix(".googleapis.com")
+        return isGoogleHost ? trimmed : defaultBaseURL
+    }
+
+    static func endpoint(baseURL: URL) -> URL {
+        baseURL.appendingPathComponent("interactions")
+    }
+
+    static func requestBody(
+        model: String,
+        audioData: Data,
+        mimeType: String,
+        customVocabulary: String
+    ) throws -> Data {
+        let terms = vocabularyTerms(from: customVocabulary)
+        let request = InteractionRequest(
+            model: model.trimmingCharacters(in: .whitespacesAndNewlines),
+            input: [
+                AudioInput(
+                    type: "audio",
+                    data: audioData.base64EncodedString(),
+                    mimeType: mimeType
+                )
+            ],
+            generationConfig: GenerationConfig(
+                transcriptionConfig: TranscriptionConfig(
+                    mode: Mode(type: smartMode),
+                    // Language is deliberately omitted. Auto-detection handles
+                    // the dictated language and code-switching, and pinning
+                    // `language_codes` was observed to drop smart mode back to
+                    // verbatim output — which would undo the cleanup pass.
+                    customVocabulary: terms.isEmpty ? nil : terms
+                )
+            )
+        )
+        return try JSONEncoder().encode(request)
+    }
+
+    /// Splits the free-text vocabulary setting the same way the post-processing
+    /// prompt does, so both stages bias on an identical list of terms.
+    static func vocabularyTerms(from rawVocabulary: String) -> [String] {
+        let terms = rawVocabulary
+            .split(whereSeparator: { $0 == "\n" || $0 == "," || $0 == ";" })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        var seen = Set<String>()
+        let deduplicated = terms.filter { seen.insert($0.lowercased()).inserted }
+        return Array(deduplicated.prefix(customVocabularyLimit))
+    }
+
+    /// Quota, validation and billing problems come back in a JSON envelope whose
+    /// message is far more actionable than the bare status line, so prefer it.
+    static func failureMessage(fromResponse data: Data, fallback: String) -> String {
+        guard let message = errorMessage(fromResponse: data), !message.isEmpty else {
+            return fallback
+        }
+        return message
+    }
+
+    /// Google is inconsistent here: parameter and quota failures arrive as a
+    /// bare object, while auth failures arrive wrapped in an array. Read both,
+    /// otherwise an invalid key degrades to a generic status line.
+    private static func errorMessage(fromResponse data: Data) -> String? {
+        let decoder = JSONDecoder()
+        if let failure = try? decoder.decode(InteractionErrorEnvelope.self, from: data) {
+            return failure.error.message
+        }
+        if let failures = try? decoder.decode([InteractionErrorEnvelope].self, from: data) {
+            return failures.compactMap { $0.error.message }.first
+        }
+        return nil
+    }
+
+    /// Pulls the transcript out of the interaction's model output. Errors are
+    /// reported in the body with HTTP 200 in some cases, so the payload is
+    /// checked for a failure before its text is trusted.
+    static func transcript(fromResponse data: Data) throws -> String {
+        let decoder = JSONDecoder()
+
+        if let message = errorMessage(fromResponse: data) {
+            throw TranscriptionError.transcriptionFailed(message)
+        }
+
+        guard let response = try? decoder.decode(InteractionResponse.self, from: data) else {
+            throw TranscriptionError.transcriptionFailed("Unreadable Gemini transcription response.")
+        }
+
+        if let status = response.status, status != "completed" {
+            throw TranscriptionError.transcriptionFailed("Gemini transcription \(status).")
+        }
+
+        let transcript = (response.steps ?? [])
+            .filter { $0.type == nil || $0.type == "model_output" }
+            .flatMap { $0.content ?? [] }
+            .compactMap { $0.text }
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !transcript.isEmpty else {
+            throw TranscriptionError.transcriptionFailed("Gemini returned an empty transcript.")
+        }
+        return transcript
+    }
+
+    // MARK: - Wire format
+
+    private struct InteractionRequest: Encodable {
+        let model: String
+        let input: [AudioInput]
+        let generationConfig: GenerationConfig
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case input
+            case generationConfig = "generation_config"
+        }
+    }
+
+    private struct AudioInput: Encodable {
+        let type: String
+        let data: String
+        let mimeType: String
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case data
+            case mimeType = "mime_type"
+        }
+    }
+
+    private struct GenerationConfig: Encodable {
+        let transcriptionConfig: TranscriptionConfig
+
+        enum CodingKeys: String, CodingKey {
+            case transcriptionConfig = "transcription_config"
+        }
+    }
+
+    private struct TranscriptionConfig: Encodable {
+        let mode: Mode
+        let customVocabulary: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case mode
+            case customVocabulary = "custom_vocabulary"
+        }
+    }
+
+    private struct Mode: Encodable {
+        let type: String
+    }
+
+    private struct InteractionResponse: Decodable {
+        let status: String?
+        let steps: [Step]?
+    }
+
+    private struct Step: Decodable {
+        let type: String?
+        let content: [Content]?
+    }
+
+    private struct Content: Decodable {
+        let text: String?
+    }
+
+    private struct InteractionErrorEnvelope: Decodable {
+        let error: InteractionError
+    }
+
+    private struct InteractionError: Decodable {
+        let message: String?
+    }
+}

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -26,7 +26,11 @@ public struct ModelConfiguration {
 
     public static let transcriptionModels = [
         "whisper-large-v3",
-        "whisper-large-v3-turbo"
+        "whisper-large-v3-turbo",
+        // Google's transcribe model needs its own key and provider URL, set in
+        // the transcription overrides. Its smart mode also cleans up the text,
+        // so the post-processing pass has less left to do.
+        "gemini-3.5-transcribe"
     ]
 
     public static func config(for model: String) -> ModelConfig {

--- a/Sources/RealtimeTranscriptBackend.swift
+++ b/Sources/RealtimeTranscriptBackend.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A streaming transcription socket that receives microphone audio while the
+/// user dictates and produces the transcript when the dictation ends.
+///
+/// Two implementations exist because the providers speak different protocols:
+/// ``RealtimeTranscriptionService`` for OpenAI-compatible realtime endpoints,
+/// and ``GeminiLiveTranscriptionService`` for the Gemini Live API.
+protocol RealtimeTranscriptBackend: AnyObject {
+    /// Partial transcript updates, delivered on the main queue.
+    var onPartialUpdate: ((String) -> Void)? { get set }
+
+    func start() throws
+    func appendPCM16(_ data: Data)
+    func commitAndAwaitFinal() async throws -> String
+    func cancel()
+}

--- a/Sources/RealtimeTranscriptionService.swift
+++ b/Sources/RealtimeTranscriptionService.swift
@@ -19,7 +19,7 @@ enum RealtimeTranscriptionError: LocalizedError {
     }
 }
 
-final class RealtimeTranscriptionService {
+final class RealtimeTranscriptionService: RealtimeTranscriptBackend {
     struct Configuration {
         let baseURL: String
         let apiKey: String

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -18,6 +18,7 @@ class TranscriptionService {
     private let baseURL: URL
     private let transcriptionModel: String
     private let language: String?
+    private let customVocabulary: String
     private var transcriptionResponseFormat: String {
         Self.responseFormat(forModel: transcriptionModel)
     }
@@ -30,14 +31,22 @@ class TranscriptionService {
         apiKey: String,
         baseURL: String = "https://api.groq.com/openai/v1",
         transcriptionModel: String = "whisper-large-v3",
-        language: String? = nil
+        language: String? = nil,
+        customVocabulary: String = ""
     ) throws {
         self.apiKey = apiKey
-        self.baseURL = try Self.normalizedBaseURL(from: baseURL)
         let trimmedModel = transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
         self.transcriptionModel = trimmedModel.isEmpty ? "whisper-large-v3" : trimmedModel
+        // Gemini transcription lives on Google's Interactions API. An existing
+        // install still carries a Groq provider URL here, so the Gemini host is
+        // substituted rather than requiring everyone to retype a provider URL.
+        let resolvedBaseURL = GeminiTranscription.handlesModel(self.transcriptionModel)
+            ? GeminiTranscription.resolvedBaseURL(from: baseURL)
+            : baseURL
+        self.baseURL = try Self.normalizedBaseURL(from: resolvedBaseURL)
         let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.language = (trimmedLanguage?.isEmpty == false) ? trimmedLanguage : nil
+        self.customVocabulary = customVocabulary
     }
 
     static func responseFormat(forModel model: String) -> String {
@@ -111,7 +120,73 @@ class TranscriptionService {
 
     // Send audio file for transcription and return text
     private func transcribeAudio(fileURL: URL) async throws -> String {
+        if GeminiTranscription.handlesModel(transcriptionModel) {
+            return try await transcribeWithGemini(fileURL: fileURL)
+        }
         return try await transcribeAudioWithURLSession(fileURL: fileURL)
+    }
+
+    /// Gemini's smart mode returns prose that is already de-filled and
+    /// punctuated, so this single request covers what the Groq path splits
+    /// between Whisper and a follow-up cleanup model.
+    private func transcribeWithGemini(fileURL: URL) async throws -> String {
+        var request = URLRequest(url: GeminiTranscription.endpoint(baseURL: baseURL))
+        request.httpMethod = "POST"
+        request.timeoutInterval = transcriptionTimeoutSeconds
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let audioData = try Data(contentsOf: fileURL)
+        let body = try GeminiTranscription.requestBody(
+            model: transcriptionModel,
+            audioData: audioData,
+            mimeType: audioContentType(for: fileURL.lastPathComponent),
+            customVocabulary: customVocabulary
+        )
+
+        do {
+            let (data, response) = try await LLMAPITransport.upload(for: request, from: body)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw TranscriptionError.submissionFailed("No response from server")
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                let responseBody = String(data: data, encoding: .utf8) ?? ""
+                os_log(
+                    .error,
+                    log: transcriptionLog,
+                    "Gemini transcription returned HTTP %ld for %{public}@ (bytes=%{public}lld) body=%{public}@",
+                    httpResponse.statusCode,
+                    fileURL.lastPathComponent,
+                    fileSizeBytes(for: fileURL),
+                    responseBody
+                )
+                throw TranscriptionError.submissionFailed(GeminiTranscription.failureMessage(
+                    fromResponse: data,
+                    fallback: Self.friendlyHTTPMessage(
+                        status: httpResponse.statusCode,
+                        host: baseURL.host
+                    )
+                ))
+            }
+
+            return try GeminiTranscription.transcript(fromResponse: data)
+        } catch let error as TranscriptionError {
+            throw error
+        } catch {
+            let nsError = error as NSError
+            os_log(
+                .error,
+                log: transcriptionLog,
+                "Gemini transcription upload failed for %{public}@ (bytes=%{public}lld): domain=%{public}@ code=%ld desc=%{public}@",
+                fileURL.lastPathComponent,
+                fileSizeBytes(for: fileURL),
+                nsError.domain,
+                nsError.code,
+                error.localizedDescription
+            )
+            throw error
+        }
     }
 
     private func transcribeAudioWithURLSession(fileURL: URL) async throws -> String {

--- a/Tests/GeminiLiveTranscriptionTests.swift
+++ b/Tests/GeminiLiveTranscriptionTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+enum GeminiLiveTranscriptionTests {
+    static func run() {
+        testOnlyLiveModelsAreRouted()
+        testSocketURLIsDerivedFromAnyGeminiBase()
+        testSetupAsksForSmartModeAndVocabulary()
+        testAudioFramesDeclareTheRealSampleRate()
+        testServerFramesAreClassified()
+    }
+
+    private static func testOnlyLiveModelsAreRouted() {
+        TestSupport.expect(GeminiLiveTranscription.handlesModel("gemini-3.5-transcribe-live"), "Should route the live model")
+        TestSupport.expect(GeminiLiveTranscription.handlesModel(" GEMINI-3.5-TRANSCRIBE-LIVE "), "Should tolerate spacing and case")
+
+        // The batch model goes to the Interactions API instead.
+        TestSupport.expect(!GeminiLiveTranscription.handlesModel("gemini-3.5-transcribe"), "Should not route the batch model")
+        TestSupport.expect(!GeminiLiveTranscription.handlesModel("gpt-4o-transcribe"), "Should leave other providers alone")
+
+        // The two routers must never both claim a model.
+        for model in ["gemini-3.5-transcribe", "gemini-3.5-transcribe-live", "whisper-large-v3"] {
+            TestSupport.expect(
+                !(GeminiTranscription.handlesModel(model) && GeminiLiveTranscription.handlesModel(model)),
+                "Routers must not overlap for \(model)"
+            )
+        }
+    }
+
+    private static func testSocketURLIsDerivedFromAnyGeminiBase() {
+        let expected = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+
+        // An https REST base upgrades to wss and picks up the service path.
+        TestSupport.expectEqual(
+            GeminiLiveTranscription.socketURL(baseURL: "https://generativelanguage.googleapis.com/v1beta")?.absoluteString,
+            expected
+        )
+        TestSupport.expectEqual(GeminiLiveTranscription.socketURL(baseURL: "")?.absoluteString, expected)
+
+        // A Groq provider URL cannot serve this protocol, so fall back.
+        TestSupport.expectEqual(
+            GeminiLiveTranscription.socketURL(baseURL: "https://api.groq.com/openai/v1")?.absoluteString,
+            expected
+        )
+
+        // Any credentials already on the base URL must not survive.
+        TestSupport.expect(
+            GeminiLiveTranscription.socketURL(baseURL: "https://generativelanguage.googleapis.com/v1beta?key=secret")?
+                .absoluteString.contains("secret") == false,
+            "Query parameters must be dropped"
+        )
+    }
+
+    private static func testSetupAsksForSmartModeAndVocabulary() {
+        let setup = try! GeminiLiveTranscription.setupMessage(
+            model: "gemini-3.5-transcribe-live",
+            customVocabulary: "FreeFlow, Groq, Groq"
+        )
+        let json = try! JSONSerialization.jsonObject(with: Data(setup.utf8)) as! [String: Any]
+        let body = json["setup"] as! [String: Any]
+
+        // The Live API namespaces models under models/.
+        TestSupport.expectEqual(body["model"] as? String, "models/gemini-3.5-transcribe-live")
+        TestSupport.expectEqual(
+            (body["generationConfig"] as? [String: Any])?["responseModalities"] as? [String],
+            ["TEXT"]
+        )
+
+        let transcription = body["inputAudioTranscription"] as? [String: Any]
+        // Smart mode is upper case here, unlike the Interactions API.
+        TestSupport.expectEqual(transcription?["mode"] as? String, "SMART")
+        TestSupport.expectEqual(transcription?["custom_vocabulary"] as? [String], ["FreeFlow", "Groq"])
+
+        // Pinning a language drops the model out of smart mode.
+        TestSupport.expect(transcription?["language_codes"] == nil, "Should let Gemini auto-detect the language")
+
+        let bare = try! GeminiLiveTranscription.setupMessage(model: "models/gemini-3.5-transcribe-live", customVocabulary: "")
+        let bareBody = (try! JSONSerialization.jsonObject(with: Data(bare.utf8)) as! [String: Any])["setup"] as! [String: Any]
+        TestSupport.expectEqual(bareBody["model"] as? String, "models/gemini-3.5-transcribe-live")
+        TestSupport.expect(
+            (bareBody["inputAudioTranscription"] as? [String: Any])?["custom_vocabulary"] == nil,
+            "Should omit an empty vocabulary"
+        )
+    }
+
+    private static func testAudioFramesDeclareTheRealSampleRate() {
+        let pcm = Data([0x10, 0x20, 0x30, 0x40])
+        let frame = try! GeminiLiveTranscription.audioMessage(pcm16: pcm, sampleRate: 24_000)
+        let json = try! JSONSerialization.jsonObject(with: Data(frame.utf8)) as! [String: Any]
+        let audio = ((json["realtimeInput"] as? [String: Any])?["audio"]) as? [String: Any]
+
+        // The recorder streams 24 kHz; the frame must say so rather than
+        // claiming the documented 16 kHz.
+        TestSupport.expectEqual(audio?["mimeType"] as? String, "audio/pcm;rate=24000")
+        TestSupport.expectEqual(audio?["data"] as? String, pcm.base64EncodedString())
+
+        let end = try! GeminiLiveTranscription.audioStreamEndMessage()
+        let endJSON = try! JSONSerialization.jsonObject(with: Data(end.utf8)) as! [String: Any]
+        TestSupport.expectEqual(
+            (endJSON["realtimeInput"] as? [String: Any])?["audioStreamEnd"] as? Bool,
+            true
+        )
+    }
+
+    private static func testServerFramesAreClassified() {
+        let q = "\""
+        func frame(_ body: String) -> GeminiLiveTranscription.ServerFrame {
+            GeminiLiveTranscription.parseServerFrame(body)
+        }
+
+        let partial = frame("{\(q)serverContent\(q):{\(q)inputTranscription\(q):{\(q)text\(q):\(q)Привет\(q)}}}")
+        TestSupport.expectEqual(partial.transcript, "Привет")
+        TestSupport.expect(!partial.isComplete, "A partial frame is not complete")
+
+        let done = frame("{\(q)serverContent\(q):{\(q)turnComplete\(q):true}}")
+        TestSupport.expect(done.isComplete, "turnComplete ends the turn")
+
+        let generated = frame("{\(q)serverContent\(q):{\(q)generationComplete\(q):true}}")
+        TestSupport.expect(generated.isComplete, "generationComplete ends the turn")
+
+        let ready = frame("{\(q)setupComplete\(q):{}}")
+        TestSupport.expect(ready.isSetupComplete, "setupComplete is recognised")
+        TestSupport.expect(!ready.isComplete, "setupComplete does not end the turn")
+
+        let failure = frame("{\(q)error\(q):{\(q)message\(q):\(q)Quota exceeded\(q)}}")
+        TestSupport.expectEqual(failure.errorMessage, "Quota exceeded")
+        TestSupport.expect(failure.isComplete, "An error ends the turn")
+
+        // Garbage must not crash or be mistaken for a transcript.
+        let junk = frame("not json")
+        TestSupport.expect(junk.transcript == nil && !junk.isComplete && junk.errorMessage == nil, "Junk is ignored")
+    }
+}

--- a/Tests/GeminiTranscriptionTests.swift
+++ b/Tests/GeminiTranscriptionTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+enum GeminiTranscriptionTests {
+    static func run() {
+        testOnlyInteractionsCapableModelsAreRouted()
+        testGroqProviderURLIsReplacedWithGoogleHost()
+        testRequestAsksForSmartModeWithInlineAudio()
+        testVocabularyIsSplitDeduplicatedAndCapped()
+        testTranscriptIsReadFromModelOutput()
+        testFailuresSurfaceGoogleMessage()
+    }
+
+    private static func testOnlyInteractionsCapableModelsAreRouted() {
+        TestSupport.expect(GeminiTranscription.handlesModel("gemini-3.5-transcribe"), "Should route the transcribe model")
+        TestSupport.expect(GeminiTranscription.handlesModel(" GEMINI-3.5-TRANSCRIBE "), "Should tolerate spacing and case")
+
+        // The live model streams over a socket, so it must not be routed here.
+        TestSupport.expect(!GeminiTranscription.handlesModel("gemini-3.5-transcribe-live"), "Should not route the live model")
+        TestSupport.expect(!GeminiTranscription.handlesModel("whisper-large-v3"), "Should leave Whisper on the Groq path")
+        TestSupport.expect(!GeminiTranscription.handlesModel("gemini-3.5-flash"), "Should not route non-transcribe Gemini models")
+    }
+
+    private static func testGroqProviderURLIsReplacedWithGoogleHost() {
+        TestSupport.expectEqual(
+            GeminiTranscription.resolvedBaseURL(from: "https://api.groq.com/openai/v1"),
+            GeminiTranscription.defaultBaseURL
+        )
+        TestSupport.expectEqual(GeminiTranscription.resolvedBaseURL(from: ""), GeminiTranscription.defaultBaseURL)
+        TestSupport.expectEqual(
+            GeminiTranscription.resolvedBaseURL(from: "https://generativelanguage.googleapis.com/v1beta"),
+            "https://generativelanguage.googleapis.com/v1beta"
+        )
+
+        TestSupport.expectEqual(
+            GeminiTranscription.endpoint(baseURL: URL(string: "https://generativelanguage.googleapis.com/v1beta")!)
+                .absoluteString,
+            "https://generativelanguage.googleapis.com/v1beta/interactions"
+        )
+    }
+
+    private static func testRequestAsksForSmartModeWithInlineAudio() {
+        let audio = Data([0x01, 0x02, 0x03])
+        let body = try! GeminiTranscription.requestBody(
+            model: "gemini-3.5-transcribe",
+            audioData: audio,
+            mimeType: "audio/wav",
+            customVocabulary: "FreeFlow, Groq"
+        )
+        let json = try! JSONSerialization.jsonObject(with: body) as! [String: Any]
+
+        TestSupport.expectEqual(json["model"] as? String, "gemini-3.5-transcribe")
+
+        let input = (json["input"] as? [[String: Any]]) ?? []
+        TestSupport.expectEqual(input.count, 1)
+        TestSupport.expectEqual(input.first?["type"] as? String, "audio")
+        TestSupport.expectEqual(input.first?["mime_type"] as? String, "audio/wav")
+        TestSupport.expectEqual(input.first?["data"] as? String, audio.base64EncodedString())
+
+        let config = ((json["generation_config"] as? [String: Any])?["transcription_config"]) as? [String: Any]
+        TestSupport.expectEqual((config?["mode"] as? [String: Any])?["type"] as? String, "smart")
+        TestSupport.expectEqual(config?["custom_vocabulary"] as? [String], ["FreeFlow", "Groq"])
+
+        // Pinning a language was observed to drop smart mode back to verbatim
+        // output, which would silently undo the cleanup this model is used for.
+        TestSupport.expect(config?["language_codes"] == nil, "Should let Gemini auto-detect the language")
+
+        // Smart mode rejects these, so they must never be sent.
+        TestSupport.expect((config?["mode"] as? [String: Any])?["timestamp_granularities"] == nil, "No timestamps in smart mode")
+        TestSupport.expect((config?["mode"] as? [String: Any])?["diarization_mode"] == nil, "No diarization in smart mode")
+    }
+
+    private static func testVocabularyIsSplitDeduplicatedAndCapped() {
+        TestSupport.expectEqual(
+            GeminiTranscription.vocabularyTerms(from: "Kubernetes\nBigQuery; Groq , Groq"),
+            ["Kubernetes", "BigQuery", "Groq"]
+        )
+        TestSupport.expectEqual(GeminiTranscription.vocabularyTerms(from: "  ,  ;  \n "), [])
+
+        let oversized = (1...1200).map { "term\($0)" }.joined(separator: ",")
+        TestSupport.expectEqual(GeminiTranscription.vocabularyTerms(from: oversized).count, 1000)
+
+        // An empty vocabulary must be omitted rather than sent as an empty list.
+        let body = try! GeminiTranscription.requestBody(
+            model: "gemini-3.5-transcribe",
+            audioData: Data([0x00]),
+            mimeType: "audio/wav",
+            customVocabulary: ""
+        )
+        let json = try! JSONSerialization.jsonObject(with: body) as! [String: Any]
+        let config = ((json["generation_config"] as? [String: Any])?["transcription_config"]) as? [String: Any]
+        TestSupport.expect(config?["custom_vocabulary"] == nil, "Should omit an empty vocabulary")
+    }
+
+    private static func testTranscriptIsReadFromModelOutput() {
+        let payload = """
+        {"status":"completed","steps":[{"type":"model_output","content":[{"text":"  Hello there. ","type":"text"}]}]}
+        """
+        TestSupport.expectEqual(try! GeminiTranscription.transcript(fromResponse: Data(payload.utf8)), "Hello there.")
+
+        let empty = """
+        {"status":"completed","steps":[{"type":"model_output","content":[{"text":"   ","type":"text"}]}]}
+        """
+        expectThrows(Data(empty.utf8), "Empty transcripts should be rejected")
+
+        let unfinished = """
+        {"status":"failed","steps":[{"type":"model_output","content":[{"text":"partial","type":"text"}]}]}
+        """
+        expectThrows(Data(unfinished.utf8), "Non-completed interactions should be rejected")
+
+        expectThrows(Data("not json".utf8), "Unreadable payloads should be rejected")
+    }
+
+    private static func testFailuresSurfaceGoogleMessage() {
+        let quota = """
+        {"error":{"code":"resource_exhausted","message":"You exceeded your current quota."}}
+        """
+        TestSupport.expectEqual(
+            GeminiTranscription.failureMessage(fromResponse: Data(quota.utf8), fallback: "HTTP 429"),
+            "You exceeded your current quota."
+        )
+        TestSupport.expectEqual(
+            GeminiTranscription.failureMessage(fromResponse: Data("not json".utf8), fallback: "HTTP 500"),
+            "HTTP 500"
+        )
+
+        // Auth failures arrive wrapped in an array rather than as a bare object.
+        let badKey = "[{\"error\":{\"code\":400,\"message\":\"API key not valid. Please pass a valid API key.\",\"status\":\"INVALID_ARGUMENT\"}}]"
+        TestSupport.expectEqual(
+            GeminiTranscription.failureMessage(fromResponse: Data(badKey.utf8), fallback: "HTTP 400"),
+            "API key not valid. Please pass a valid API key."
+        )
+
+        // An error body carrying HTTP 200 must not be mistaken for a transcript.
+        expectThrows(Data(quota.utf8), "Error envelopes should not parse as transcripts")
+    }
+
+    private static func expectThrows(_ data: Data, _ message: String) {
+        do {
+            _ = try GeminiTranscription.transcript(fromResponse: data)
+            TestSupport.expect(false, message)
+        } catch {
+        }
+    }
+}

--- a/Tests/TestMain.swift
+++ b/Tests/TestMain.swift
@@ -4,6 +4,7 @@ import Foundation
 struct FreeFlowTests {
     static func main() {
         AppContextServiceTests.run()
+        GeminiLiveTranscriptionTests.run()
         GeminiTranscriptionTests.run()
         ModelConfigurationTests.run()
         ShortcutCoreTests.run()

--- a/Tests/TestMain.swift
+++ b/Tests/TestMain.swift
@@ -4,6 +4,7 @@ import Foundation
 struct FreeFlowTests {
     static func main() {
         AppContextServiceTests.run()
+        GeminiTranscriptionTests.run()
         ModelConfigurationTests.run()
         ShortcutCoreTests.run()
         SemanticVersionTests.run()


### PR DESCRIPTION
## Summary

Adds Google's Gemini transcription models as transcription backends alongside
the Whisper options. Both transcribe in smart mode, which removes filler words
and false starts and repairs punctuation as part of transcription, and both
accept the existing custom vocabulary as recognition biasing, so names and
jargon are biased during recognition rather than only corrected afterwards.

Two models are added, because they suit different paths:

| Model | Path | API |
| --- | --- | --- |
| `gemini-3.5-transcribe` | file upload after recording | Interactions API |
| `gemini-3.5-transcribe-live` | streams while the user speaks | Live API socket |

They map onto FreeFlow's two existing model settings, so **no new preferences
are introduced**: the live model goes in the realtime streaming model, the batch
model in the transcription model, where it also serves as the socket's fallback.

User-visible changes:

- `gemini-3.5-transcribe` appears in the transcription model picker; the live
  model is typed into the existing realtime streaming model field.
- Either requires only a transcription API key; the transcription API URL can
  stay empty, since Gemini is routed to Google automatically.
- An OpenAI-compatible realtime socket is still skipped when a Gemini batch
  model is selected, since the key cannot authenticate it.
- README gains a "Using Gemini Transcribe" section covering both models.

## Why

FreeFlow currently spends two API round trips per dictation: one to transcribe,
one to clean the transcript up. Gemini's smart mode does both in one step, which
removes a round trip from the hot path and lets users who enable **preserve
exact wording** run dictation against one provider with one key.

Neither model can be reached through the existing "custom model and API URL"
settings, because neither is OpenAI-compatible:

- The batch model runs on `POST /v1beta/interactions`. Calling it through
  `generateContent` returns HTTP 200 with an empty result, and Google's
  OpenAI-compatibility route `/v1beta/openai/audio/transcriptions` also returns
  empty.
- The live model runs on the Live API socket and exchanges
  `setup` / `realtimeInput` / `serverContent` frames, rather than the
  `session.update` / `input_audio_buffer.*` events `RealtimeTranscriptionService`
  sends. Hence a sibling service behind a shared `RealtimeTranscriptBackend`
  protocol rather than a variant of the existing one.
- Both authenticate with `x-goog-api-key` rather than a bearer token.

**Why both, rather than just the batch model:** on the free tier the batch model
allows roughly 25 requests per day, which is about 25 dictations. The live model
is bounded by tokens per minute instead, which a single speaker cannot
realistically exhaust. Shipping only the batch model would look like Gemini
support while running out within a day of normal use.

No issue exists for this; I did not find prior discussion in issues or PRs.

## Verification

- [x] `make check`
- [x] `git diff --check`
- [x] Focused regression test added or updated, or no-test reason documented below
- [x] Manual app verification completed, if required

`Tests/GeminiTranscriptionTests.swift` covers batch model routing, provider URL
substitution, request shape, vocabulary parsing, transcript extraction, and both
error-envelope shapes. `Tests/GeminiLiveTranscriptionTests.swift` covers live
model routing, socket URL derivation, the setup frame, audio framing, and server
frame classification, and asserts the two routers never both claim a model.
`Sources/GeminiTranscription.swift`, `Sources/GeminiLiveTranscription.swift` and
`Sources/TranscriptionService.swift` were added to `TEST_PRODUCTION_SOURCES`.

Manual verification performed:

Built with `make ARCH="$(uname -m)" CODESIGN_IDENTITY=-` and ran the bundle.
Configured a Google AI Studio key in the transcription API key field, leaving the
transcription API URL empty. Dictated with the hold shortcut into a text field
and confirmed the text was inserted at the cursor, first with the batch model,
then with realtime streaming enabled and the live model set.

With **preserve exact wording** enabled, pipeline history recorded the raw
transcript already punctuated and free of filler, with status
`Preserved exact wording, skipped post-processing` — confirming the cleanup came
from transcription itself and no cleanup model was called.

Both services were also exercised directly against the live API with a
deliberately disfluent recording:

- Verbatim output retained the filler words on both models; smart mode returned
  the same sentence de-filled and punctuated on both.
- An invalid key surfaced Google's own message on the batch path, and a named
  connection error on the live path.
- The live service was fed 100 ms PCM chunks in real time, matching how
  `AudioRecorder` streams, and returned the transcript on stream end.

## Risk and privacy

- [x] No real API keys, audio, transcripts, screenshots, selected text,
      clipboard contents, window titles, or private provider URLs are included
- [ ] Data sent to providers is unchanged, or the change is explained below
- [x] Credential and Keychain behavior is unchanged, or explained below
- [x] macOS permissions and entitlements are unchanged, or explained below
- [x] Preferences and pipeline-history compatibility are unchanged, or
      explained below
- [x] Signing, notarization, updates, and GitHub workflows are unchanged, or
      explained below

Risk notes:

**Data sent to providers changes, but only on explicit opt-in.** When and only
when a user selects a Gemini transcription model, recorded audio and the custom
vocabulary are sent to `generativelanguage.googleapis.com` instead of the
configured provider. On the live path the audio is streamed while the user
speaks rather than uploaded afterwards. The key travels in a header, so it never
appears in a URL or a log line. Users who do not select the model are unaffected: the Groq
path is untouched, and existing installs keep their current model. This is the
first Google endpoint FreeFlow talks to, so it is worth a maintainer's judgement
on whether the README note is sufficient disclosure.

The credential mechanism is unchanged — the existing transcription API key
setting is reused, with no new storage or migration. Entitlements, permissions,
signing, notarization, updates and workflows are untouched. The only preferences
change is a new valid value for the existing `transcription_model` key, so
downgrades keep working; pipeline history is unchanged.

Four behaviours found while testing are encoded deliberately and are worth
review attention:

- **Language is not pinned.** Sending `language_codes` was observed to drop the
  model back to verbatim output, silently undoing the cleanup the model is being
  used for. Auto-detection handles the dictated language, including
  code-switching. The consequence is that the existing transcription-language
  setting has no effect on the Gemini path.
- **Error envelopes have two shapes.** Auth failures arrive wrapped in a JSON
  array while parameter and quota failures arrive as a bare object. Both are
  read so Google's message is surfaced instead of a generic status.
- **The live socket streams 24 kHz, not the documented 16 kHz.** The recorder's
  out-of-band PCM stream is already 24 kHz for the existing realtime path. The
  model accepts it as long as the frames declare the real rate, so the recorder
  is untouched and the rate is passed through instead.
- **A rejected key fails during the HTTP upgrade** on the live path, so no error
  frame ever arrives and the socket reports a bare POSIX "Socket is not
  connected". Any failure before `setupComplete` is therefore reported as a
  connection problem naming the key.

Rollback is switching the models back to the Whisper options, or reverting these
commits; nothing persists that would outlive either.

## Screenshots

Not applicable — the only UI change is an additional entry in the existing
transcription model picker.
