### PR TITLE
Add managed on-device Parakeet transcription

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -106,10 +106,10 @@ jobs:
 
       # --- Build universal dev app ---
       - name: Build universal
-        run: make ARCH=universal CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
+        run: make ARCH=universal CODESIGN_IDENTITY="$CODESIGN_IDENTITY" INCLUDE_LOCAL_ASR=1
 
       - name: Create universal DMG
-        run: make dmg ARCH=universal CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
+        run: make dmg ARCH=universal CODESIGN_IDENTITY="$CODESIGN_IDENTITY" INCLUDE_LOCAL_ASR=1
 
       - name: Sign universal DMG
         run: codesign --force --sign "$CODESIGN_IDENTITY" "build/FreeFlow Dev.dmg"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,10 @@ jobs:
 
       # --- Build universal ---
       - name: Build universal
-        run: make ARCH=universal APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
+        run: make ARCH=universal APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY="$CODESIGN_IDENTITY" INCLUDE_LOCAL_ASR=1
 
       - name: Create universal DMG
-        run: make dmg ARCH=universal APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
+        run: make dmg ARCH=universal APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY="$CODESIGN_IDENTITY" INCLUDE_LOCAL_ASR=1
 
       - name: Sign universal DMG
         run: codesign --force --sign "$CODESIGN_IDENTITY" build/FreeFlow.dmg

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ empty :=
 space := $(empty) $(empty)
 APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
 APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
+LOCAL_ASR_DIR = $(BUILD_DIR)/local-asr
+LOCAL_ASR_HELPER = $(LOCAL_ASR_DIR)/freeflow-local-asr
 
 SOURCES = $(shell find Sources -name '*.swift' -type f | LC_ALL=C sort)
 TEST_RUNNER = $(BUILD_DIR)/FreeFlowTests
@@ -17,6 +19,9 @@ TEST_PRODUCTION_SOURCES = \
 	Sources/AppName.swift \
 	Sources/LLMAPITransport.swift \
 	Sources/LLMCooldownManager.swift \
+	Sources/LocalParakeetModelManager.swift \
+	Sources/LocalParakeetTranscriptionService.swift \
+	Sources/LocalTranscriptionPolicy.swift \
 	Sources/ModelConfiguration.swift \
 	Sources/TranscriptTextCore.swift \
 	Sources/UpdateManager.swift \
@@ -24,7 +29,7 @@ TEST_PRODUCTION_SOURCES = \
 	Sources/ShortcutCore/ShortcutMatcher.swift \
 	Sources/ShortcutCore/ShortcutModels.swift
 TEST_SOURCES = $(shell find Tests -name '*.swift' -type f | LC_ALL=C sort)
-SHELL_SCRIPTS = $(shell find .github/scripts .agents/skills -name '*.sh' -type f | LC_ALL=C sort)
+SHELL_SCRIPTS = $(shell find .github/scripts .agents/skills scripts -name '*.sh' -type f | LC_ALL=C sort)
 YAML_FILES = $(shell find .github -type f \( -name '*.yml' -o -name '*.yaml' \) | LC_ALL=C sort)
 RESOURCES = $(CONTENTS)/Resources
 ARCH ?= $(shell uname -m)
@@ -44,7 +49,10 @@ endif
 
 all: $(APP_EXECUTABLE_TARGET)
 
-$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS)
+$(LOCAL_ASR_HELPER): scripts/build-local-asr-helper.sh
+	@./scripts/build-local-asr-helper.sh "$(LOCAL_ASR_DIR)"
+
+$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(LOCAL_ASR_HELPER)
 	@mkdir -p "$(MACOS_DIR)" "$(RESOURCES)"
 ifeq ($(ARCH),universal)
 	swiftc \
@@ -80,6 +88,11 @@ endif
 	@plutil -replace NSMicrophoneUsageDescription -string "$(APP_NAME) needs microphone access to transcribe your speech." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSSpeechRecognitionUsageDescription -string "$(APP_NAME) needs speech recognition to convert your voice to text." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSAccessibilityUsageDescription -string "$(APP_NAME) needs accessibility access to detect the text cursor position and paste transcribed text." "$(CONTENTS)/Info.plist"
+	@cp "$(LOCAL_ASR_HELPER)" "$(MACOS_DIR)/freeflow-local-asr"
+	@mkdir -p "$(RESOURCES)/ThirdPartyLicenses"
+	@cp -f "$(LOCAL_ASR_DIR)/licenses/"* "$(RESOURCES)/ThirdPartyLicenses/"
+	@cp -f Resources/LocalASR-Third-Party-Notices.txt "$(RESOURCES)/ThirdPartyLicenses/"
+	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" "$(MACOS_DIR)/freeflow-local-asr"
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,15 @@ APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
 APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
 LOCAL_ASR_DIR = $(BUILD_DIR)/local-asr
 LOCAL_ASR_HELPER = $(LOCAL_ASR_DIR)/freeflow-local-asr
+LOCAL_ASR_LICENSES = \
+	$(LOCAL_ASR_DIR)/licenses/parakeet-coreml-swift-APACHE-2.0.txt \
+	$(LOCAL_ASR_DIR)/licenses/swift-argument-parser-APACHE-2.0.txt
+LOCAL_ASR_BUILD_STAMP = $(LOCAL_ASR_DIR)/.built
+LOCAL_ASR_CONFIG_STAMP = $(BUILD_DIR)/.include-local-asr
 INCLUDE_LOCAL_ASR ?= 0
 
 ifeq ($(INCLUDE_LOCAL_ASR),1)
-LOCAL_ASR_PREREQUISITES = $(LOCAL_ASR_HELPER) Resources/LocalASR-Third-Party-Notices.txt
+LOCAL_ASR_PREREQUISITES = $(LOCAL_ASR_BUILD_STAMP) Resources/LocalASR-Third-Party-Notices.txt
 endif
 
 SOURCES = $(shell find Sources -name '*.swift' -type f | LC_ALL=C sort)
@@ -50,16 +55,29 @@ ICON_SOURCE = Resources/AppIcon-Source.png
 ICON_ICNS = Resources/AppIcon.icns
 endif
 
-.PHONY: all check clean run icon local-asr dmg codesign-dmg notarize test typecheck validate
+.PHONY: all check clean run icon local-asr dmg codesign-dmg notarize test typecheck validate FORCE
 
 all: $(APP_EXECUTABLE_TARGET)
 
-$(LOCAL_ASR_HELPER): scripts/build-local-asr-helper.sh Resources/LocalASR-Package.resolved
-	@./scripts/build-local-asr-helper.sh "$(LOCAL_ASR_DIR)"
+FORCE:
 
-local-asr: $(LOCAL_ASR_HELPER)
+$(LOCAL_ASR_CONFIG_STAMP): FORCE
+	@mkdir -p "$(BUILD_DIR)"
+	@printf '%s\n' '$(INCLUDE_LOCAL_ASR)' | cmp -s - "$@" || printf '%s\n' '$(INCLUDE_LOCAL_ASR)' > "$@"
 
-$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(LOCAL_ASR_PREREQUISITES)
+$(LOCAL_ASR_BUILD_STAMP): FORCE scripts/build-local-asr-helper.sh Resources/LocalASR-Package.resolved
+	@if [ ! -x "$(LOCAL_ASR_HELPER)" ] \
+		|| [ ! -f "$(word 1,$(LOCAL_ASR_LICENSES))" ] \
+		|| [ ! -f "$(word 2,$(LOCAL_ASR_LICENSES))" ] \
+		|| [ ! -f "$@" ] \
+		|| [ scripts/build-local-asr-helper.sh -nt "$@" ] \
+		|| [ Resources/LocalASR-Package.resolved -nt "$@" ]; then \
+		./scripts/build-local-asr-helper.sh "$(LOCAL_ASR_DIR)" && touch "$@"; \
+	fi
+
+local-asr: $(LOCAL_ASR_BUILD_STAMP)
+
+$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(LOCAL_ASR_CONFIG_STAMP) $(LOCAL_ASR_PREREQUISITES)
 	@mkdir -p "$(MACOS_DIR)" "$(RESOURCES)"
 ifeq ($(ARCH),universal)
 	swiftc \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
 APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
 LOCAL_ASR_DIR = $(BUILD_DIR)/local-asr
 LOCAL_ASR_HELPER = $(LOCAL_ASR_DIR)/freeflow-local-asr
+INCLUDE_LOCAL_ASR ?= 0
+
+ifeq ($(INCLUDE_LOCAL_ASR),1)
+LOCAL_ASR_PREREQUISITES = $(LOCAL_ASR_HELPER) Resources/LocalASR-Third-Party-Notices.txt
+endif
 
 SOURCES = $(shell find Sources -name '*.swift' -type f | LC_ALL=C sort)
 TEST_RUNNER = $(BUILD_DIR)/FreeFlowTests
@@ -45,14 +50,16 @@ ICON_SOURCE = Resources/AppIcon-Source.png
 ICON_ICNS = Resources/AppIcon.icns
 endif
 
-.PHONY: all check clean run icon dmg codesign-dmg notarize test typecheck validate
+.PHONY: all check clean run icon local-asr dmg codesign-dmg notarize test typecheck validate
 
 all: $(APP_EXECUTABLE_TARGET)
 
-$(LOCAL_ASR_HELPER): scripts/build-local-asr-helper.sh
+$(LOCAL_ASR_HELPER): scripts/build-local-asr-helper.sh Resources/LocalASR-Package.resolved
 	@./scripts/build-local-asr-helper.sh "$(LOCAL_ASR_DIR)"
 
-$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(LOCAL_ASR_HELPER)
+local-asr: $(LOCAL_ASR_HELPER)
+
+$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(LOCAL_ASR_PREREQUISITES)
 	@mkdir -p "$(MACOS_DIR)" "$(RESOURCES)"
 ifeq ($(ARCH),universal)
 	swiftc \
@@ -88,11 +95,18 @@ endif
 	@plutil -replace NSMicrophoneUsageDescription -string "$(APP_NAME) needs microphone access to transcribe your speech." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSSpeechRecognitionUsageDescription -string "$(APP_NAME) needs speech recognition to convert your voice to text." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSAccessibilityUsageDescription -string "$(APP_NAME) needs accessibility access to detect the text cursor position and paste transcribed text." "$(CONTENTS)/Info.plist"
+ifeq ($(INCLUDE_LOCAL_ASR),1)
 	@cp "$(LOCAL_ASR_HELPER)" "$(MACOS_DIR)/freeflow-local-asr"
 	@mkdir -p "$(RESOURCES)/ThirdPartyLicenses"
 	@cp -f "$(LOCAL_ASR_DIR)/licenses/"* "$(RESOURCES)/ThirdPartyLicenses/"
 	@cp -f Resources/LocalASR-Third-Party-Notices.txt "$(RESOURCES)/ThirdPartyLicenses/"
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" "$(MACOS_DIR)/freeflow-local-asr"
+else
+	@rm -f "$(MACOS_DIR)/freeflow-local-asr" \
+		"$(RESOURCES)/ThirdPartyLicenses/LocalASR-Third-Party-Notices.txt" \
+		"$(RESOURCES)/ThirdPartyLicenses/parakeet-coreml-swift-APACHE-2.0.txt" \
+		"$(RESOURCES)/ThirdPartyLicenses/swift-argument-parser-APACHE-2.0.txt"
+endif
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ transcript is pasted directly, apart from a narrow deterministic repair for a
 known decoder punctuation artifact. Voice macros remain available because
 they are deterministic and local.
 
+Signed release workflows include the helper. Source builds remain
+network-independent by default; pass `INCLUDE_LOCAL_ASR=1` to `make` when you
+want to fetch, build, and bundle the pinned local helper.
+
 <details>
   <summary>Configure longer timeouts for local models</summary>
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ On Apple silicon Macs running macOS 15 or newer, enable **On-Device
 Transcription** in General Settings. FreeFlow downloads and verifies the
 approximately 459 MiB Parakeet TDT 0.6B v3 Core ML model, shows setup progress,
 and prepares it before the first dictation. The same Settings card can remove
-the model and its compiled cache.
+the model and its compiled cache. When a local recording starts, FreeFlow
+warms Core ML with generated silence so cold-start time overlaps the dictation.
 
 While on-device transcription is enabled, dictated audio and text do not go to
 a provider. Screenshot context, realtime streaming, translation, Edit Mode,

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ FreeFlow can use OpenAI-compatible local or self-hosted providers instead of Gro
 
 Local models are often slower than hosted providers, especially on cold start, long recordings, or busy hardware.
 
+### Built-in on-device transcription
+
+On Apple silicon Macs running macOS 15 or newer, enable **On-Device
+Transcription** in General Settings. FreeFlow downloads and verifies the
+approximately 459 MiB Parakeet TDT 0.6B v3 Core ML model, shows setup progress,
+and prepares it before the first dictation. The same Settings card can remove
+the model and its compiled cache.
+
+While on-device transcription is enabled, dictated audio and text do not go to
+a provider. Screenshot context, realtime streaming, translation, Edit Mode,
+and language-model cleanup are skipped at the code-path level. The raw local
+transcript is pasted directly, apart from a narrow deterministic repair for a
+known decoder punctuation artifact. Voice macros remain available because
+they are deterministic and local.
+
 <details>
   <summary>Configure longer timeouts for local models</summary>
 

--- a/Resources/LocalASR-Package.resolved
+++ b/Resources/LocalASR-Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "eec5234fc92976ec0b2e42a75ffeca2ec0c5093df8289c2eb0671e2f7091e807",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Resources/LocalASR-Third-Party-Notices.txt
+++ b/Resources/LocalASR-Third-Party-Notices.txt
@@ -1,0 +1,18 @@
+FreeFlow uses the following third-party components for on-device transcription:
+
+parakeet-coreml-swift
+Copyright its contributors; licensed under Apache License 2.0.
+Source: https://github.com/mweinbach/parakeet-coreml-swift
+Pinned version: v0.1.1 (75aec2a1c991319657ff4dec5f602c12da6c5012)
+
+swift-argument-parser
+Copyright Apple Inc. and the Swift project authors; licensed under Apache License 2.0.
+Source: https://github.com/apple/swift-argument-parser
+
+Parakeet TDT 0.6B v3 model weights
+Copyright NVIDIA; licensed under Creative Commons Attribution 4.0.
+Source: https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3
+Core ML conversion: https://huggingface.co/mweinbach1/parakeet-tdt-0.6b-v3-coreml
+
+The complete Apache 2.0 license texts for the bundled executable are included
+next to this notice in the app's ThirdPartyLicenses resource directory.

--- a/Resources/LocalASR-Third-Party-Notices.txt
+++ b/Resources/LocalASR-Third-Party-Notices.txt
@@ -8,6 +8,7 @@ Pinned version: v0.1.1 (75aec2a1c991319657ff4dec5f602c12da6c5012)
 swift-argument-parser
 Copyright Apple Inc. and the Swift project authors; licensed under Apache License 2.0.
 Source: https://github.com/apple/swift-argument-parser
+Pinned version: 1.8.2 (6a52f3251125d74daf04fcbd5e6f08a75d074382)
 
 Parakeet TDT 0.6B v3 model weights
 Copyright NVIDIA; licensed under Creative Commons Attribution 4.0.

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -607,6 +607,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var debugOverlayTimer: Timer?
     private var recordingInitializationTimer: DispatchSourceTimer?
     private var transcriptionTask: Task<Void, Never>?
+    private var localTranscriptionWarmupTask: Task<Void, Never>?
     private var transcribingAudioFileName: String?
     private var contextService: AppContextService
     private var contextCaptureTask: Task<AppContext?, Never>?
@@ -1834,6 +1835,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         statusText = "Cancelled"
         overlayManager.dismiss()
         tearDownRealtimeService()
+        cancelLocalTranscriptionWarmup()
         audioRecorder.cancelRecording()
         restoreAudioInterruptionIfNeeded()
         endCriticalDictationActivity()
@@ -1848,6 +1850,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         transcriptionTask?.cancel()
         transcriptionTask = nil
+        cancelLocalTranscriptionWarmup()
         contextCaptureTask?.cancel()
         contextCaptureTask = nil
         capturedContext = nil
@@ -2212,6 +2215,29 @@ final class AppState: ObservableObject, @unchecked Sendable {
         automaticTerminationDisabled = false
     }
 
+    private func startLocalTranscriptionWarmupIfNeeded() {
+        guard localTranscriptionPolicy.isEnabled,
+              localParakeetModelManager.store.isInstalled,
+              localTranscriptionWarmupTask == nil,
+              let service = try? LocalParakeetTranscriptionService(
+                  modelDirectory: localParakeetModelManager.store.modelDirectory
+              ) else { return }
+        localTranscriptionWarmupTask = Task(priority: .userInitiated) {
+            try? await service.prewarm()
+        }
+    }
+
+    private func finishLocalTranscriptionWarmupIfNeeded() async {
+        guard let task = localTranscriptionWarmupTask else { return }
+        await task.value
+        localTranscriptionWarmupTask = nil
+    }
+
+    private func cancelLocalTranscriptionWarmup() {
+        localTranscriptionWarmupTask?.cancel()
+        localTranscriptionWarmupTask = nil
+    }
+
     private func beginRecording(triggerMode: RecordingTriggerMode) {
         os_log(.info, log: recordingLog, "beginRecording() entered")
         beginCriticalDictationActivity()
@@ -2221,6 +2247,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isRecording = true
         statusText = "Starting..."
         hasShownScreenshotPermissionAlert = false
+        startLocalTranscriptionWarmupIfNeeded()
 
         // Show initializing dots only if engine takes longer than 0.2s to start
         var overlayShown = false
@@ -2310,6 +2337,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         contextCaptureTask = nil
         capturedContext = nil
         tearDownRealtimeService()
+        cancelLocalTranscriptionWarmup()
         audioRecorder.cleanup()
         restoreAudioInterruptionIfNeeded()
         isRecording = false
@@ -2691,6 +2719,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioRecorder.stopRecording { [weak self] fileURL in
             guard let self else { return }
             guard let fileURL else {
+                self.cancelLocalTranscriptionWarmup()
                 self.isTranscribing = false
                 self.audioRecorder.cleanup()
                 self.endCriticalDictationActivity()
@@ -2702,6 +2731,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
 
             guard self.isTranscribing else {
+                self.cancelLocalTranscriptionWarmup()
                 self.tearDownRealtimeService()
                 self.audioRecorder.cleanup()
                 self.refreshAvailableMicrophonesIfNeeded()
@@ -2742,6 +2772,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     activeRealtime?.cancel()
                 }
                 do {
+                    await self.finishLocalTranscriptionWarmupIfNeeded()
+                    try Task.checkCancellation()
                     let transcriptionService = try self.makeTranscriptionService()
                     async let transcript = Self.resolveRawTranscript(
                         realtimeService: activeRealtime,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -236,6 +236,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
+    private let localTranscriptionEnabledStorageKey = "local_transcription_enabled"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
     private let clipboardRestoreDelay: TimeInterval = 1.0
@@ -319,6 +320,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var transcriptionModel: String {
         didSet {
             UserDefaults.standard.set(transcriptionModel, forKey: transcriptionModelStorageKey)
+        }
+    }
+
+    @Published var localTranscriptionEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(localTranscriptionEnabled, forKey: localTranscriptionEnabledStorageKey)
         }
     }
 
@@ -594,6 +601,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     let audioRecorder = AudioRecorder()
     let hotkeyManager = HotkeyManager()
     let overlayManager = RecordingOverlayManager()
+    let localParakeetModelManager = LocalParakeetModelManager()
     private var accessibilityTimer: Timer?
     private var audioLevelCancellable: AnyCancellable?
     private var debugOverlayTimer: Timer?
@@ -634,6 +642,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let transcriptionModel = UserDefaults.standard.string(forKey: transcriptionModelStorageKey) ?? Self.defaultTranscriptionModel
         let transcriptionAPIURL = Self.loadOptionalStoredAPIValue(account: transcriptionAPIURLStorageKey)
         let transcriptionAPIKey = Self.loadStoredAPIKey(account: transcriptionAPIKeyStorageKey)
+        let localTranscriptionEnabled = UserDefaults.standard.bool(forKey: localTranscriptionEnabledStorageKey)
         let postProcessingModel = UserDefaults.standard.string(forKey: postProcessingModelStorageKey) ?? Self.defaultPostProcessingModel
         let postProcessingFallbackModel = Self.loadStoredPostProcessingFallbackModel(
             key: postProcessingFallbackModelStorageKey
@@ -739,6 +748,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.transcriptionAPIURL = transcriptionAPIURL
         self.transcriptionAPIKey = transcriptionAPIKey
         self.transcriptionModel = transcriptionModel
+        self.localTranscriptionEnabled = localTranscriptionEnabled
         self.postProcessingModel = postProcessingModel
         self.postProcessingFallbackModel = postProcessingFallbackModel
         self.contextModel = contextModel
@@ -1032,7 +1042,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func makeTranscriptionService() throws -> TranscriptionService {
-        try TranscriptionService(
+        if localTranscriptionPolicy.isEnabled {
+            guard localParakeetModelManager.store.isInstalled else {
+                throw LocalParakeetError.modelUnavailable
+            }
+            return try TranscriptionService(
+                localParakeetModelDirectory: localParakeetModelManager.store.modelDirectory,
+                language: resolvedTranscriptionLanguage
+            )
+        }
+        return try TranscriptionService(
             apiKey: resolvedTranscriptionAPIKey,
             baseURL: resolvedTranscriptionBaseURL,
             transcriptionModel: transcriptionModel,
@@ -1043,6 +1062,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var resolvedTranscriptionLanguage: String? {
         let normalized = Self.normalizeTranscriptionLanguage(transcriptionLanguage)
         return normalized.isEmpty ? nil : normalized
+    }
+
+    private var localTranscriptionPolicy: LocalTranscriptionPolicy {
+        LocalTranscriptionPolicy(isEnabled: localTranscriptionEnabled)
     }
 
     private func persistShortcut(_ binding: ShortcutBinding, key: String) {
@@ -1851,10 +1874,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func scheduleShortcutStart(mode: RecordingTriggerMode) {
         cancelPendingShortcutStart(resetMode: false)
-        pendingSelectionSnapshot = contextService.collectSelectionSnapshot()
-        pendingManualCommandInvocation = hotkeyManager.currentPressedModifiers.contains(
-            commandModeManualModifier.shortcutModifier
-        )
+        if localTranscriptionPolicy.allowsContextCapture {
+            pendingSelectionSnapshot = contextService.collectSelectionSnapshot()
+            pendingManualCommandInvocation = hotkeyManager.currentPressedModifiers.contains(
+                commandModeManualModifier.shortcutModifier
+            )
+        } else {
+            pendingSelectionSnapshot = nil
+            pendingManualCommandInvocation = false
+        }
         pendingShortcutStartMode = mode
         let delay = shortcutStartDelay
 
@@ -2008,6 +2036,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
         }
 
+        if localTranscriptionPolicy.isEnabled {
+            // On-device mode deliberately ignores Edit Mode and selected text:
+            // both would otherwise enter the cloud LLM/context path.
+            currentSessionIntent = .dictation
+            hasScreenRecordingPermission = false
+            overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
+            return true
+        }
+
         let selectionSnapshot = selectionSnapshot ?? contextService.collectSelectionSnapshot()
         let manualCommandRequested = manualCommandRequested
             ?? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
@@ -2061,7 +2098,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
             prepareForMicrophonePermissionPrompt(
                 triggerMode: triggerMode,
-                selectionSnapshot: pendingSelectionSnapshot ?? contextService.collectSelectionSnapshot(),
+                selectionSnapshot: localTranscriptionPolicy.allowsContextCapture
+                    ? (pendingSelectionSnapshot ?? contextService.collectSelectionSnapshot())
+                    : nil,
                 manualCommandRequested: currentSessionIntent.isManualCommand
             )
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
@@ -2516,6 +2555,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return ("", .skippedEmptyRawTranscript, "")
         }
 
+        // On-device transcription is a hard privacy boundary, not merely a UI preset.
+        // Never let a stored Edit Mode/output-language setting route audio or
+        // text into the cloud pipeline. Deterministic voice macros remain local.
+        if !localTranscriptionPolicy.allowsLanguageModelProcessing {
+            if let macro = findMatchingMacro(for: trimmedRawTranscript) {
+                return (macro.payload, .voiceMacro(command: macro.command), "")
+            }
+            return (trimmedRawTranscript, .preservedExactWording, "")
+        }
+
         if case .command(let invocation, let selectedText) = intent {
             do {
                 let result = try await postProcessingService.commandTransform(
@@ -2716,7 +2765,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         }
                     }
                     let appContext: AppContext
-                    if let sessionContext {
+                    if !self.localTranscriptionPolicy.allowsContextCapture {
+                        appContext = self.onDeviceContext()
+                    } else if let sessionContext {
                         appContext = sessionContext
                     } else if let inFlightContext = await inFlightContextTask?.value {
                         appContext = inFlightContext
@@ -2927,6 +2978,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func startRealtimeStreamingIfEnabled() {
+        guard localTranscriptionPolicy.allowsRealtimeStreaming else { return }
         guard realtimeStreamingEnabled else { return }
         let trimmedBase = resolvedTranscriptionBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedBase.isEmpty else {
@@ -2960,6 +3012,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func startContextCapture() {
+        guard localTranscriptionPolicy.allowsContextCapture else {
+            capturedContext = nil
+            contextCaptureTask = nil
+            lastContextSummary = "On-device transcription; app context is disabled."
+            lastContextScreenshotDataURL = nil
+            lastContextScreenshotStatus = "Disabled for on-device transcription"
+            lastContextAppName = ""
+            lastContextBundleIdentifier = ""
+            lastContextWindowTitle = ""
+            lastContextSelectedText = ""
+            lastContextLLMPrompt = ""
+            lastPostProcessingStatus = "Cloud processing disabled"
+            return
+        }
         contextCaptureTask?.cancel()
         capturedContext = nil
         lastContextSummary = "Collecting app context..."
@@ -3002,6 +3068,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
             screenshotDataURL: nil,
             screenshotMimeType: nil,
             screenshotError: "No app context captured before stop"
+        )
+    }
+
+    private func onDeviceContext() -> AppContext {
+        AppContext(
+            appName: nil,
+            bundleIdentifier: nil,
+            windowTitle: nil,
+            selectedText: nil,
+            currentActivity: "On-device transcription; app context is disabled.",
+            contextSystemPrompt: nil,
+            contextPrompt: nil,
+            screenshotDataURL: nil,
+            screenshotMimeType: nil,
+            screenshotError: "Disabled for on-device transcription"
         )
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1069,6 +1069,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         LocalTranscriptionPolicy(isEnabled: localTranscriptionEnabled)
     }
 
+    var requiresScreenRecordingPermission: Bool {
+        localTranscriptionPolicy.allowsContextCapture
+    }
+
     private func persistShortcut(_ binding: ShortcutBinding, key: String) {
         let normalizedBinding = binding.normalizedForStorageMigration()
         guard let data = try? JSONEncoder().encode(normalizedBinding) else { return }
@@ -1335,16 +1339,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         accessibilityTimer?.invalidate()
         accessibilityTimer = nil
         hasAccessibility = AXIsProcessTrusted()
-        hasScreenRecordingPermission = hasScreenCapturePermission()
-        if hasAccessibility && hasScreenRecordingPermission {
+        if requiresScreenRecordingPermission {
+            hasScreenRecordingPermission = hasScreenCapturePermission()
+        }
+        if hasAccessibility && (!requiresScreenRecordingPermission || hasScreenRecordingPermission) {
             return
         }
         accessibilityTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.hasAccessibility = AXIsProcessTrusted()
-                self.hasScreenRecordingPermission = self.hasScreenCapturePermission()
-                if self.hasAccessibility && self.hasScreenRecordingPermission {
+                if self.requiresScreenRecordingPermission {
+                    self.hasScreenRecordingPermission = self.hasScreenCapturePermission()
+                }
+                if self.hasAccessibility
+                    && (!self.requiresScreenRecordingPermission || self.hasScreenRecordingPermission) {
                     self.accessibilityTimer?.invalidate()
                     self.accessibilityTimer = nil
                 }
@@ -3168,6 +3177,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func handleScreenshotCaptureIssue(_ message: String?) {
+        guard localTranscriptionPolicy.allowsContextCapture else { return }
         guard let message, !message.isEmpty else {
             hasShownScreenshotPermissionAlert = false
             return

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2043,7 +2043,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             // On-device mode deliberately ignores Edit Mode and selected text:
             // both would otherwise enter the cloud LLM/context path.
             currentSessionIntent = .dictation
-            hasScreenRecordingPermission = false
             overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
             return true
         }
@@ -2916,7 +2915,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     }
                 } catch {
                     let resolvedContext: AppContext
-                    if let sessionContext {
+                    if !self.localTranscriptionPolicy.allowsContextCapture {
+                        resolvedContext = self.onDeviceContext()
+                    } else if let sessionContext {
                         resolvedContext = sessionContext
                     } else if let inFlightContext = await inFlightContextTask?.value {
                         resolvedContext = inFlightContext

--- a/Sources/LocalParakeetModelManager.swift
+++ b/Sources/LocalParakeetModelManager.swift
@@ -10,7 +10,7 @@ struct LocalParakeetModelAsset: Equatable {
 
 struct LocalParakeetModelStore {
     static let repositoryDirectoryName = "mweinbach1_parakeet-tdt-0.6b-v3-coreml"
-    static let markerContents = "freeflow-parakeet-coreml-v1\n"
+    static let legacyMarkerContents = "freeflow-parakeet-coreml-v1\n"
     static let downloadByteCount: Int64 = 480_766_756
     static let pinnedAssets = [
         LocalParakeetModelAsset(
@@ -89,9 +89,12 @@ struct LocalParakeetModelStore {
         modelDirectory.appendingPathComponent(".freeflow-verified", isDirectory: false)
     }
 
+    private var compiledCacheRoot: URL {
+        cacheRoot.appendingPathComponent("mlmodelc", isDirectory: true)
+    }
+
     var isInstalled: Bool {
-        guard let marker = try? String(contentsOf: verifiedMarkerURL, encoding: .utf8),
-              marker == Self.markerContents else { return false }
+        guard installationMarker != nil else { return false }
         return assets.allSatisfy { asset in
             let url = modelDirectory.appendingPathComponent(asset.relativePath)
             let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
@@ -110,8 +113,12 @@ struct LocalParakeetModelStore {
         }
     }
 
-    func markInstalled() throws {
-        try Data(Self.markerContents.utf8).write(to: verifiedMarkerURL, options: .atomic)
+    func markInstalled(compiledCacheDirectories: Set<String> = []) throws {
+        let marker = LocalParakeetInstallationMarker(
+            version: 2,
+            compiledCacheDirectories: compiledCacheDirectories.sorted()
+        )
+        try JSONEncoder().encode(marker).write(to: verifiedMarkerURL, options: .atomic)
     }
 
     func downloadedByteCount() -> Int64 {
@@ -119,16 +126,51 @@ struct LocalParakeetModelStore {
     }
 
     func installedByteCount() -> Int64 {
-        byteCount(in: cacheRoot)
+        let compiledBytes = installationMarker?.compiledCacheDirectories.reduce(Int64(0)) { total, name in
+            guard Self.isSafeCompiledCacheName(name) else { return total }
+            return total + byteCount(in: compiledCacheRoot.appendingPathComponent(name, isDirectory: true))
+        } ?? 0
+        return byteCount(in: modelDirectory) + compiledBytes
     }
 
     func removeModel() throws {
         let fileManager = FileManager.default
-        let downloadedModels = cacheRoot.appendingPathComponent("hf-models", isDirectory: true)
-        let compiledModels = cacheRoot.appendingPathComponent("mlmodelc", isDirectory: true)
-        for url in [downloadedModels, compiledModels] where fileManager.fileExists(atPath: url.path) {
+        let compiledDirectories = installationMarker?.compiledCacheDirectories ?? []
+        if fileManager.fileExists(atPath: modelDirectory.path) {
+            try fileManager.removeItem(at: modelDirectory)
+        }
+        for name in compiledDirectories where Self.isSafeCompiledCacheName(name) {
+            let url = compiledCacheRoot.appendingPathComponent(name, isDirectory: true)
+            guard fileManager.fileExists(atPath: url.path) else { continue }
             try fileManager.removeItem(at: url)
         }
+    }
+
+    func compiledCacheDirectoryNames() -> Set<String> {
+        guard let urls = try? FileManager.default.contentsOfDirectory(
+            at: compiledCacheRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        return Set(urls.compactMap { url in
+            guard Self.isSafeCompiledCacheName(url.lastPathComponent),
+                  (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { return nil }
+            return url.lastPathComponent
+        })
+    }
+
+    private var installationMarker: LocalParakeetInstallationMarker? {
+        guard let data = try? Data(contentsOf: verifiedMarkerURL) else { return nil }
+        if let marker = try? JSONDecoder().decode(LocalParakeetInstallationMarker.self, from: data),
+           marker.version == 2 {
+            return marker
+        }
+        guard String(data: data, encoding: .utf8) == Self.legacyMarkerContents else { return nil }
+        return LocalParakeetInstallationMarker(version: 1, compiledCacheDirectories: [])
+    }
+
+    private static func isSafeCompiledCacheName(_ name: String) -> Bool {
+        name.count == 24 && name.allSatisfy { $0.isHexDigit && !$0.isUppercase }
     }
 
     private func byteCount(in directory: URL) -> Int64 {
@@ -155,6 +197,11 @@ struct LocalParakeetModelStore {
         }
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
+}
+
+private struct LocalParakeetInstallationMarker: Codable {
+    let version: Int
+    let compiledCacheDirectories: [String]
 }
 
 enum LocalParakeetModelState: Equatable {
@@ -244,12 +291,16 @@ final class LocalParakeetModelManager: ObservableObject {
                 try store.validateDownloadedModel()
             }.value
             state = .preparing
+            let compiledCacheDirectoriesBeforePreparation = store.compiledCacheDirectoryNames()
             let transcriptionService = try LocalParakeetTranscriptionService(
                 modelDirectory: store.modelDirectory,
                 executableURL: executableURL
             )
             try await transcriptionService.prewarm()
-            try store.markInstalled()
+            try store.markInstalled(
+                compiledCacheDirectories: store.compiledCacheDirectoryNames()
+                    .subtracting(compiledCacheDirectoriesBeforePreparation)
+            )
             state = .ready(store.installedByteCount())
             return true
         } catch is CancellationError {

--- a/Sources/LocalParakeetModelManager.swift
+++ b/Sources/LocalParakeetModelManager.swift
@@ -251,7 +251,7 @@ final class LocalParakeetModelManager: ObservableObject {
                 arguments: [
                     "transcribe", preparationAudio.path,
                     "--models", store.modelDirectory.path,
-                    "--compute-units", "ane",
+                    "--compute-units", LocalParakeetTranscriptionService.computeUnits,
                     "--max-seconds", "0.1",
                 ],
                 monitorsDownload: false

--- a/Sources/LocalParakeetModelManager.swift
+++ b/Sources/LocalParakeetModelManager.swift
@@ -1,0 +1,351 @@
+import Combine
+import CryptoKit
+import Foundation
+
+struct LocalParakeetModelAsset: Equatable {
+    let relativePath: String
+    let byteCount: Int64
+    let sha256: String
+}
+
+struct LocalParakeetModelStore {
+    static let repositoryDirectoryName = "mweinbach1_parakeet-tdt-0.6b-v3-coreml"
+    static let markerContents = "freeflow-parakeet-coreml-v1\n"
+    static let downloadByteCount: Int64 = 480_766_756
+    static let pinnedAssets = [
+        LocalParakeetModelAsset(
+            relativePath: "encoder.mlpackage/Data/com.apple.CoreML/model.mlmodel",
+            byteCount: 625_663,
+            sha256: "2e4e6b54f32029d7b2a69549c2cedf5cd9c6daa8e5274a2b357fc7911747204b"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "encoder.mlpackage/Data/com.apple.CoreML/weights/weight.bin",
+            byteCount: 444_016_768,
+            sha256: "23867a834223ee6484d0b7b9b703530e8606546efa8e710535163d51ed9aac04"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "encoder.mlpackage/Manifest.json",
+            byteCount: 617,
+            sha256: "9fd1153994eb4bdae923626ffc4684c6e0ce547ab393f0d15010c0c3ed14ece7"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "decoder.mlpackage/Data/com.apple.CoreML/model.mlmodel",
+            byteCount: 12_897,
+            sha256: "8d068618a9fd3a981d6cbc09ae9643a25b2e382f2c3e05d3b9412b9c25a4372e"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "decoder.mlpackage/Data/com.apple.CoreML/weights/weight.bin",
+            byteCount: 24_425_600,
+            sha256: "36cd656ebf1105ee5aa85d1e55c00f25669327aef8b39346333a19260ca78018"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "decoder.mlpackage/Manifest.json",
+            byteCount: 617,
+            sha256: "ef610fe0ccaff752f58f086772207ffb08970e67bf41fd07c923f9e006f8e4ec"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "joint.mlpackage/Data/com.apple.CoreML/model.mlmodel",
+            byteCount: 4_025,
+            sha256: "cde4d7c509e8053ec7c90d04368f2d4bb5ad8db87a28b550de80541193100a39"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "joint.mlpackage/Data/com.apple.CoreML/weights/weight.bin",
+            byteCount: 10_510_028,
+            sha256: "d83381f8a19ac296033554a7cfec355063b8f3225129cb8bed013c92f6ab141f"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "joint.mlpackage/Manifest.json",
+            byteCount: 617,
+            sha256: "977190c2261e2040f081fd0669fa3da7c4089c7d3f04c04a3c2b25e63f77f45c"
+        ),
+        LocalParakeetModelAsset(
+            relativePath: "tokenizer.json",
+            byteCount: 1_159_960,
+            sha256: "bd321b096832a3f270bd3b2a88823957920f1a5c5ada71114a26ea729d0cbe91"
+        ),
+    ]
+
+    let cacheRoot: URL
+    let assets: [LocalParakeetModelAsset]
+
+    init(cacheRoot: URL = Self.defaultCacheRoot(), assets: [LocalParakeetModelAsset] = Self.pinnedAssets) {
+        self.cacheRoot = cacheRoot
+        self.assets = assets
+    }
+
+    static func defaultCacheRoot() -> URL {
+        let cache = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return cache.appendingPathComponent("com.parakeet-tdt", isDirectory: true)
+    }
+
+    var modelDirectory: URL {
+        cacheRoot
+            .appendingPathComponent("hf-models", isDirectory: true)
+            .appendingPathComponent(Self.repositoryDirectoryName, isDirectory: true)
+    }
+
+    private var verifiedMarkerURL: URL {
+        modelDirectory.appendingPathComponent(".freeflow-verified", isDirectory: false)
+    }
+
+    var isInstalled: Bool {
+        guard let marker = try? String(contentsOf: verifiedMarkerURL, encoding: .utf8),
+              marker == Self.markerContents else { return false }
+        return assets.allSatisfy { asset in
+            let url = modelDirectory.appendingPathComponent(asset.relativePath)
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            return (attributes?[.size] as? NSNumber)?.int64Value == asset.byteCount
+        }
+    }
+
+    func validateDownloadedModel() throws {
+        for asset in assets {
+            let url = modelDirectory.appendingPathComponent(asset.relativePath)
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            guard (attributes[.size] as? NSNumber)?.int64Value == asset.byteCount,
+                  try Self.sha256(of: url) == asset.sha256 else {
+                throw LocalParakeetModelError.integrityCheckFailed
+            }
+        }
+    }
+
+    func markInstalled() throws {
+        try Data(Self.markerContents.utf8).write(to: verifiedMarkerURL, options: .atomic)
+    }
+
+    func downloadedByteCount() -> Int64 {
+        byteCount(in: modelDirectory)
+    }
+
+    func installedByteCount() -> Int64 {
+        byteCount(in: cacheRoot)
+    }
+
+    func removeModel() throws {
+        let fileManager = FileManager.default
+        let downloadedModels = cacheRoot.appendingPathComponent("hf-models", isDirectory: true)
+        let compiledModels = cacheRoot.appendingPathComponent("mlmodelc", isDirectory: true)
+        for url in [downloadedModels, compiledModels] where fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    private func byteCount(in directory: URL) -> Int64 {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+        var total: Int64 = 0
+        for case let url as URL in enumerator {
+            guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                  values.isRegularFile == true else { continue }
+            total += Int64(values.fileSize ?? 0)
+        }
+        return total
+    }
+
+    private static func sha256(of url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1_048_576), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+enum LocalParakeetModelState: Equatable {
+    case unavailable(String)
+    case notInstalled
+    case downloading(Double)
+    case verifying
+    case preparing
+    case ready(Int64)
+    case failed(String)
+
+    var isBusy: Bool {
+        switch self {
+        case .downloading, .verifying, .preparing: return true
+        default: return false
+        }
+    }
+}
+
+final class LocalParakeetModelManager: ObservableObject {
+    @Published private(set) var state: LocalParakeetModelState
+
+    let store: LocalParakeetModelStore
+    private let executableURL: URL?
+    private let platformSupported: Bool
+
+    init(
+        store: LocalParakeetModelStore = LocalParakeetModelStore(),
+        executableURL: URL? = LocalParakeetModelManager.bundledExecutableURL(),
+        platformSupported: Bool = LocalParakeetModelManager.isPlatformSupported
+    ) {
+        self.store = store
+        self.executableURL = executableURL
+        self.platformSupported = platformSupported
+        if !platformSupported {
+            self.state = .unavailable("Requires Apple silicon and macOS 15 or newer.")
+        } else if executableURL == nil {
+            self.state = .unavailable("This build does not include the local transcription engine.")
+        } else if store.isInstalled {
+            self.state = .ready(store.installedByteCount())
+        } else {
+            self.state = .notInstalled
+        }
+    }
+
+    static var isPlatformSupported: Bool {
+#if arch(arm64)
+        if #available(macOS 15.0, *) { return true }
+#endif
+        return false
+    }
+
+    static func bundledExecutableURL() -> URL? {
+        guard let mainExecutable = Bundle.main.executableURL else { return nil }
+        let url = mainExecutable.deletingLastPathComponent()
+            .appendingPathComponent("freeflow-local-asr", isDirectory: false)
+        return FileManager.default.isExecutableFile(atPath: url.path) ? url : nil
+    }
+
+    @MainActor
+    func refresh() {
+        guard platformSupported, executableURL != nil else { return }
+        guard !state.isBusy else { return }
+        state = store.isInstalled ? .ready(store.installedByteCount()) : .notInstalled
+    }
+
+    @MainActor
+    func install() async -> Bool {
+        guard platformSupported, let executableURL else { return false }
+        guard !state.isBusy else { return false }
+        if store.isInstalled {
+            state = .ready(store.installedByteCount())
+            return true
+        }
+
+        do {
+            state = .downloading(downloadProgress)
+            try await run(
+                executableURL: executableURL,
+                arguments: ["download"],
+                monitorsDownload: true
+            )
+            state = .downloading(1)
+            state = .verifying
+            let store = store
+            try await Task.detached(priority: .userInitiated) {
+                try store.validateDownloadedModel()
+            }.value
+            state = .preparing
+            let preparationAudio = try makePreparationAudio()
+            defer { try? FileManager.default.removeItem(at: preparationAudio) }
+            try await run(
+                executableURL: executableURL,
+                arguments: [
+                    "transcribe", preparationAudio.path,
+                    "--models", store.modelDirectory.path,
+                    "--compute-units", "ane",
+                    "--max-seconds", "0.1",
+                ],
+                monitorsDownload: false
+            )
+            try store.markInstalled()
+            state = .ready(store.installedByteCount())
+            return true
+        } catch is CancellationError {
+            state = .failed("Model download was cancelled.")
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+        return false
+    }
+
+    @MainActor
+    func removeModel() {
+        guard !state.isBusy else { return }
+        do {
+            try store.removeModel()
+            state = .notInstalled
+        } catch {
+            state = .failed("Could not remove the local model: \(error.localizedDescription)")
+        }
+    }
+
+    private var downloadProgress: Double {
+        min(1, Double(store.downloadedByteCount()) / Double(LocalParakeetModelStore.downloadByteCount))
+    }
+
+    @MainActor
+    private func run(executableURL: URL, arguments: [String], monitorsDownload: Bool) async throws {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        do {
+            while process.isRunning {
+                try await Task.sleep(nanoseconds: 200_000_000)
+                if monitorsDownload {
+                    state = .downloading(downloadProgress)
+                }
+            }
+        } catch {
+            if process.isRunning { process.terminate() }
+            throw error
+        }
+        guard process.terminationReason == .exit, process.terminationStatus == 0 else {
+            throw LocalParakeetModelError.helperFailed(process.terminationStatus)
+        }
+    }
+
+    private func makePreparationAudio() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freeflow-local-model-setup-\(UUID().uuidString).wav")
+        let sampleCount: UInt32 = 1_600
+        let dataByteCount = sampleCount * 2
+        var data = Data("RIFF".utf8)
+        data.appendLittleEndian(36 + dataByteCount)
+        data.append(Data("WAVEfmt ".utf8))
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(UInt32(16_000))
+        data.appendLittleEndian(UInt32(32_000))
+        data.appendLittleEndian(UInt16(2))
+        data.appendLittleEndian(UInt16(16))
+        data.append(Data("data".utf8))
+        data.appendLittleEndian(dataByteCount)
+        data.append(Data(count: Int(dataByteCount)))
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+}
+
+enum LocalParakeetModelError: LocalizedError {
+    case helperFailed(Int32)
+    case integrityCheckFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .helperFailed(let status):
+            return "Local model setup failed (engine exit \(status))."
+        case .integrityCheckFailed:
+            return "The downloaded model failed its integrity check. Remove it and try again."
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
+    }
+}

--- a/Sources/LocalParakeetModelManager.swift
+++ b/Sources/LocalParakeetModelManager.swift
@@ -135,11 +135,16 @@ struct LocalParakeetModelStore {
 
     func removeModel() throws {
         let fileManager = FileManager.default
-        let compiledDirectories = installationMarker?.compiledCacheDirectories ?? []
+        let compiledDirectories = Set(installationMarker?.compiledCacheDirectories ?? [])
         if fileManager.fileExists(atPath: modelDirectory.path) {
             try fileManager.removeItem(at: modelDirectory)
         }
-        for name in compiledDirectories where Self.isSafeCompiledCacheName(name) {
+        try removeCompiledCacheDirectories(compiledDirectories)
+    }
+
+    func removeCompiledCacheDirectories(_ names: Set<String>) throws {
+        let fileManager = FileManager.default
+        for name in names where Self.isSafeCompiledCacheName(name) {
             let url = compiledCacheRoot.appendingPathComponent(name, isDirectory: true)
             guard fileManager.fileExists(atPath: url.path) else { continue }
             try fileManager.removeItem(at: url)
@@ -166,7 +171,55 @@ struct LocalParakeetModelStore {
             return marker
         }
         guard String(data: data, encoding: .utf8) == Self.legacyMarkerContents else { return nil }
-        return LocalParakeetInstallationMarker(version: 1, compiledCacheDirectories: [])
+        return LocalParakeetInstallationMarker(
+            version: 1,
+            compiledCacheDirectories: legacyCompiledCacheDirectoryNames().sorted()
+        )
+    }
+
+    func legacyCompiledCacheDirectoryNames() -> Set<String> {
+        let relativePackages = Set(assets.compactMap { asset -> String? in
+            let components = asset.relativePath.split(separator: "/")
+            guard let index = components.firstIndex(where: { $0.hasSuffix(".mlpackage") }) else {
+                return nil
+            }
+            return components[...index].joined(separator: "/")
+        })
+        return Set(relativePackages.compactMap { relativePath in
+            Self.compiledCacheName(
+                for: modelDirectory.appendingPathComponent(relativePath, isDirectory: true)
+            )
+        })
+    }
+
+    // Mirrors the pinned helper's content-addressed ModelCache key so legacy
+    // FreeFlow markers can claim only caches compiled from their own packages.
+    private static func compiledCacheName(for source: URL) -> String? {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: source.path) else { return nil }
+        var hasher = SHA256()
+        hasher.update(data: Data(source.resolvingSymlinksInPath().path.utf8))
+        if let enumerator = fileManager.enumerator(
+            at: source,
+            includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for case let url as URL in enumerator {
+                guard let values = try? url.resourceValues(
+                    forKeys: [.fileSizeKey, .contentModificationDateKey]
+                ) else { continue }
+                hasher.update(data: Data(url.lastPathComponent.utf8))
+                if let size = values.fileSize {
+                    Swift.withUnsafeBytes(of: Int64(size)) { hasher.update(data: Data($0)) }
+                }
+                if let modified = values.contentModificationDate {
+                    Swift.withUnsafeBytes(of: modified.timeIntervalSince1970) {
+                        hasher.update(data: Data($0))
+                    }
+                }
+            }
+        }
+        return hasher.finalize().prefix(12).map { String(format: "%02x", $0) }.joined()
     }
 
     private static func isSafeCompiledCacheName(_ name: String) -> Bool {
@@ -296,11 +349,23 @@ final class LocalParakeetModelManager: ObservableObject {
                 modelDirectory: store.modelDirectory,
                 executableURL: executableURL
             )
-            try await transcriptionService.prewarm()
-            try store.markInstalled(
-                compiledCacheDirectories: store.compiledCacheDirectoryNames()
-                    .subtracting(compiledCacheDirectoriesBeforePreparation)
-            )
+            do {
+                try await transcriptionService.prewarm()
+            } catch {
+                try? store.removeCompiledCacheDirectories(
+                    store.compiledCacheDirectoryNames()
+                        .subtracting(compiledCacheDirectoriesBeforePreparation)
+                )
+                throw error
+            }
+            let preparedDirectories = store.compiledCacheDirectoryNames()
+                .subtracting(compiledCacheDirectoriesBeforePreparation)
+            do {
+                try store.markInstalled(compiledCacheDirectories: preparedDirectories)
+            } catch {
+                try? store.removeCompiledCacheDirectories(preparedDirectories)
+                throw error
+            }
             state = .ready(store.installedByteCount())
             return true
         } catch is CancellationError {

--- a/Sources/LocalParakeetModelManager.swift
+++ b/Sources/LocalParakeetModelManager.swift
@@ -244,18 +244,11 @@ final class LocalParakeetModelManager: ObservableObject {
                 try store.validateDownloadedModel()
             }.value
             state = .preparing
-            let preparationAudio = try makePreparationAudio()
-            defer { try? FileManager.default.removeItem(at: preparationAudio) }
-            try await run(
-                executableURL: executableURL,
-                arguments: [
-                    "transcribe", preparationAudio.path,
-                    "--models", store.modelDirectory.path,
-                    "--compute-units", LocalParakeetTranscriptionService.computeUnits,
-                    "--max-seconds", "0.1",
-                ],
-                monitorsDownload: false
+            let transcriptionService = try LocalParakeetTranscriptionService(
+                modelDirectory: store.modelDirectory,
+                executableURL: executableURL
             )
+            try await transcriptionService.prewarm()
             try store.markInstalled()
             state = .ready(store.installedByteCount())
             return true
@@ -305,28 +298,6 @@ final class LocalParakeetModelManager: ObservableObject {
             throw LocalParakeetModelError.helperFailed(process.terminationStatus)
         }
     }
-
-    private func makePreparationAudio() throws -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("freeflow-local-model-setup-\(UUID().uuidString).wav")
-        let sampleCount: UInt32 = 1_600
-        let dataByteCount = sampleCount * 2
-        var data = Data("RIFF".utf8)
-        data.appendLittleEndian(36 + dataByteCount)
-        data.append(Data("WAVEfmt ".utf8))
-        data.appendLittleEndian(UInt32(16))
-        data.appendLittleEndian(UInt16(1))
-        data.appendLittleEndian(UInt16(1))
-        data.appendLittleEndian(UInt32(16_000))
-        data.appendLittleEndian(UInt32(32_000))
-        data.appendLittleEndian(UInt16(2))
-        data.appendLittleEndian(UInt16(16))
-        data.append(Data("data".utf8))
-        data.appendLittleEndian(dataByteCount)
-        data.append(Data(count: Int(dataByteCount)))
-        try data.write(to: url, options: .atomic)
-        return url
-    }
 }
 
 enum LocalParakeetModelError: LocalizedError {
@@ -340,12 +311,5 @@ enum LocalParakeetModelError: LocalizedError {
         case .integrityCheckFailed:
             return "The downloaded model failed its integrity check. Remove it and try again."
         }
-    }
-}
-
-private extension Data {
-    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
-        var littleEndian = value.littleEndian
-        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
     }
 }

--- a/Sources/LocalParakeetTranscriptionService.swift
+++ b/Sources/LocalParakeetTranscriptionService.swift
@@ -6,6 +6,11 @@ import Foundation
 /// this Mac; the helper receives only a local file path and writes its result to
 /// a temporary file that is deleted immediately after parsing.
 final class LocalParakeetTranscriptionService {
+    // ANE model loading can sporadically stall for 30–45 seconds after idle.
+    // CPU-only remains much faster than real time on supported Macs, has a
+    // predictable cold start, and still releases all model memory after use.
+    static let computeUnits = "cpu"
+
     private let executableURL: URL
     private let modelDirectory: URL
 
@@ -53,7 +58,7 @@ final class LocalParakeetTranscriptionService {
             "transcribe",
             fileURL.path,
             "--models", modelDirectory.path,
-            "--compute-units", "ane",
+            "--compute-units", Self.computeUnits,
         ]
 
         // Diagnostics go to stderr; stdout contains only the transcript. Keep

--- a/Sources/LocalParakeetTranscriptionService.swift
+++ b/Sources/LocalParakeetTranscriptionService.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Runs the bundled Parakeet Core ML helper as an isolated, one-shot process.
-/// The model is loaded only while a transcription is running, keeping idle RAM
+/// The model is loaded only while prewarming or transcribing, keeping idle RAM
 /// use close to the stock FreeFlow app. All audio and transcript data stay on
 /// this Mac; the helper receives only a local file path and writes its result to
 /// a temporary file that is deleted immediately after parsing.
@@ -52,14 +52,7 @@ final class LocalParakeetTranscriptionService {
         let outputHandle = try FileHandle(forWritingTo: outputURL)
         defer { try? outputHandle.close() }
 
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = [
-            "transcribe",
-            fileURL.path,
-            "--models", modelDirectory.path,
-            "--compute-units", Self.computeUnits,
-        ]
+        let process = makeProcess(fileURL: fileURL)
 
         // Diagnostics go to stderr; stdout contains only the transcript. Keep
         // both out of persistent application logs and delete the private output
@@ -75,6 +68,24 @@ final class LocalParakeetTranscriptionService {
         try outputHandle.synchronize()
         let data = try Data(contentsOf: outputURL)
         return try Self.parseTranscript(from: data)
+    }
+
+    /// Loads and exercises the same model path before recording stops, using
+    /// generated silence only. The one-shot helper exits immediately, so this
+    /// hides Core ML's cold start behind the user's recording without keeping
+    /// model RAM resident while idle.
+    func prewarm() async throws {
+        let audioURL = try makePreparationAudio()
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+        // Exercise the first prediction too: model load alone does not warm
+        // Core ML's execution path and leaves several seconds after recording.
+        let process = makeProcess(fileURL: audioURL, maxSeconds: 0.1)
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try await run(process)
+        guard process.terminationReason == .exit, process.terminationStatus == 0 else {
+            throw LocalParakeetError.helperFailed(process.terminationStatus)
+        }
     }
 
     static func parseTranscript(from data: Data) throws -> String {
@@ -132,6 +143,42 @@ final class LocalParakeetTranscriptionService {
         return String(characters)
     }
 
+    private func makeProcess(fileURL: URL, maxSeconds: Double? = nil) -> Process {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = [
+            "transcribe", fileURL.path,
+            "--models", modelDirectory.path,
+            "--compute-units", Self.computeUnits,
+        ]
+        if let maxSeconds {
+            process.arguments? += ["--max-seconds", String(maxSeconds)]
+        }
+        return process
+    }
+
+    private func makePreparationAudio() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freeflow-local-model-prewarm-\(UUID().uuidString).wav")
+        let sampleCount: UInt32 = 1_600
+        let dataByteCount = sampleCount * 2
+        var data = Data("RIFF".utf8)
+        data.appendLittleEndian(36 + dataByteCount)
+        data.append(Data("WAVEfmt ".utf8))
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(UInt32(16_000))
+        data.appendLittleEndian(UInt32(32_000))
+        data.appendLittleEndian(UInt16(2))
+        data.appendLittleEndian(UInt16(16))
+        data.append(Data("data".utf8))
+        data.appendLittleEndian(dataByteCount)
+        data.append(Data(count: Int(dataByteCount)))
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
     private func run(_ process: Process) async throws {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
@@ -151,6 +198,13 @@ final class LocalParakeetTranscriptionService {
             }
         }
         try Task.checkCancellation()
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
     }
 }
 

--- a/Sources/LocalParakeetTranscriptionService.swift
+++ b/Sources/LocalParakeetTranscriptionService.swift
@@ -180,13 +180,22 @@ final class LocalParakeetTranscriptionService {
     }
 
     private func run(_ process: Process) async throws {
+        try Task.checkCancellation()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 process.terminationHandler = { _ in
                     continuation.resume()
                 }
                 do {
+                    guard !Task.isCancelled else {
+                        process.terminationHandler = nil
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    }
                     try process.run()
+                    if Task.isCancelled, process.isRunning {
+                        process.terminate()
+                    }
                 } catch {
                     process.terminationHandler = nil
                     continuation.resume(throwing: error)

--- a/Sources/LocalParakeetTranscriptionService.swift
+++ b/Sources/LocalParakeetTranscriptionService.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Runs the bundled Parakeet Core ML helper as an isolated, one-shot process.
+/// The model is loaded only while a transcription is running, keeping idle RAM
+/// use close to the stock FreeFlow app. All audio and transcript data stay on
+/// this Mac; the helper receives only a local file path and writes its result to
+/// a temporary file that is deleted immediately after parsing.
+final class LocalParakeetTranscriptionService {
+    private let executableURL: URL
+    private let modelDirectory: URL
+
+    init(modelDirectory: URL, executableURL: URL? = nil) throws {
+        let resolvedURL: URL
+        if let executableURL {
+            resolvedURL = executableURL
+        } else if let mainExecutable = Bundle.main.executableURL {
+            resolvedURL = mainExecutable
+                .deletingLastPathComponent()
+                .appendingPathComponent("freeflow-local-asr", isDirectory: false)
+        } else {
+            throw LocalParakeetError.helperUnavailable
+        }
+
+        guard FileManager.default.isExecutableFile(atPath: resolvedURL.path) else {
+            throw LocalParakeetError.helperUnavailable
+        }
+        guard FileManager.default.fileExists(atPath: modelDirectory.path) else {
+            throw LocalParakeetError.modelUnavailable
+        }
+        self.executableURL = resolvedURL
+        self.modelDirectory = modelDirectory
+    }
+
+    func transcribe(fileURL: URL) async throws -> String {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freeflow-local-asr-\(UUID().uuidString)")
+            .appendingPathExtension("txt")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        guard FileManager.default.createFile(
+            atPath: outputURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw LocalParakeetError.invalidOutput
+        }
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        defer { try? outputHandle.close() }
+
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = [
+            "transcribe",
+            fileURL.path,
+            "--models", modelDirectory.path,
+            "--compute-units", "ane",
+        ]
+
+        // Diagnostics go to stderr; stdout contains only the transcript. Keep
+        // both out of persistent application logs and delete the private output
+        // file immediately after parsing.
+        process.standardOutput = outputHandle
+        process.standardError = FileHandle.nullDevice
+
+        try await run(process)
+        guard process.terminationReason == .exit, process.terminationStatus == 0 else {
+            throw LocalParakeetError.helperFailed(process.terminationStatus)
+        }
+
+        try outputHandle.synchronize()
+        let data = try Data(contentsOf: outputURL)
+        return try Self.parseTranscript(from: data)
+    }
+
+    static func parseTranscript(from data: Data) throws -> String {
+        guard let output = String(data: data, encoding: .utf8) else {
+            throw LocalParakeetError.invalidOutput
+        }
+        let repairedTranscript = removingSingleTrailingForeignScriptArtifact(
+            in: output.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        let transcript = collapseRepeatedTerminalPunctuation(in: repairedTranscript)
+        guard !transcript.isEmpty else {
+            throw LocalParakeetError.invalidOutput
+        }
+        return transcript
+    }
+
+    /// Some short Latin-script dictations end with one unrelated script token.
+    /// Remove only that narrow decoder artifact; never filter a non-Latin
+    /// transcript or an actual multi-character word.
+    private static func removingSingleTrailingForeignScriptArtifact(in transcript: String) -> String {
+        guard let last = transcript.last,
+              last.unicodeScalars.contains(where: { CharacterSet.letters.contains($0) && !isLatin($0) }),
+              let lastIndex = transcript.indices.last,
+              lastIndex > transcript.startIndex else { return transcript }
+        let prefixEnd = transcript.index(before: lastIndex)
+        guard transcript[prefixEnd].isWhitespace else { return transcript }
+        let prefix = transcript[..<prefixEnd].trimmingCharacters(in: .whitespacesAndNewlines)
+        let letters = prefix.unicodeScalars.filter { CharacterSet.letters.contains($0) }
+        guard letters.count >= 4,
+              letters.filter({ isLatin($0) }).count * 10 >= letters.count * 9 else { return transcript }
+        return prefix
+    }
+
+    private static func isLatin(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x0041...0x005A, 0x0061...0x007A, 0x00C0...0x024F:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// The current Core ML decoder can repeat its terminal punctuation token
+    /// (for example `sentence........`). This local, deterministic repair is
+    /// deliberately narrow and never rewrites dictated words.
+    private static func collapseRepeatedTerminalPunctuation(in transcript: String) -> String {
+        var characters = Array(transcript)
+        let collapsible: Set<Character> = [".", "!", "?"]
+        while characters.count >= 2,
+              let last = characters.last,
+              collapsible.contains(last),
+              characters[characters.count - 2] == last {
+            characters.removeLast()
+        }
+        return String(characters)
+    }
+
+    private func run(_ process: Process) async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                process.terminationHandler = { _ in
+                    continuation.resume()
+                }
+                do {
+                    try process.run()
+                } catch {
+                    process.terminationHandler = nil
+                    continuation.resume(throwing: error)
+                }
+            }
+        } onCancel: {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+        try Task.checkCancellation()
+    }
+}
+
+enum LocalParakeetError: LocalizedError {
+    case helperUnavailable
+    case modelUnavailable
+    case helperFailed(Int32)
+    case invalidOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .helperUnavailable:
+            return "The bundled local transcription engine is missing or cannot be executed."
+        case .modelUnavailable:
+            return "The on-device transcription model is not installed. Open Settings to download it."
+        case .helperFailed(let status):
+            return "Local transcription failed (engine exit \(status))."
+        case .invalidOutput:
+            return "The local transcription engine returned no readable transcript."
+        }
+    }
+}

--- a/Sources/LocalParakeetTranscriptionService.swift
+++ b/Sources/LocalParakeetTranscriptionService.swift
@@ -13,8 +13,13 @@ final class LocalParakeetTranscriptionService {
 
     private let executableURL: URL
     private let modelDirectory: URL
+    private let beforeProcessLaunch: (@Sendable () async -> Void)?
 
-    init(modelDirectory: URL, executableURL: URL? = nil) throws {
+    init(
+        modelDirectory: URL,
+        executableURL: URL? = nil,
+        beforeProcessLaunch: (@Sendable () async -> Void)? = nil
+    ) throws {
         let resolvedURL: URL
         if let executableURL {
             resolvedURL = executableURL
@@ -34,6 +39,7 @@ final class LocalParakeetTranscriptionService {
         }
         self.executableURL = resolvedURL
         self.modelDirectory = modelDirectory
+        self.beforeProcessLaunch = beforeProcessLaunch
     }
 
     func transcribe(fileURL: URL) async throws -> String {
@@ -180,6 +186,7 @@ final class LocalParakeetTranscriptionService {
     }
 
     private func run(_ process: Process) async throws {
+        await beforeProcessLaunch?()
         try Task.checkCancellation()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in

--- a/Sources/LocalTranscriptionPolicy.swift
+++ b/Sources/LocalTranscriptionPolicy.swift
@@ -1,0 +1,7 @@
+struct LocalTranscriptionPolicy: Equatable {
+    let isEnabled: Bool
+
+    var allowsContextCapture: Bool { !isEnabled }
+    var allowsRealtimeStreaming: Bool { !isEnabled }
+    var allowsLanguageModelProcessing: Bool { !isEnabled }
+}

--- a/Sources/LocalTranscriptionSettingsView.swift
+++ b/Sources/LocalTranscriptionSettingsView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct LocalTranscriptionSettingsView: View {
+    @EnvironmentObject private var appState: AppState
+    @ObservedObject private var modelManager: LocalParakeetModelManager
+    @State private var showsRemovalConfirmation = false
+    let compact: Bool
+
+    init(modelManager: LocalParakeetModelManager, compact: Bool = false) {
+        self.modelManager = modelManager
+        self.compact = compact
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Use on-device transcription", isOn: localModeBinding)
+                .disabled(
+                    modelManager.state.isBusy || isUnavailable
+                        || appState.isRecording || appState.isTranscribing
+                )
+
+            if !compact {
+                Text("Parakeet TDT 0.6B v3 runs on Apple silicon. While enabled, dictated audio and text stay on this Mac; screenshots, app context, translation, realtime streaming, Edit Mode, and language-model cleanup are skipped.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            modelStatus
+                .disabled(appState.isRecording || appState.isTranscribing)
+        }
+        .onAppear { modelManager.refresh() }
+        .confirmationDialog(
+            "Remove the on-device model?",
+            isPresented: $showsRemovalConfirmation
+        ) {
+            Button("Remove Model", role: .destructive) {
+                appState.localTranscriptionEnabled = false
+                modelManager.removeModel()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This frees the model cache. You can download it again at any time.")
+        }
+    }
+
+    private var localModeBinding: Binding<Bool> {
+        Binding(
+            get: { appState.localTranscriptionEnabled || modelManager.state.isBusy },
+            set: { enabled in
+                if enabled {
+                    enableLocalMode()
+                } else {
+                    appState.localTranscriptionEnabled = false
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private var modelStatus: some View {
+        switch modelManager.state {
+        case .unavailable(let reason):
+            Label(reason, systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+        case .notInstalled:
+            HStack {
+                Text("Enabling this downloads and prepares a verified 459 MB model.")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if appState.localTranscriptionEnabled {
+                    Button("Download Model") { enableLocalMode() }
+                }
+            }
+        case .downloading(let progress):
+            VStack(alignment: .leading, spacing: 5) {
+                ProgressView(value: progress)
+                Text("Downloading model… \(Int(progress * 100))%")
+                    .foregroundStyle(.secondary)
+            }
+        case .verifying:
+            progressLabel("Verifying model integrity…")
+        case .preparing:
+            progressLabel("Preparing Core ML for first use…")
+        case .ready(let byteCount):
+            HStack {
+                Label(
+                    "Model ready · \(ByteCountFormatter.string(fromByteCount: byteCount, countStyle: .file)) on disk",
+                    systemImage: "checkmark.circle.fill"
+                )
+                .foregroundStyle(.green)
+                Spacer()
+                Button("Remove Model") { showsRemovalConfirmation = true }
+                    .disabled(
+                        modelManager.state.isBusy || appState.isRecording || appState.isTranscribing
+                    )
+            }
+        case .failed(let message):
+            HStack(alignment: .firstTextBaseline) {
+                Label(message, systemImage: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                Spacer()
+                Button("Try Again") { enableLocalMode() }
+            }
+        }
+    }
+
+    private var isUnavailable: Bool {
+        if case .unavailable = modelManager.state { return true }
+        return false
+    }
+
+    private func progressLabel(_ text: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text(text).foregroundStyle(.secondary)
+        }
+    }
+
+    private func enableLocalMode() {
+        Task { @MainActor in
+            if await modelManager.install() {
+                appState.localTranscriptionEnabled = true
+            }
+        }
+    }
+}

--- a/Sources/LocalTranscriptionSettingsView.swift
+++ b/Sources/LocalTranscriptionSettingsView.swift
@@ -15,7 +15,8 @@ struct LocalTranscriptionSettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             Toggle("Use on-device transcription", isOn: localModeBinding)
                 .disabled(
-                    modelManager.state.isBusy || isUnavailable
+                    modelManager.state.isBusy
+                        || (isUnavailable && !appState.localTranscriptionEnabled)
                         || appState.isRecording || appState.isTranscribing
                 )
 

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -56,7 +56,7 @@ struct MenuBarView: View {
 
             Divider()
 
-            if !appState.hasScreenRecordingPermission {
+            if appState.requiresScreenRecordingPermission && !appState.hasScreenRecordingPermission {
                 Button {
                     appState.requestScreenCapturePermission()
                 } label: {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -720,6 +720,12 @@ struct GeneralSettingsView: View {
                 SettingsCard("Output Language", icon: "globe") {
                     outputLanguageSection
                 }
+                .disabled(appState.localTranscriptionEnabled)
+                .opacity(appState.localTranscriptionEnabled ? 0.55 : 1)
+                SettingsCard("On-Device Transcription", icon: "lock.shield.fill") {
+                    LocalTranscriptionSettingsView(modelManager: appState.localParakeetModelManager)
+                        .environmentObject(appState)
+                }
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
                 }
@@ -732,9 +738,13 @@ struct GeneralSettingsView: View {
                 SettingsCard("Edit Mode", icon: "pencil") {
                     commandModeSection
                 }
+                .disabled(appState.localTranscriptionEnabled)
+                .opacity(appState.localTranscriptionEnabled ? 0.55 : 1)
                 SettingsCard("Cleanup", icon: "sparkles") {
                     cleanupSection
                 }
+                .disabled(appState.localTranscriptionEnabled)
+                .opacity(appState.localTranscriptionEnabled ? 0.55 : 1)
                 SettingsCard("Clipboard", icon: "doc.on.clipboard") {
                     clipboardSection
                 }
@@ -747,6 +757,8 @@ struct GeneralSettingsView: View {
                 SettingsCard("Custom Vocabulary", icon: "text.book.closed.fill") {
                     vocabularySection
                 }
+                .disabled(appState.localTranscriptionEnabled)
+                .opacity(appState.localTranscriptionEnabled ? 0.55 : 1)
                 SettingsCard("Permissions", icon: "lock.shield.fill") {
                     permissionsSection
                 }
@@ -1444,14 +1456,16 @@ struct GeneralSettingsView: View {
                 }
             )
 
-            permissionRow(
-                title: "Screen Recording",
-                icon: "camera.viewfinder",
-                granted: appState.hasScreenRecordingPermission,
-                action: {
-                    appState.requestScreenCapturePermission()
-                }
-            )
+            if !appState.localTranscriptionEnabled {
+                permissionRow(
+                    title: "Screen Recording",
+                    icon: "camera.viewfinder",
+                    granted: appState.hasScreenRecordingPermission,
+                    action: {
+                        appState.requestScreenCapturePermission()
+                    }
+                )
+            }
         }
     }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1128,7 +1128,8 @@ struct SetupView: View {
         case .accessibility:
             return accessibilityGranted
         case .screenRecording:
-            return appState.hasScreenRecordingPermission
+            return !appState.requiresScreenRecordingPermission
+                || appState.hasScreenRecordingPermission
         case .testTranscription:
             return testPhase == .done && !testTranscript.isEmpty && testError == nil
         default:

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -107,7 +107,21 @@ struct SetupView: View {
     @StateObject private var testHotkeyHarness = SetupTestHotkeyHarness()
     @AppStorage("use_compact_overlay") private var useCompactOverlay = true
 
-    private let totalSteps: [SetupStep] = SetupStep.allCases
+    private var totalSteps: [SetupStep] {
+        guard appState.localTranscriptionEnabled else { return SetupStep.allCases }
+        return [
+            .welcome,
+            .micPermission,
+            .accessibility,
+            .holdShortcut,
+            .toggleShortcut,
+            .copyAgainShortcut,
+            .launchAtLogin,
+            .overlayStyle,
+            .testTranscription,
+            .ready,
+        ]
+    }
     private var isCapturingShortcut: Bool {
         isCapturingHoldShortcut || isCapturingToggleShortcut || isCapturingCopyAgainShortcut
     }
@@ -202,8 +216,10 @@ struct SetupView: View {
             customVocabularyInput = appState.customVocabulary
             checkMicPermission()
             checkAccessibility()
-            Task {
-                await githubCache.fetchIfNeeded()
+            if !appState.localTranscriptionEnabled {
+                Task {
+                    await githubCache.fetchIfNeeded()
+                }
             }
         }
         .onDisappear {
@@ -275,11 +291,24 @@ struct SetupView: View {
                 Text("Welcome to \(AppName.displayName)")
                     .font(.system(size: 30, weight: .bold, design: .rounded))
 
-                Text("Dictate text anywhere on your Mac.\nHold to talk or tap to toggle dictation.")
+                Text(appState.localTranscriptionEnabled
+                    ? "Dictate privately with a model that runs entirely on this Mac.\nNo screenshots, cleanup model, or cloud transcription."
+                    : "Dictate text anywhere on your Mac.\nHold to talk or tap to toggle dictation.")
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            LocalTranscriptionSettingsView(
+                modelManager: appState.localParakeetModelManager,
+                compact: true
+            )
+            .environmentObject(appState)
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+            )
 
             VStack(spacing: 10) {
                 HStack(spacing: 8) {
@@ -1087,6 +1116,10 @@ struct SetupView: View {
 
     private var canContinueFromCurrentStep: Bool {
         switch currentStep {
+        case .welcome:
+            return !appState.localParakeetModelManager.state.isBusy
+                && (!appState.localTranscriptionEnabled
+                    || appState.localParakeetModelManager.store.isInstalled)
         case .micPermission:
             return micPermissionGranted
         case .accessibility:
@@ -1165,13 +1198,13 @@ struct SetupView: View {
     }
 
     private func previousStep(_ step: SetupStep) -> SetupStep {
-        let previous = SetupStep(rawValue: step.rawValue - 1)
-        return previous ?? .welcome
+        guard let index = totalSteps.firstIndex(of: step), index > 0 else { return .welcome }
+        return totalSteps[index - 1]
     }
 
     private func nextStep(_ step: SetupStep) -> SetupStep {
-        let next = SetupStep(rawValue: step.rawValue + 1)
-        return next ?? .ready
+        guard let index = totalSteps.firstIndex(of: step), index + 1 < totalSteps.count else { return .ready }
+        return totalSteps[index + 1]
     }
 
     func checkMicPermission() {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1117,6 +1117,9 @@ struct SetupView: View {
     private var canContinueFromCurrentStep: Bool {
         switch currentStep {
         case .welcome:
+            if case .unavailable = appState.localParakeetModelManager.state {
+                return !appState.localTranscriptionEnabled
+            }
             return !appState.localParakeetModelManager.state.isBusy
                 && (!appState.localTranscriptionEnabled
                     || appState.localParakeetModelManager.store.isInstalled)

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -18,12 +18,16 @@ class TranscriptionService {
     private let baseURL: URL
     private let transcriptionModel: String
     private let language: String?
+    private let localParakeetService: LocalParakeetTranscriptionService?
     private var transcriptionResponseFormat: String {
         Self.responseFormat(forModel: transcriptionModel)
     }
     private var transcriptionTimeoutSeconds: TimeInterval {
-        let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
-        return override > 0 ? override : 20
+        let key = localParakeetService == nil
+            ? "transcription_timeout_seconds"
+            : "local_transcription_timeout_seconds"
+        let override = UserDefaults.standard.double(forKey: key)
+        return override > 0 ? override : (localParakeetService == nil ? 20 : 120)
     }
 
     init(
@@ -38,6 +42,16 @@ class TranscriptionService {
         self.transcriptionModel = trimmedModel.isEmpty ? "whisper-large-v3" : trimmedModel
         let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.language = (trimmedLanguage?.isEmpty == false) ? trimmedLanguage : nil
+        self.localParakeetService = nil
+    }
+
+    init(localParakeetModelDirectory modelDirectory: URL, language: String? = nil) throws {
+        self.apiKey = ""
+        self.baseURL = URL(string: "http://127.0.0.1")!
+        self.transcriptionModel = "parakeet-tdt-0.6b-v3-coreml-int4"
+        let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.language = (trimmedLanguage?.isEmpty == false) ? trimmedLanguage : nil
+        self.localParakeetService = try LocalParakeetTranscriptionService(modelDirectory: modelDirectory)
     }
 
     static func responseFormat(forModel model: String) -> String {
@@ -111,6 +125,9 @@ class TranscriptionService {
 
     // Send audio file for transcription and return text
     private func transcribeAudio(fileURL: URL) async throws -> String {
+        if let localParakeetService {
+            return try await localParakeetService.transcribe(fileURL: fileURL)
+        }
         return try await transcribeAudioWithURLSession(fileURL: fileURL)
     }
 

--- a/Tests/LocalParakeetModelStoreTests.swift
+++ b/Tests/LocalParakeetModelStoreTests.swift
@@ -3,6 +3,7 @@ import Foundation
 enum LocalParakeetModelStoreTests {
     static func run() {
         validatesMarksAndRemovesOnlyTheModelCache()
+        legacyMarkerRemovesOnlyMatchingCompiledCache()
         rejectsModifiedModelAssets()
     }
 
@@ -54,12 +55,45 @@ enum LocalParakeetModelStoreTests {
         }
     }
 
-    private static func withStore(_ body: (LocalParakeetModelStore, URL) throws -> Void) {
+    private static func legacyMarkerRemovesOnlyMatchingCompiledCache() {
+        withStore(relativePath: "encoder.mlpackage/Data/model.bin") { store, assetURL in
+            try Data("hello".utf8).write(to: assetURL)
+            let names = store.legacyCompiledCacheDirectoryNames()
+            TestSupport.expectEqual(names.count, 1)
+            guard let ownedName = names.first else { return }
+            let compiledRoot = store.cacheRoot.appendingPathComponent("mlmodelc", isDirectory: true)
+            let owned = compiledRoot.appendingPathComponent(ownedName, isDirectory: true)
+            let unrelated = compiledRoot.appendingPathComponent(
+                "89abcdef0123456701234567",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: owned, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: unrelated, withIntermediateDirectories: true)
+            try Data(LocalParakeetModelStore.legacyMarkerContents.utf8).write(
+                to: store.modelDirectory.appendingPathComponent(".freeflow-verified")
+            )
+
+            try store.removeModel()
+            TestSupport.expect(
+                !FileManager.default.fileExists(atPath: owned.path),
+                "Legacy removal left the matching compiled cache"
+            )
+            TestSupport.expect(
+                FileManager.default.fileExists(atPath: unrelated.path),
+                "Legacy removal deleted an unrelated compiled cache"
+            )
+        }
+    }
+
+    private static func withStore(
+        relativePath: String = "test/asset.bin",
+        _ body: (LocalParakeetModelStore, URL) throws -> Void
+    ) {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("freeflow-local-model-tests-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
         let asset = LocalParakeetModelAsset(
-            relativePath: "test/asset.bin",
+            relativePath: relativePath,
             byteCount: 5,
             sha256: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         )

--- a/Tests/LocalParakeetModelStoreTests.swift
+++ b/Tests/LocalParakeetModelStoreTests.swift
@@ -10,8 +10,18 @@ enum LocalParakeetModelStoreTests {
         withStore { store, assetURL in
             try Data("hello".utf8).write(to: assetURL)
             try store.validateDownloadedModel()
-            try store.markInstalled()
+            let compiledRoot = store.cacheRoot.appendingPathComponent("mlmodelc", isDirectory: true)
+            let ownedName = "0123456789abcdef01234567"
+            let unrelatedName = "89abcdef0123456701234567"
+            let owned = compiledRoot.appendingPathComponent(ownedName, isDirectory: true)
+            let unrelatedCompiled = compiledRoot.appendingPathComponent(unrelatedName, isDirectory: true)
+            try FileManager.default.createDirectory(at: owned, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: unrelatedCompiled, withIntermediateDirectories: true)
+            try Data("mine".utf8).write(to: owned.appendingPathComponent("model.bin"))
+            try Data("other".utf8).write(to: unrelatedCompiled.appendingPathComponent("model.bin"))
+            try store.markInstalled(compiledCacheDirectories: [ownedName])
             TestSupport.expect(store.isInstalled, "Verified local model was not reported as installed")
+            TestSupport.expectEqual(store.installedByteCount(), 9)
 
             let unrelated = store.cacheRoot.appendingPathComponent("keep-me.txt")
             try Data("safe".utf8).write(to: unrelated)
@@ -20,6 +30,14 @@ enum LocalParakeetModelStoreTests {
             TestSupport.expect(
                 FileManager.default.fileExists(atPath: unrelated.path),
                 "Removing the model deleted an unrelated cache file"
+            )
+            TestSupport.expect(
+                !FileManager.default.fileExists(atPath: owned.path),
+                "Removing the model left its recorded compiled cache"
+            )
+            TestSupport.expect(
+                FileManager.default.fileExists(atPath: unrelatedCompiled.path),
+                "Removing the model deleted an unrelated compiled cache"
             )
         }
     }

--- a/Tests/LocalParakeetModelStoreTests.swift
+++ b/Tests/LocalParakeetModelStoreTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum LocalParakeetModelStoreTests {
+    static func run() {
+        validatesMarksAndRemovesOnlyTheModelCache()
+        rejectsModifiedModelAssets()
+    }
+
+    private static func validatesMarksAndRemovesOnlyTheModelCache() {
+        withStore { store, assetURL in
+            try Data("hello".utf8).write(to: assetURL)
+            try store.validateDownloadedModel()
+            try store.markInstalled()
+            TestSupport.expect(store.isInstalled, "Verified local model was not reported as installed")
+
+            let unrelated = store.cacheRoot.appendingPathComponent("keep-me.txt")
+            try Data("safe".utf8).write(to: unrelated)
+            try store.removeModel()
+            TestSupport.expect(!store.isInstalled, "Removed local model remains installed")
+            TestSupport.expect(
+                FileManager.default.fileExists(atPath: unrelated.path),
+                "Removing the model deleted an unrelated cache file"
+            )
+        }
+    }
+
+    private static func rejectsModifiedModelAssets() {
+        withStore { store, assetURL in
+            try Data("HELLO".utf8).write(to: assetURL)
+            do {
+                try store.validateDownloadedModel()
+                TestSupport.expect(false, "Modified model asset passed its SHA-256 check")
+            } catch LocalParakeetModelError.integrityCheckFailed {
+                TestSupport.expect(true, "Modified model asset correctly rejected")
+            }
+        }
+    }
+
+    private static func withStore(_ body: (LocalParakeetModelStore, URL) throws -> Void) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freeflow-local-model-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let asset = LocalParakeetModelAsset(
+            relativePath: "test/asset.bin",
+            byteCount: 5,
+            sha256: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+        let store = LocalParakeetModelStore(cacheRoot: root, assets: [asset])
+        let assetURL = store.modelDirectory.appendingPathComponent(asset.relativePath)
+        do {
+            try FileManager.default.createDirectory(
+                at: assetURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try body(store, assetURL)
+        } catch {
+            fatalError("Local model store test failed: \(error)")
+        }
+    }
+}

--- a/Tests/LocalParakeetTranscriptionServiceTests.swift
+++ b/Tests/LocalParakeetTranscriptionServiceTests.swift
@@ -2,10 +2,18 @@ import Foundation
 
 enum LocalParakeetTranscriptionServiceTests {
     static func run() {
+        usesPredictableCPUCompute()
         parsesAndTrimsDedicatedTranscriptField()
         collapsesDecoderPunctuationRepetition()
         removesUnexpectedScriptArtifacts()
         rejectsResponsesWithoutTranscriptText()
+    }
+
+    private static func usesPredictableCPUCompute() {
+        TestSupport.expect(
+            LocalParakeetTranscriptionService.computeUnits == "cpu",
+            "Local transcription should avoid sporadic Neural Engine cold-start stalls"
+        )
     }
 
     private static func collapsesDecoderPunctuationRepetition() {

--- a/Tests/LocalParakeetTranscriptionServiceTests.swift
+++ b/Tests/LocalParakeetTranscriptionServiceTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum LocalParakeetTranscriptionServiceTests {
+    static func run() {
+        parsesAndTrimsDedicatedTranscriptField()
+        collapsesDecoderPunctuationRepetition()
+        removesUnexpectedScriptArtifacts()
+        rejectsResponsesWithoutTranscriptText()
+    }
+
+    private static func collapsesDecoderPunctuationRepetition() {
+        let data = Data("Versie 7.. Really??? Yes!!".utf8)
+        let transcript = try? LocalParakeetTranscriptionService.parseTranscript(from: data)
+        TestSupport.expectEqual(transcript, "Versie 7.. Really??? Yes!")
+    }
+
+    private static func removesUnexpectedScriptArtifacts() {
+        let data = Data("naïeve façade — goed. Ю".utf8)
+        let transcript = try? LocalParakeetTranscriptionService.parseTranscript(from: data)
+        TestSupport.expectEqual(transcript, "naïeve façade — goed.")
+
+        let nonLatin = Data("Dit is naam Юрий".utf8)
+        let preservedName = try? LocalParakeetTranscriptionService.parseTranscript(from: nonLatin)
+        TestSupport.expectEqual(preservedName, "Dit is naam Юрий")
+
+        let fullNonLatin = Data("Добрый день. Ю".utf8)
+        let preservedTranscript = try? LocalParakeetTranscriptionService.parseTranscript(from: fullNonLatin)
+        TestSupport.expectEqual(preservedTranscript, "Добрый день. Ю")
+    }
+
+    private static func parsesAndTrimsDedicatedTranscriptField() {
+        let data = Data("  Hallo wereld. \n".utf8)
+        let transcript = try? LocalParakeetTranscriptionService.parseTranscript(from: data)
+        TestSupport.expectEqual(transcript, "Hallo wereld.")
+    }
+
+    private static func rejectsResponsesWithoutTranscriptText() {
+        let data = Data()
+        do {
+            _ = try LocalParakeetTranscriptionService.parseTranscript(from: data)
+            TestSupport.expect(false, "Empty helper output should fail parsing")
+        } catch {
+            TestSupport.expect(true, "Empty helper output correctly rejected")
+        }
+    }
+}

--- a/Tests/LocalParakeetTranscriptionServiceTests.swift
+++ b/Tests/LocalParakeetTranscriptionServiceTests.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+private actor ProcessLaunchGate {
+    private var reached = false
+    private var reachedContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func pause() async {
+        reached = true
+        reachedContinuation?.resume()
+        reachedContinuation = nil
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+
+    func waitUntilReached() async {
+        guard !reached else { return }
+        await withCheckedContinuation { reachedContinuation = $0 }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
 enum LocalParakeetTranscriptionServiceTests {
     static func run() async {
         usesPredictableCPUCompute()
@@ -21,12 +44,18 @@ enum LocalParakeetTranscriptionServiceTests {
             try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
             try Data("#!/bin/sh\n/usr/bin/touch \"$0.ran\"\n".utf8).write(to: helper)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+            let launchGate = ProcessLaunchGate()
             let service = try LocalParakeetTranscriptionService(
                 modelDirectory: modelDirectory,
-                executableURL: helper
+                executableURL: helper,
+                beforeProcessLaunch: {
+                    await launchGate.pause()
+                }
             )
-            let task = Task { try await service.prewarm() }
+            let task = Task.detached { try await service.prewarm() }
+            await launchGate.waitUntilReached()
             task.cancel()
+            await launchGate.release()
             do {
                 try await task.value
                 TestSupport.expect(false, "Cancelled prewarm unexpectedly succeeded")

--- a/Tests/LocalParakeetTranscriptionServiceTests.swift
+++ b/Tests/LocalParakeetTranscriptionServiceTests.swift
@@ -1,12 +1,45 @@
 import Foundation
 
 enum LocalParakeetTranscriptionServiceTests {
-    static func run() {
+    static func run() async {
         usesPredictableCPUCompute()
+        await cancellationBeforeLaunchDoesNotRunHelper()
         parsesAndTrimsDedicatedTranscriptField()
         collapsesDecoderPunctuationRepetition()
         removesUnexpectedScriptArtifacts()
         rejectsResponsesWithoutTranscriptText()
+    }
+
+    private static func cancellationBeforeLaunchDoesNotRunHelper() async {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("freeflow-local-cancel-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = root.appendingPathComponent("fake-helper")
+        let marker = URL(fileURLWithPath: helper.path + ".ran")
+        let modelDirectory = root.appendingPathComponent("models", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+            try Data("#!/bin/sh\n/usr/bin/touch \"$0.ran\"\n".utf8).write(to: helper)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+            let service = try LocalParakeetTranscriptionService(
+                modelDirectory: modelDirectory,
+                executableURL: helper
+            )
+            let task = Task { try await service.prewarm() }
+            task.cancel()
+            do {
+                try await task.value
+                TestSupport.expect(false, "Cancelled prewarm unexpectedly succeeded")
+            } catch is CancellationError {
+                TestSupport.expect(true, "Prewarm cancellation propagated")
+            }
+            TestSupport.expect(
+                !FileManager.default.fileExists(atPath: marker.path),
+                "A helper launched after prewarm was already cancelled"
+            )
+        } catch {
+            TestSupport.expect(false, "Cancellation regression test failed: \(error)")
+        }
     }
 
     private static func usesPredictableCPUCompute() {

--- a/Tests/LocalTranscriptionPolicyTests.swift
+++ b/Tests/LocalTranscriptionPolicyTests.swift
@@ -1,0 +1,13 @@
+enum LocalTranscriptionPolicyTests {
+    static func run() {
+        let local = LocalTranscriptionPolicy(isEnabled: true)
+        TestSupport.expect(!local.allowsContextCapture, "Local mode allowed context capture")
+        TestSupport.expect(!local.allowsRealtimeStreaming, "Local mode allowed realtime streaming")
+        TestSupport.expect(!local.allowsLanguageModelProcessing, "Local mode allowed LLM processing")
+
+        let remote = LocalTranscriptionPolicy(isEnabled: false)
+        TestSupport.expect(remote.allowsContextCapture, "Remote mode lost context capture")
+        TestSupport.expect(remote.allowsRealtimeStreaming, "Remote mode lost realtime streaming")
+        TestSupport.expect(remote.allowsLanguageModelProcessing, "Remote mode lost LLM processing")
+    }
+}

--- a/Tests/TestMain.swift
+++ b/Tests/TestMain.swift
@@ -2,14 +2,14 @@ import Foundation
 
 @main
 struct FreeFlowTests {
-    static func main() {
+    static func main() async {
         AppContextServiceTests.run()
         ModelConfigurationTests.run()
         ShortcutCoreTests.run()
         SemanticVersionTests.run()
         LLMCooldownManagerTests.run()
         LocalParakeetModelStoreTests.run()
-        LocalParakeetTranscriptionServiceTests.run()
+        await LocalParakeetTranscriptionServiceTests.run()
         LocalTranscriptionPolicyTests.run()
         TranscriptTextCoreTests.run()
         print("FreeFlowTests passed")

--- a/Tests/TestMain.swift
+++ b/Tests/TestMain.swift
@@ -8,6 +8,9 @@ struct FreeFlowTests {
         ShortcutCoreTests.run()
         SemanticVersionTests.run()
         LLMCooldownManagerTests.run()
+        LocalParakeetModelStoreTests.run()
+        LocalParakeetTranscriptionServiceTests.run()
+        LocalTranscriptionPolicyTests.run()
         TranscriptTextCoreTests.run()
         print("FreeFlowTests passed")
     }

--- a/scripts/build-local-asr-helper.sh
+++ b/scripts/build-local-asr-helper.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_dir="${1:-build/local-asr}"
+runtime_repo="https://github.com/mweinbach/parakeet-coreml-swift.git"
+runtime_tag="v0.1.1"
+runtime_commit="75aec2a1c991319657ff4dec5f602c12da6c5012"
+work_dir="$(mktemp -d /tmp/freeflow-local-asr.XXXXXX)"
+
+cleanup() {
+    if [[ "$work_dir" == /tmp/freeflow-local-asr.* && -d "$work_dir" ]]; then
+        rm -rf "$work_dir"
+    fi
+}
+trap cleanup EXIT
+
+git clone --depth 1 --branch "$runtime_tag" "$runtime_repo" "$work_dir/runtime"
+actual_commit="$(git -C "$work_dir/runtime" rev-parse HEAD)"
+if [[ "$actual_commit" != "$runtime_commit" ]]; then
+    echo "Unexpected parakeet-coreml-swift commit: $actual_commit" >&2
+    exit 1
+fi
+
+swift build -c release --arch arm64 --package-path "$work_dir/runtime" --product parakeet
+
+mkdir -p "$output_dir/licenses"
+cp -f "$work_dir/runtime/.build/release/parakeet" "$output_dir/freeflow-local-asr"
+cp -f "$work_dir/runtime/LICENSE" "$output_dir/licenses/parakeet-coreml-swift-APACHE-2.0.txt"
+cp -f "$work_dir/runtime/.build/checkouts/swift-argument-parser/LICENSE.txt" \
+    "$output_dir/licenses/swift-argument-parser-APACHE-2.0.txt"
+chmod 755 "$output_dir/freeflow-local-asr"
+
+echo "Built $output_dir/freeflow-local-asr from $runtime_tag ($runtime_commit)"

--- a/scripts/build-local-asr-helper.sh
+++ b/scripts/build-local-asr-helper.sh
@@ -2,9 +2,11 @@
 set -euo pipefail
 
 output_dir="${1:-build/local-asr}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 runtime_repo="https://github.com/mweinbach/parakeet-coreml-swift.git"
 runtime_tag="v0.1.1"
 runtime_commit="75aec2a1c991319657ff4dec5f602c12da6c5012"
+argument_parser_commit="6a52f3251125d74daf04fcbd5e6f08a75d074382"
 work_dir="$(mktemp -d /tmp/freeflow-local-asr.XXXXXX)"
 
 cleanup() {
@@ -21,7 +23,16 @@ if [[ "$actual_commit" != "$runtime_commit" ]]; then
     exit 1
 fi
 
-swift build -c release --arch arm64 --package-path "$work_dir/runtime" --product parakeet
+cp -f "$script_dir/../Resources/LocalASR-Package.resolved" "$work_dir/runtime/Package.resolved"
+swift build -c release --arch arm64 --package-path "$work_dir/runtime" \
+    --product parakeet --disable-automatic-resolution
+actual_argument_parser_commit="$(
+    git -C "$work_dir/runtime/.build/checkouts/swift-argument-parser" rev-parse HEAD
+)"
+if [[ "$actual_argument_parser_commit" != "$argument_parser_commit" ]]; then
+    echo "Unexpected swift-argument-parser commit: $actual_argument_parser_commit" >&2
+    exit 1
+fi
 
 mkdir -p "$output_dir/licenses"
 cp -f "$work_dir/runtime/.build/release/parakeet" "$output_dir/freeflow-local-asr"


### PR DESCRIPTION
I've used FreeFlow for a while and really like it. The one major downside for me was that my dictated data had to be sent to a remote server. Over the past few days I developed and tested a fully local version using Parakeet TDT 0.6B v3. It is extremely fast and surprisingly accurate across English and other languages; even a smaller language such as Dutch works remarkably well without any LLM cleanup. In my use, its accuracy has been comparable to the current hosted implementation. I thought it was worth opening a PR so you can take a look and merge it if it fits the project. The technical details below were prepared by my coding agent.

## Summary

- Add an opt-in **On-Device Transcription** switch to onboarding and General Settings; the existing remote pipeline remains the default.
- Download, SHA-256 verify, prepare, report disk usage for, and remove the Parakeet TDT 0.6B v3 Core ML model from the same settings card.
- Bundle a signed, pinned Parakeet Core ML helper and invoke it as a one-shot process so the model consumes no RAM while FreeFlow is idle.
- Use CPU-only Core ML scheduling for predictable cold starts after reproducing a 43-second Neural Engine load stall after idle.
- Start a generated-silence prewarm when local recording begins, await any unfinished portion at stop, and cancel it with the recording so cold-start time normally overlaps speech.
- Make local mode a strict pipeline policy: no provider fallback, screenshots, app/selected-text context, realtime streaming, translation, Edit Mode, or language-model cleanup.

## Why

This implements a focused Parakeet/Core ML path for #249. It gives Apple-silicon users a fast Dutch- and English-capable transcription option whose dictated audio and text stay on the Mac.

## Verification

- [x] `make check`
- [x] `git diff --check`
- [x] Focused regression tests added for model integrity/removal, decoder-output repair, and the strict local pipeline policy
- [ ] Manual app verification completed, if required

Manual verification performed:

- The requester tested real Dutch dictation in the earlier local build and reported that it worked completely, very quickly, and with very good transcription.
- Removed the real model cache through `LocalParakeetModelManager`, then completed a clean managed download, SHA-256 verification, and Core ML preparation. The ready state reports 960,396,759 bytes across the source and compiled caches.
- Transcribed invented 13-second Dutch and English fixtures through the bundled service while macOS `sandbox-exec` denied all network access. Both completed successfully. After reproducing a 43.14 s ANE cold-load stall, the CPU-only fix completed the cold Dutch service run in 4.89 s and the following warm English run in 0.61 s on this M1 Pro.
- Exercised the recording-start prewarm sequence under the same network-denied sandbox. After six simulated recording seconds, no warmup wait remained at stop and the full Dutch transcription completed in another 0.69 s.
- Built the release-shaped universal app. The main executable contains `x86_64` and `arm64`; the optional helper is `arm64`; `codesign --verify --deep --strict` passes; the helper is not resident while the app is idle.
- Verified an `x86_64` typecheck and a default helper-free source build. Rebuilt the helper with both Swift dependencies locked to exact commits and automatic dependency resolution disabled.
- The integrated review app launches without crashing. The requester has used its local dictation path; final manual confirmation of the recording-start prewarm remains pending.

## Risk and privacy

- [x] No real API keys, audio, transcripts, screenshots, selected text,
      clipboard contents, window titles, or private provider URLs are included
- [x] Data sent to providers is unchanged, or the change is explained below
- [x] Credential and Keychain behavior is unchanged, or explained below
- [x] macOS permissions and entitlements are unchanged, or explained below
- [x] Preferences and pipeline-history compatibility are unchanged, or
      explained below
- [x] Signing, notarization, updates, and GitHub workflows are unchanged, or
      explained below

Risk notes:

- Remote transcription remains the default and its request path is unchanged. Local mode has no remote fallback and passes an explicit verified model directory to the helper, preventing transcription-time model downloads.
- Enabling local mode contacts Hugging Face only to download the model; no dictated audio, transcript, screenshot, selected text, or app context is sent. The approximately 459 MiB download uses about 916 MiB after Core ML compilation and can be removed from Settings.
- Local mode is available only on Apple silicon with macOS 15 or newer. Intel and macOS 13/14 builds retain the existing remote behavior.
- The one-shot CPU helper had an observed peak physical footprint of about 151 MB on the M1 Pro test Mac and exits immediately after each generated-silence prewarm or transcription, leaving no model process or model RAM resident while idle.
- The existing app entitlement file and credential/Keychain behavior are unchanged. Local mode avoids the Screen Recording path; microphone and Accessibility remain necessary for recording and pasting.
- A new opt-in UserDefaults boolean is backward compatible. Pipeline-history storage remains compatible and on-device results use the existing history behavior.
- The helper build pins `parakeet-coreml-swift` v0.1.1 to commit `75aec2a1c991319657ff4dec5f602c12da6c5012` and `swift-argument-parser` 1.8.2 to `6a52f3251125d74daf04fcbd5e6f08a75d074382`, with a committed lockfile and automatic resolution disabled. It bundles license notices and signs the nested helper before the app.
- Ordinary source builds remain helper-free and network-independent. The release and dev-release workflows now pass `INCLUDE_LOCAL_ASR=1`; no workflow permissions, secrets, signing identity setup, notarization, updater, or release-publishing logic changed.
- Rollback is immediate: turn off local mode to restore the existing provider pipeline. **Remove Model** deletes only the pinned Parakeet source directory and compiled-cache directories recorded as created by FreeFlow; unrelated Parakeet caches are preserved and excluded from its disk-usage display.

## Screenshots

Pending the requester's visual review of the separately identified review build; no user content will be included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional on-device transcription for Apple silicon Macs running macOS 15 or later.
  * Added model download, verification, preparation progress, removal controls, and installation status.
  * Local transcription keeps audio on-device, supports voice macros, preserves wording, and repairs common punctuation issues.
  * Updated setup and settings flows for local mode and cloud-dependent feature availability.
  * Release builds can optionally include local transcription components.

* **Bug Fixes**
  * Improved cleanup of model files and caches after interrupted or failed operations.
  * Screen-recording warnings now appear only when permission is required.

* **Documentation**
  * Added setup guidance and third-party notices.

* **Tests**
  * Added coverage for model management, transcription output, and local-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->