### PR TITLE
Deliver transcripts back to the element they were dictated into, and let dictations overlap

### DIFF
--- a/DEVLOG/async-delivery.md
+++ b/DEVLOG/async-delivery.md
@@ -123,6 +123,39 @@ which is why short test recordings produce 0-byte
 `prefetch_transcript_*.txt` files. Not waiting for any of it is the entire
 point of this fork.
 
+## Field results, 2026-09-02
+
+Works: Claude Code, pi, Brave, and across windows and apps, including
+continuing to type elsewhere while it delivers. Does not work: Tana, Paseo,
+and a bare shell prompt in Terminal, where the text simply disappears.
+
+Three changes came out of that session:
+
+- **Exact caret, not just the window.** `DeliveryTarget` now also pins
+  `kAXSelectedTextRange`, and the insert restores that range before writing.
+  Continuing to work at a different spot in the same document no longer sends
+  the transcript to wherever the caret happens to be.
+- **Verified writes.** An AX write into Chromium or Electron can return
+  `.success` while the text never reaches the editable surface, which is
+  precisely how a transcript vanishes in Tana. The insert now reads
+  `kAXNumberOfCharacters`, falling back to `kAXValue`, before and after, and
+  treats "no growth" as failure so the ladder falls through to the keystroke
+  tier. Elements exposing neither attribute are accepted unverified.
+- **The overlay outlives one session.** `dismissOverlayIfIdle()` only takes the
+  overlay down when no transcriptions remain, and
+  `pendingTranscriptionCount` drives a count badge to the left of the
+  processing bars, so a queue of several is legible.
+
+## Signing
+
+The bundle is signed with a stable self-signed identity, "FreeFlow Local
+Signing", created 2026-09-02 and trusted for code signing in the login
+keychain. Ad-hoc signing gave the bundle a new code identity on every rebuild,
+which made macOS silently invalidate the Accessibility grant while still
+showing the toggle as enabled; `tccutil reset Accessibility <bundle-id>` is the
+cure when that happens. Build with
+`SIGN_IDENTITY="FreeFlow Local Signing"` to keep the grant across rebuilds.
+
 ## Primary target: Paseo
 
 `@getpaseo/cli` 0.7.0, "control your AI coding agents from the command line",

--- a/DEVLOG/async-delivery.md
+++ b/DEVLOG/async-delivery.md
@@ -1,0 +1,157 @@
+# Async delivery fork — never wait on the transcription
+
+Branch: `feat/async-target-paste`
+Worktree: `/Users/personal/Documents/code/other/freeflow-fork-wt-async`
+Base: `a8d2334` (main, "durable prefetch transcripts + default prefetch on")
+
+## Goal
+
+Two things the old behaviour could not do:
+
+1. The transcript lands in the text field you were writing in when you released
+   the key, even after you switched app, window or Desktop. Your focus is never
+   pulled back.
+2. You can start the next dictation while the previous one is still
+   transcribing. Each transcript still finds its own field.
+
+## Why the previous attempt did not work
+
+`P11` (commit f2eb538) already tried "async paste": it stored the frontmost
+`NSRunningApplication` at stop time, then called `activate()` and sent Cmd-V.
+That is exactly the focus steal we are trying to remove. It also pulls you back
+to the app's Desktop, and it only ever knew the *app*, not the field, so a
+different window or tab of the same app would receive the text.
+
+## Design
+
+### Delivery ladder (`Sources/TextDelivery.swift`)
+
+`DeliveryTarget` pins, at stop time: process id, bundle id, app name, and the
+live `AXUIElement` that had keyboard focus. Delivery then tries, in order:
+
+| Tier | Mechanism | Focus steal | Works for |
+|------|-----------|-------------|-----------|
+| 1 `ax-insert` | `AXUIElementSetAttributeValue(el, kAXSelectedText, text)` on the pinned element | none | native Cocoa apps; Electron only when it accepts the write |
+| 2 `pid-keystroke` | `CGEvent.postToPid()` with `keyboardSetUnicodeString`, chunked to 16 UTF-16 units | none | terminals and anything that refuses AX writes but processes background key events |
+| 3 `activate-paste` | `activate()` + poll frontmost + Cmd-V | yes | last resort, **off by default** |
+| 4 `clipboard` | text stays on the clipboard, status line says so | none | always |
+
+Every attempt is recorded. `lastDeliveryDiagnostics` shows the whole ladder for
+the last transcript in Settings → Clipboard, so a failure says *why* it went
+where it went instead of failing silently.
+
+### Rejected: TIOCSTI
+
+Injecting characters straight into the target terminal's tty would have been
+the cleanest terminal path. macOS refuses it: `ioctl(fd, TIOCSTI)` returns
+`EPERM` (errno 13) for a non-root process, verified with a pty round-trip
+probe. Tier 2 exists because of this.
+
+### Overlapping dictations
+
+`isTranscribing` was a single boolean and `transcriptionTask` a single task, so
+starting a second dictation cancelled the first. Replaced with:
+
+- `liveTranscriptionSessions: Set<UUID>` — one id per stop.
+- `transcriptionTasksBySession: [UUID: Task]` — cancel-all on Fn+Esc.
+- `isTranscribing` is now derived (`!liveTranscriptionSessions.isEmpty`) and
+  only drives the UI.
+- The delivery target is captured into a *local* at stop time and travels with
+  that session's task, so dictation #2 cannot redirect dictation #1's text.
+- `startRecording` no longer refuses while transcribing, and the shortcut
+  controller is told `isTranscribing: false` when overlap is enabled, so the
+  start press is not swallowed.
+
+### Overlap hazards that were fixed
+
+- **Recorder torn down under the next dictation.** `audioRecorder.cleanup()`
+  ran from a transcription's completion, which now happens while a later
+  recording may already be live. It is gated behind `cleanupAudioRecorderIfIdle()`.
+- **Clipboard snapshot poisoning.** Each session snapshotted the clipboard
+  before writing its transcript. With overlap, session B's snapshot captured
+  session A's transcript and restored that as "the user's clipboard". A single
+  `outstandingClipboardSnapshot` is now taken by the first session and held
+  until the last outstanding restore releases it.
+- **Terminals first, Accessibility second.** A terminal's `AXTextArea` can
+  report `kAXSelectedText` as settable while the write only touches the
+  rendered display and never reaches the tty. For known terminal bundle ids
+  (`isTerminalLike`) tier 2 runs before tier 1.
+- **Unconfirmed keystrokes keep the clipboard.** `postToPid` reports that
+  events were posted, not that the app consumed them. After the `pid-keystroke`
+  tier the transcript deliberately stays on the clipboard and the status reads
+  "Sent to X — still on clipboard", so Cmd-V always recovers it.
+
+### Known, not fixed
+
+- `transcribingAudioFileName` is still a single var; session B overwrites it
+  before session A's completion clears it. Only affects which audio file the
+  cancel path points at.
+- `endCriticalDictationActivity()` from session A fires while B records. It is
+  idempotent-guarded, so the only effect is power-management, not audio.
+
+### Settings (Settings → Clipboard)
+
+- **Deliver back to where you were dictating** — default on.
+- **Keep dictating while earlier transcripts finish** — default on.
+- **Send keystrokes to background apps** — default on. Needed for terminals.
+- **Last resort: bring the app forward and paste** — default off. This is the
+  old behaviour; turning it on reintroduces the focus steal.
+
+## Build and install
+
+```
+cd /Users/personal/Documents/code/other/freeflow-fork-wt-async
+make ARCH=arm64
+```
+
+Install over the existing dev app (same bundle id, so it replaces it):
+
+```
+make install
+```
+
+⚠️ The bundle is ad-hoc signed, so a rebuild changes its cdhash and macOS may
+ask to re-grant Accessibility. Grant it before testing, otherwise every tier
+silently degrades to clipboard.
+
+## Test procedure (needs a person at the machine)
+
+Not yet run — the screen was locked when the branch was built.
+
+1. **Same-app, no switch.** Dictate into TextEdit, release, stay put. Text
+   should appear at the caret. Settings should show `ax-insert`.
+2. **Switch app.** Dictate into TextEdit, release, immediately click into
+   another app. Text must appear in TextEdit, and the front app must not change.
+3. **Switch Desktop.** Dictate into TextEdit, release, switch Space. Same
+   result, and no Space switch.
+4. **Terminal.** Dictate into a Claude Code prompt in Terminal, release, switch
+   away. Expect `pid-keystroke`. If the diagnostics line says
+   `pid-keystroke posted` but nothing appeared, tier 2 does not work for Apple
+   Terminal and the honest answer for terminals is clipboard + Cmd-V.
+5. **Overlap.** Dictate a long sentence, release, immediately start a second
+   dictation in a different app, release. Both transcripts must land in their
+   own field, neither cancelled.
+6. **Stale target.** Dictate into a TextEdit window, release, close the window.
+   Expect status "On clipboard — press Cmd-V", nothing typed anywhere.
+
+Record which tier each app resolves to; that table is the real deliverable.
+
+## Merge hazard
+
+This branch is based on `a8d2334` and therefore does **not** contain main's
+uncommitted work in `AppState.swift`, `AppDelegate.swift`, `MenuBarView.swift`,
+`PrefetchTranscriber.swift`, `TranscriptionProgressPanel.swift` and the
+untracked `TranscribeFileView.swift`. Main's version carries a second
+single-flight mechanism, `transcriptionAttemptID`, guarded as
+`guard self.isTranscribing, self.transcriptionAttemptID == attemptID` — that
+symbol does not exist in this worktree. It needs the same per-session treatment
+before or during the merge. Cleanest order: commit main's WIP, rebase this
+branch onto it, then re-apply the session refactor over the merged function.
+
+## Open questions for the merge
+
+- If tier 2 fails for Apple Terminal, is clipboard + Cmd-V acceptable for TUI
+  targets, or should the fork special-case iTerm2 (its AppleScript can write
+  into a specific session without focus) and suggest switching terminals?
+- Should a failed delivery raise something more visible than a status line —
+  the recording overlay, or a real notification?

--- a/DEVLOG/async-delivery.md
+++ b/DEVLOG/async-delivery.md
@@ -34,7 +34,7 @@ live `AXUIElement` that had keyboard focus. Delivery then tries, in order:
 | 1 `ax-insert` | `AXUIElementSetAttributeValue(el, kAXSelectedText, text)` on the pinned element | none | native Cocoa apps; Electron only when it accepts the write |
 | 2 `pid-keystroke` | `CGEvent.postToPid()` with `keyboardSetUnicodeString`, chunked to 16 UTF-16 units | none | terminals and anything that refuses AX writes but processes background key events |
 | 3 `activate-paste` | `activate()` + poll frontmost + Cmd-V | yes | last resort, **off by default** |
-| 4 `clipboard` | text stays on the clipboard, status line says so | none | always |
+| 4 `clipboard` | text stays on the clipboard, floating panel says so | none | always |
 
 Every attempt is recorded. `lastDeliveryDiagnostics` shows the whole ladder for
 the last transcript in Settings → Clipboard, so a failure says *why* it went
@@ -96,6 +96,32 @@ starting a second dictation cancelled the first. Replaced with:
 - **Send keystrokes to background apps** — default on. Needed for terminals.
 - **Last resort: bring the app forward and paste** — default off. This is the
   old behaviour; turning it on reintroduces the focus steal.
+
+### The clipboard tier announces itself
+
+Tier 4 raises `ClipboardWaitingPanel`, built to the same pattern as the
+"still transcribing" panel: an `NSPanel` with `.nonactivatingPanel`, floating
+level, `canJoinAllSpaces`, ordered front without activating. It appears on
+whichever Space you are on, takes no focus, names the app the text could not
+reach, shows the first 240 characters waiting on the clipboard, and gives the
+reason from the last rung of the ladder.
+
+## How slow is transcription, really
+
+Measured 2026-09-02 by posting saved recordings straight at the proxy, so the
+app is out of the picture:
+
+| audio | wall clock | ratio |
+|-------|-----------|-------|
+| 73.9 s | 44.7 s | 0.61x realtime |
+| 133.1 s | 26.5 s | 0.20x realtime |
+
+The first call carries model warm-up. So a 30-second dictation costs roughly
+10 to 25 seconds after you stop, and that cost is `asr-serve`, not FreeFlow.
+Prefetch only helps past 28 seconds of audio, because that is the chunk size,
+which is why short test recordings produce 0-byte
+`prefetch_transcript_*.txt` files. Not waiting for any of it is the entire
+point of this fork.
 
 ## Primary target: Paseo
 

--- a/DEVLOG/async-delivery.md
+++ b/DEVLOG/async-delivery.md
@@ -97,6 +97,18 @@ starting a second dictation cancelled the first. Replaced with:
 - **Last resort: bring the app forward and paste** — default off. This is the
   old behaviour; turning it on reintroduces the focus steal.
 
+## Primary target: Paseo
+
+`@getpaseo/cli` 0.7.0, "control your AI coding agents from the command line",
+installed at `~/.npm-global/bin/paseo`, running as a Paseo Supervisor plus a
+Paseo Daemon that listens on 127.0.0.1:6767 and 127.0.0.1:51021. The daemon
+answers `/` with 404 and no content type, so it is an API/WebSocket endpoint,
+not a web UI. Paseo's interface is therefore the CLI itself, which means the
+delivery target is **Apple Terminal** (`com.apple.Terminal`), already in
+`isTerminalLike`, so it resolves to tier 2 (`pid-keystroke`) and skips the AX
+tier by design. If Apple Terminal turns out to drop background key events,
+Paseo has no no-focus-steal path and the honest fallback is clipboard + Cmd-V.
+
 ## Build and install
 
 ```
@@ -104,11 +116,21 @@ cd /Users/personal/Documents/code/other/freeflow-fork-wt-async
 make ARCH=arm64
 ```
 
-Install over the existing dev app (same bundle id, so it replaces it):
+Install **alongside** the existing dev app, as its own bundle:
 
 ```
-make install
+make ARCH=arm64 APP_NAME="FreeFlow Dev Async" BUNDLE_ID="com.zachlatta.freeflow.dev.async" install
 ```
+
+That is what is installed now, at `~/Applications/FreeFlow Dev Async.app`. It
+carries the release icon rather than the hammer dev icon, so the two are
+distinguishable in the menu bar. `FreeFlow Dev.app` is untouched.
+
+Because the bundle id is new, macOS treats it as a different app: it needs its
+own Accessibility and Microphone grants, and it starts from its own settings
+domain. `hasCompletedSetup` and `updateAutoCheckEnabled` were carried over with
+`defaults export | defaults import`; anything held in the Keychain was not, so
+the API key may need entering once.
 
 ⚠️ The bundle is ad-hoc signed, so a rebuild changes its cdhash and macOS may
 ask to re-grant Accessibility. Grant it before testing, otherwise every tier
@@ -116,7 +138,10 @@ silently degrades to clipboard.
 
 ## Test procedure (needs a person at the machine)
 
-Not yet run — the screen was locked when the branch was built.
+Not yet run. Order of operations: launch `FreeFlow Dev Async`, grant
+Accessibility and Microphone when asked, set a shortcut that does not collide
+with `FreeFlow Dev` (or keep `FreeFlow Dev` quit while testing), then work
+through the cases below and note which tier each app resolves to.
 
 1. **Same-app, no switch.** Dictate into TextEdit, release, stay put. Text
    should appear at the caret. Settings should show `ax-insert`.
@@ -124,7 +149,7 @@ Not yet run — the screen was locked when the branch was built.
    another app. Text must appear in TextEdit, and the front app must not change.
 3. **Switch Desktop.** Dictate into TextEdit, release, switch Space. Same
    result, and no Space switch.
-4. **Terminal.** Dictate into a Claude Code prompt in Terminal, release, switch
+4. **Terminal / Paseo.** Dictate into a Paseo or Claude Code prompt in Terminal, release, switch
    away. Expect `pid-keystroke`. If the diagnostics line says
    `pid-keystroke posted` but nothing appeared, tier 2 does not work for Apple
    Terminal and the honest answer for terminals is clipboard + Cmd-V.

--- a/DEVLOG/async-delivery.md
+++ b/DEVLOG/async-delivery.md
@@ -161,6 +161,39 @@ through the cases below and note which tier each app resolves to.
 
 Record which tier each app resolves to; that table is the real deliverable.
 
+## First test run, 2026-09-02: recordings vanished at the transcribe step
+
+Symptom: pressing the toggle shortcut a second time made the recording
+disappear instead of producing text. Not the shortcut or the session refactor.
+The run log told the whole story:
+
+```
+1  13:10:40  com.zachlatta.freeflow.dev.async  Error: Submission failed: Endpoint not found at localhost (HTTP 404).
+2  13:10:42  com.apple.Terminal                Error: Submission failed: Endpoint not found at localhost (HTTP 404).
+3  13:11:50  com.apple.Terminal                Error: Submission failed: Endpoint not found at localhost (HTTP 404).
+4  13:12:18  com.apple.Terminal                Error: Submission failed: Endpoint not found at localhost (HTTP 404).
+```
+
+Four sessions reached "Transcribing audio" with audio files on disk, so
+recording, stop and session bookkeeping all worked. The transcription POST went
+to the wrong host.
+
+Cause: settings do not live in `UserDefaults`. `AppSettingsStorage`
+(`Sources/KeychainStorage.swift`) keeps them in a plain JSON file at
+`~/Library/Application Support/<CFBundleName>/.settings`, keyed by account, and
+`AppName.displayName` is the bundle name — so a differently *named* app gets a
+different settings file, and the new bundle started empty. Its
+`transcription_api_url` was unset, so `resolvedTranscriptionBaseURL` fell back
+to `api_base_url`, which is Ollama on :11434, which 404s on the transcription
+path.
+
+The local stack was healthy throughout: `~/qwen3_asr_rs/proxy.py` on
+127.0.0.1:8001 forwarding to `asr-serve` on 127.0.0.1:8000, which answers 200.
+
+Fix: copy `~/Library/Application Support/FreeFlow Dev/.settings` over the
+async app's copy (old one kept as a timestamped `.bak`), then relaunch. Note
+for any future side-by-side build: copy that file, not the `defaults` domain.
+
 ## Merge hazard
 
 This branch is based on `a8d2334` and therefore does **not** contain main's

--- a/DEVLOG/subsystem-delineation.html
+++ b/DEVLOG/subsystem-delineation.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>FreeFlow subsystem delineation</title>
+<style>
+  :root {
+    --bg: #faf9f7;
+    --panel: #ffffff;
+    --ink: #1a1a1a;
+    --muted: #6b6b6b;
+    --line: #d8d5d0;
+    --core: #2f6f5e;
+    --core-soft: #e3f0ec;
+    --app: #6b5b95;
+    --app-soft: #ece8f4;
+    --keep: #8a6d3b;
+    --keep-soft: #f6efe2;
+    --accent: #b03a2e;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #17181a;
+      --panel: #1f2124;
+      --ink: #ececec;
+      --muted: #9a9a9a;
+      --line: #34383d;
+      --core: #6fd3b4;
+      --core-soft: #1d3a33;
+      --app: #b3a4e0;
+      --app-soft: #2a2540;
+      --keep: #d9b874;
+      --keep-soft: #38301f;
+      --accent: #f08a7a;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    padding: 32px 24px 64px;
+  }
+  .wrap { max-width: 1100px; margin: 0 auto; }
+  h1 { font-size: 26px; margin: 0 0 4px; letter-spacing: -0.01em; }
+  .sub { color: var(--muted); margin: 0 0 28px; font-size: 14px; }
+  h2 { font-size: 17px; margin: 40px 0 10px; letter-spacing: -0.01em; }
+  p { margin: 0 0 12px; max-width: 74ch; }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 18px;
+    overflow-x: auto;
+  }
+  svg { display: block; max-width: 100%; height: auto; }
+  .legend { display: flex; gap: 20px; flex-wrap: wrap; margin: 14px 0 0; font-size: 13px; color: var(--muted); }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; }
+  .swatch { width: 13px; height: 13px; border-radius: 3px; display: inline-block; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; margin-top: 8px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: .04em; }
+  code { font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; background: rgba(128,128,128,.13); padding: 1px 5px; border-radius: 4px; }
+  .note { border-left: 3px solid var(--accent); padding-left: 14px; color: var(--muted); font-size: 14px; }
+  ul { max-width: 74ch; padding-left: 20px; }
+  li { margin-bottom: 7px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Surgically delineating the FreeFlow subsystem</h1>
+<p class="sub">What the Tana note from 2026-08-22 would actually mean in code, and where TalkWeave would plug in. Nothing here is built yet.</p>
+
+<h2>Today: one app, seven concerns</h2>
+<p>Every box below is real code in the fork. The problem is not that any of it is bad, it is that the parts another app would want are wired directly to the parts only a dictation app needs: a global hotkey, an overlay near the notch, and pasting into whatever had focus.</p>
+
+<div class="panel">
+<svg viewBox="0 0 1000 330" role="img" aria-label="FreeFlow today: trigger, capture, transcription, enrichment, delivery, presentation and persistence all inside one app target">
+  <defs>
+    <marker id="a1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+  <rect x="8" y="8" width="984" height="314" rx="10" fill="none" stroke="var(--line)" stroke-dasharray="5 4"/>
+  <text x="24" y="30" font-size="12" fill="var(--muted)" letter-spacing="1.2">ONE APP TARGET — FreeFlow Dev Async</text>
+
+  <g font-size="12.5">
+    <!-- row: pipeline -->
+    <g>
+      <rect x="28" y="52" width="150" height="86" rx="8" fill="var(--keep-soft)" stroke="var(--keep)"/>
+      <text x="103" y="76" text-anchor="middle" font-weight="700" fill="var(--ink)">Trigger</text>
+      <text x="103" y="96" text-anchor="middle" fill="var(--muted)" font-size="11">HotkeyManager</text>
+      <text x="103" y="112" text-anchor="middle" fill="var(--muted)" font-size="11">GlobalShortcutBackend</text>
+      <text x="103" y="128" text-anchor="middle" fill="var(--muted)" font-size="11">ShortcutCore/*</text>
+    </g>
+
+    <g>
+      <rect x="208" y="52" width="150" height="86" rx="8" fill="var(--core-soft)" stroke="var(--core)" stroke-width="1.5"/>
+      <text x="283" y="76" text-anchor="middle" font-weight="700" fill="var(--ink)">Capture</text>
+      <text x="283" y="96" text-anchor="middle" fill="var(--muted)" font-size="11">AudioRecorder</text>
+      <text x="283" y="112" text-anchor="middle" fill="var(--muted)" font-size="11">LiveAudioLevelNormalizer</text>
+      <text x="283" y="128" text-anchor="middle" fill="var(--muted)" font-size="11">SystemAudioStatus</text>
+    </g>
+
+    <g>
+      <rect x="388" y="52" width="170" height="86" rx="8" fill="var(--core-soft)" stroke="var(--core)" stroke-width="1.5"/>
+      <text x="473" y="76" text-anchor="middle" font-weight="700" fill="var(--ink)">Transcription</text>
+      <text x="473" y="96" text-anchor="middle" fill="var(--muted)" font-size="11">TranscriptionService</text>
+      <text x="473" y="112" text-anchor="middle" fill="var(--muted)" font-size="11">RealtimeTranscriptionService</text>
+      <text x="473" y="128" text-anchor="middle" fill="var(--muted)" font-size="11">PrefetchTranscriber</text>
+    </g>
+
+    <g>
+      <rect x="588" y="52" width="160" height="86" rx="8" fill="var(--core-soft)" stroke="var(--core)" stroke-width="1.5"/>
+      <text x="668" y="76" text-anchor="middle" font-weight="700" fill="var(--ink)">Enrichment</text>
+      <text x="668" y="96" text-anchor="middle" fill="var(--muted)" font-size="11">PostProcessingService</text>
+      <text x="668" y="112" text-anchor="middle" fill="var(--muted)" font-size="11">AppContextService</text>
+      <text x="668" y="128" text-anchor="middle" fill="var(--muted)" font-size="11">ModelConfiguration</text>
+    </g>
+
+    <g>
+      <rect x="778" y="52" width="150" height="86" rx="8" fill="var(--keep-soft)" stroke="var(--keep)"/>
+      <text x="853" y="76" text-anchor="middle" font-weight="700" fill="var(--ink)">Delivery</text>
+      <text x="853" y="96" text-anchor="middle" fill="var(--muted)" font-size="11">TextDelivery</text>
+      <text x="853" y="112" text-anchor="middle" fill="var(--muted)" font-size="11">pasteboard snapshot</text>
+      <text x="853" y="128" text-anchor="middle" fill="var(--muted)" font-size="11">AX + CGEvent tiers</text>
+    </g>
+
+    <!-- arrows between pipeline stages -->
+    <g stroke="var(--muted)" fill="none" color="var(--muted)" stroke-width="1.3">
+      <line x1="180" y1="95" x2="204" y2="95" marker-end="url(#a1)"/>
+      <line x1="360" y1="95" x2="384" y2="95" marker-end="url(#a1)"/>
+      <line x1="560" y1="95" x2="584" y2="95" marker-end="url(#a1)"/>
+      <line x1="750" y1="95" x2="774" y2="95" marker-end="url(#a1)"/>
+    </g>
+
+    <!-- cross-cutting -->
+    <g>
+      <rect x="28" y="182" width="440" height="76" rx="8" fill="var(--app-soft)" stroke="var(--app)"/>
+      <text x="248" y="206" text-anchor="middle" font-weight="700" fill="var(--ink)">Presentation</text>
+      <text x="248" y="226" text-anchor="middle" fill="var(--muted)" font-size="11">RecordingOverlay · TranscriptionProgressPanel · ClipboardWaitingPanel</text>
+      <text x="248" y="242" text-anchor="middle" fill="var(--muted)" font-size="11">MenuBarView · SettingsView · SetupView</text>
+    </g>
+
+    <g>
+      <rect x="498" y="182" width="430" height="76" rx="8" fill="var(--app-soft)" stroke="var(--app)"/>
+      <text x="713" y="206" text-anchor="middle" font-weight="700" fill="var(--ink)">Persistence and orchestration</text>
+      <text x="713" y="226" text-anchor="middle" fill="var(--muted)" font-size="11">AppState (3500 lines) · PipelineHistoryStore · AppSettingsStorage</text>
+      <text x="713" y="242" text-anchor="middle" fill="var(--muted)" font-size="11">UpdateManager · KeychainStorage</text>
+    </g>
+
+    <g stroke="var(--app)" fill="none" stroke-dasharray="3 3" opacity=".65">
+      <line x1="103" y1="138" x2="103" y2="182"/>
+      <line x1="283" y1="138" x2="283" y2="182"/>
+      <line x1="473" y1="138" x2="560" y2="182"/>
+      <line x1="668" y1="138" x2="700" y2="182"/>
+      <line x1="853" y1="138" x2="800" y2="182"/>
+    </g>
+
+    <text x="500" y="294" text-anchor="middle" fill="var(--muted)" font-size="11.5">Everything routes through one AppState, so nothing can be lifted out on its own.</text>
+  </g>
+</svg>
+<div class="legend">
+  <span><i class="swatch" style="background:var(--core-soft);border:1.5px solid var(--core)"></i> would move into the core</span>
+  <span><i class="swatch" style="background:var(--keep-soft);border:1px solid var(--keep)"></i> stays app-specific</span>
+  <span><i class="swatch" style="background:var(--app-soft);border:1px solid var(--app)"></i> app shell and glue</span>
+</div>
+</div>
+
+<h2>After the cut: a headless core with two consumers</h2>
+<p>The delineation is one seam, drawn between <em>producing text from a microphone</em> and <em>deciding when to listen and where the text goes</em>. Everything above the seam has no opinion about hotkeys, overlays, Accessibility or the menu bar.</p>
+
+<div class="panel">
+<svg viewBox="0 0 1000 350" role="img" aria-label="After extraction: a headless VoiceCore package consumed by FreeFlow and TalkWeave">
+  <g font-size="12.5">
+    <rect x="250" y="20" width="500" height="128" rx="10" fill="var(--core-soft)" stroke="var(--core)" stroke-width="2"/>
+    <text x="500" y="46" text-anchor="middle" font-weight="700" font-size="15" fill="var(--ink)">VoiceCore — headless Swift package</text>
+    <text x="500" y="68" text-anchor="middle" fill="var(--muted)" font-size="11.5">no AppKit windows · no global hotkeys · no Accessibility · no pasteboard</text>
+
+    <rect x="272" y="82" width="140" height="50" rx="6" fill="var(--panel)" stroke="var(--core)"/>
+    <text x="342" y="102" text-anchor="middle" font-weight="600" fill="var(--ink)">Capture</text>
+    <text x="342" y="119" text-anchor="middle" fill="var(--muted)" font-size="10.5">audio + level stream</text>
+
+    <rect x="430" y="82" width="140" height="50" rx="6" fill="var(--panel)" stroke="var(--core)"/>
+    <text x="500" y="102" text-anchor="middle" font-weight="600" fill="var(--ink)">Transcribe</text>
+    <text x="500" y="119" text-anchor="middle" fill="var(--muted)" font-size="10.5">file · prefetch · realtime</text>
+
+    <rect x="588" y="82" width="140" height="50" rx="6" fill="var(--panel)" stroke="var(--core)"/>
+    <text x="658" y="102" text-anchor="middle" font-weight="600" fill="var(--ink)">Post-process</text>
+    <text x="658" y="119" text-anchor="middle" fill="var(--muted)" font-size="10.5">cleanup · vocabulary</text>
+
+    <!-- consumers -->
+    <rect x="80" y="222" width="330" height="104" rx="10" fill="var(--keep-soft)" stroke="var(--keep)" stroke-width="1.5"/>
+    <text x="245" y="248" text-anchor="middle" font-weight="700" font-size="14" fill="var(--ink)">FreeFlow</text>
+    <text x="245" y="270" text-anchor="middle" fill="var(--muted)" font-size="11">trigger: global hotkey</text>
+    <text x="245" y="288" text-anchor="middle" fill="var(--muted)" font-size="11">delivery: Accessibility, keystrokes, clipboard</text>
+    <text x="245" y="306" text-anchor="middle" fill="var(--muted)" font-size="11">surface: notch overlay, menu bar</text>
+
+    <rect x="590" y="222" width="330" height="104" rx="10" fill="var(--app-soft)" stroke="var(--app)" stroke-width="1.5"/>
+    <text x="755" y="248" text-anchor="middle" font-weight="700" font-size="14" fill="var(--ink)">TalkWeave</text>
+    <text x="755" y="270" text-anchor="middle" fill="var(--muted)" font-size="11">trigger: its own, per conversation</text>
+    <text x="755" y="288" text-anchor="middle" fill="var(--muted)" font-size="11">delivery: into its own document model</text>
+    <text x="755" y="306" text-anchor="middle" fill="var(--muted)" font-size="11">surface: its own UI</text>
+
+    <g stroke="var(--core)" fill="none" stroke-width="1.6" color="var(--core)">
+      <path d="M400,148 C400,190 250,182 245,218" marker-end="url(#a1)"/>
+      <path d="M600,148 C600,190 750,182 755,218" marker-end="url(#a1)"/>
+    </g>
+    <text x="330" y="196" text-anchor="middle" fill="var(--muted)" font-size="11">same package</text>
+    <text x="680" y="196" text-anchor="middle" fill="var(--muted)" font-size="11">same package</text>
+  </g>
+</svg>
+</div>
+
+<h2>What the surgery actually costs</h2>
+<table>
+  <tr><th>Seam</th><th>Why it does not cut cleanly today</th><th>Work</th></tr>
+  <tr>
+    <td><code>AppSettingsStorage</code></td>
+    <td>Resolves its file path from <code>AppName.displayName</code>, so the core would read whichever app happens to host it. Already bit us: renaming the app gave it an empty settings file.</td>
+    <td>Inject a storage location instead of deriving one.</td>
+  </tr>
+  <tr>
+    <td><code>AppState</code></td>
+    <td>3500 lines holding recording state, transcription sessions, settings, overlay control and delivery in one object. The core's state is tangled with the app's.</td>
+    <td>Lift session bookkeeping into the core; leave the SwiftUI-facing properties behind.</td>
+  </tr>
+  <tr>
+    <td><code>AudioRecorder</code></td>
+    <td>Callback properties assigned from AppState (<code>onRecordingReady</code>, <code>onPCM16Samples</code>) and reset from several places, which is what made overlapping dictations tear the recorder down mid-recording.</td>
+    <td>Expose an async sequence per session rather than shared mutable callbacks.</td>
+  </tr>
+  <tr>
+    <td><code>AppContextService</code></td>
+    <td>Reads the frontmost app, window title and a screenshot. Meaningful for dictation, meaningless for TalkWeave.</td>
+    <td>Make context an injected provider; the core takes whatever string it is handed.</td>
+  </tr>
+  <tr>
+    <td><code>PipelineHistoryStore</code></td>
+    <td>Core Data model shaped around dictation runs.</td>
+    <td>Either move it into the core as the canonical run log, or leave it in FreeFlow and give the core a delegate.</td>
+  </tr>
+</table>
+
+<h2>Why it is worth it, and why not yet</h2>
+<ul>
+  <li><strong>Worth it:</strong> the capture and transcription stack is the expensive part, and it already works against a local Qwen3 model with chunking, prefetch and a realtime path. Rebuilding that per project is the actual waste.</li>
+  <li><strong>Worth it:</strong> the seam would force the overlapping-session bookkeeping to be explicit rather than implied by two booleans, which is where today's bugs came from.</li>
+  <li><strong>Not yet:</strong> the delivery ladder is still being proven against real apps. Extracting a core while the layer above it is still moving means doing the surgery twice.</li>
+  <li><strong>Not yet:</strong> a merge upstream is easier from a shape Zach recognises. A package split is a much larger thing to ask him to take.</li>
+</ul>
+
+<p class="note">Status: nothing extracted, nothing started. This page is the map, drawn so the decision can be made on what it costs rather than on how it sounds.</p>
+
+</div>
+<!-- Artifact seen-state badge — paste before </body> in any handed-over local HTML page.
+     First visit: bright "NEW" chip. Every later visit: muted "opened <date>" chip and the
+     whole page steps back one notch (slightly lower contrast), so an artifact the user has
+     already read visibly recedes instead of looking freshly delivered.
+     Pure localStorage, per page path. No network, no storage outside the browser profile.
+     Requires nothing from the host page except a <header> (falls back to body-prepend). -->
+<style>
+  #seen-chip{display:inline-flex;align-items:center;gap:.4rem;font-size:.72rem;
+    letter-spacing:.06em;text-transform:uppercase;padding:.2rem .55rem;border-radius:1rem;
+    border:1px solid currentColor;margin-bottom:.6rem;opacity:0}
+  #seen-chip[data-state]{opacity:1;transition:opacity .25s ease}
+  #seen-chip[data-state="new"]{color:#1d7a52;background:rgba(29,122,82,.08)}
+  #seen-chip[data-state="seen"]{color:#8b938d;background:transparent;font-weight:400}
+  @media (prefers-color-scheme:dark){
+    #seen-chip[data-state="new"]{color:#7fc4a0;background:rgba(127,196,160,.1)}
+    #seen-chip[data-state="seen"]{color:#727b76}
+  }
+  html[data-seen="1"] body{filter:saturate(.72) contrast(.96)}
+  html[data-seen="1"] h1{opacity:.82}
+</style>
+<script>
+(function () {
+  var key = 'artifact-seen:' + location.pathname;
+  var chip = document.createElement('div');
+  chip.id = 'seen-chip';
+  var prior = null;
+  try { prior = localStorage.getItem(key); } catch (e) { /* private mode: stay "new" */ }
+
+  if (prior) {
+    document.documentElement.setAttribute('data-seen', '1');
+    chip.setAttribute('data-state', 'seen');
+    chip.textContent = 'opened ' + new Date(Number(prior)).toLocaleDateString();
+  } else {
+    chip.setAttribute('data-state', 'new');
+    chip.textContent = 'new — not opened before';
+  }
+  try { localStorage.setItem(key, String(Date.now())); } catch (e) {}
+
+  var host = document.querySelector('header') || document.body;
+  host.insertBefore(chip, host.firstChild);
+})();
+</script>
+</body>
+</html>

--- a/DEVLOG/upstream-issues-draft.md
+++ b/DEVLOG/upstream-issues-draft.md
@@ -1,0 +1,109 @@
+# Draft issues for zachlatta/freeflow
+
+Not posted. Each one is written as "here is a working implementation, take it or
+argue with it", with the branch as reference, rather than a feature request.
+
+Reference branch: `feat/async-target-paste` in the fork. Push it to
+`JaPossert/freeflow` first so the links resolve, then file these.
+
+---
+
+## 1. Deliver the transcript back to the element it was dictated into
+
+**Problem.** Transcription is asynchronous but delivery is not. `pasteAtCursor`
+stores the frontmost `NSRunningApplication` at stop time, then calls
+`activate(options: .activateIgnoringOtherApps)` and posts Cmd-V. Three
+consequences: it yanks focus back mid-task, it drags you across Spaces if you
+switched Desktop, and because it only remembers the *app* it will paste into a
+different window or tab of that app if you moved.
+
+**What I did instead.** A four-rung ladder, in `Sources/TextDelivery.swift`:
+
+1. `ax-insert`: pin the `AXUIElement` that had keyboard focus at stop time
+   along with its `kAXSelectedTextRange`, then restore the range and write
+   `kAXSelectedTextAttribute`. No activation, survives Space switches, lands on
+   the exact caret rather than the window.
+2. `pid-keystroke`: `CGEvent.postToPid` with `keyboardSetUnicodeString`,
+   chunked to 16 UTF-16 units, for anything that refuses AX text writes.
+3. `activate-paste`: the current behaviour, kept but off by default.
+4. `clipboard`: leave it there and say so.
+
+Every rung records why it failed, surfaced in Settings so a misdelivery is
+diagnosable instead of mysterious.
+
+**Worth discussing.** Whether rung 3 should stay opt-in or remain the default
+for existing users.
+
+---
+
+## 2. Overlapping dictations: `isTranscribing` is single-flight
+
+**Problem.** `startRecording` refuses while `isTranscribing`, `transcriptionTask`
+is one task, and the stop path cancels it before starting the next. So a second
+dictation cannot begin until the first has fully landed. On a local model that
+is a 10 to 25 second wait per 30 seconds of speech.
+
+**What I did instead.** Sessions keyed by UUID:
+`liveTranscriptionSessions: Set<UUID>`, `transcriptionTasksBySession`, and
+`isTranscribing` derived from the set. Each session carries its own delivery
+target in a local, so dictation #2 cannot redirect dictation #1's text.
+
+Three hazards that surfaced and needed fixing, all invisible until overlap
+exists:
+- `audioRecorder.cleanup()` ran from a transcription's completion, tearing the
+  shared recorder down under a recording already in progress.
+- The clipboard snapshot was taken per session, so session B captured session
+  A's transcript and would restore *that* as "the user's clipboard".
+- `endCriticalDictationActivity()` from A fires while B records; idempotent, so
+  harmless, but worth knowing.
+
+---
+
+## 3. An AX write can report success and silently swallow the text
+
+**Problem.** `AXUIElementSetAttributeValue(el, kAXSelectedTextAttribute, text)`
+returns `.success` in Chromium and Electron apps while the text never reaches
+the editable surface. The transcript vanishes with no error anywhere.
+
+**What I did instead.** Read `kAXNumberOfCharacters`, falling back to
+`kAXValue`, before and after the write. If the element did not grow, treat the
+write as failed and fall through to the next rung. Elements that expose neither
+are accepted unverified, which is the honest default.
+
+Also: set `AXManualAccessibility` on the target application before reading its
+focused element, otherwise Chromium keeps its accessibility tree switched off.
+
+---
+
+## 4. The recording overlay disappears while transcriptions are still running
+
+**Problem.** Each completion calls `overlayManager.dismiss()`. With more than
+one transcription in flight, the first to finish takes the overlay away and the
+rest run invisibly.
+
+**What I did instead.** `dismissOverlayIfIdle()` takes the overlay down only
+when no sessions remain, and `RecordingOverlayState.pendingTranscriptionCount`
+drives a small count badge to the left of the processing bars, so a queue of
+several is legible at a glance.
+
+---
+
+## 5. The recording overlay does not show loudness
+
+**Problem.** The waveform animates but does not track input level, so there is
+no way to tell mid-sentence whether the microphone is actually hearing you.
+Wispr Flow and ordinary recorders all show this.
+
+**Status.** Not implemented yet. `LiveAudioLevelNormalizer` already carries the
+signal; the work is presentational.
+
+---
+
+## 6. First toggle-stop press is swallowed after a menu-bar start
+
+**Problem.** `beginManual(mode:)` sets `toggleStopArmed = false`, but the stop
+handler requires it true, so a recording started from the menu bar ignores the
+first shortcut press.
+
+**Fix.** `toggleStopArmed = (mode == .toggle)`. One line, no design question.
+Probably the easiest of these to take.

--- a/DEVLOG/upstream-issues-draft.md
+++ b/DEVLOG/upstream-issues-draft.md
@@ -1,10 +1,26 @@
-# Draft issues for zachlatta/freeflow
+# Issues filed on zachlatta/freeflow
 
-Not posted. Each one is written as "here is a working implementation, take it or
-argue with it", with the branch as reference, rather than a feature request.
+Filed 2026-09-02 23:21. Branch pushed to
+`https://github.com/JaPossert/freeflow/tree/feat/async-target-paste` first so
+every issue can cite real code.
 
-Reference branch: `feat/async-target-paste` in the fork. Push it to
-`JaPossert/freeflow` first so the links resolve, then file these.
+| # | Issue |
+|---|---|
+| [308](https://github.com/zachlatta/freeflow/issues/308) | Caret-exact insertion is impossible inside terminals (unresolved, with findings) |
+| [309](https://github.com/zachlatta/freeflow/issues/309) | Deliver the transcript back to the element it was dictated into, without stealing focus |
+| [310](https://github.com/zachlatta/freeflow/issues/310) | Overlapping dictations: isTranscribing is single-flight |
+| [311](https://github.com/zachlatta/freeflow/issues/311) | Electron and Chromium: Accessibility writes report success and silently swallow the text |
+| [312](https://github.com/zachlatta/freeflow/issues/312) | Recording overlay disappears while other transcriptions are still running |
+| [313](https://github.com/zachlatta/freeflow/issues/313) | Recording overlay does not show input loudness |
+| [314](https://github.com/zachlatta/freeflow/issues/314) | First toggle-stop press is swallowed after a menu-bar start |
+
+Prior contributions upstream, for context: PR #250 merged (notification banner
+instead of a URLSession timeout), PR #252 open (background HTTP
+pre-transcription while recording). Related existing issue: #237, Edit Mode
+falling back to dictation in Electron and Chromium, which #311 explains the
+mechanism for.
+
+The drafts below are what was filed.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 	@plutil -replace NSMicrophoneUsageDescription -string "$(APP_NAME) needs microphone access to transcribe your speech." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSSpeechRecognitionUsageDescription -string "$(APP_NAME) needs speech recognition to convert your voice to text." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSAccessibilityUsageDescription -string "$(APP_NAME) needs accessibility access to detect the text cursor position and paste transcribed text." "$(CONTENTS)/Info.plist"
-	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
+	@codesign --force --sign - --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 
 icon: $(ICON_ICNS)

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ endif
 	@plutil -replace NSMicrophoneUsageDescription -string "$(APP_NAME) needs microphone access to transcribe your speech." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSSpeechRecognitionUsageDescription -string "$(APP_NAME) needs speech recognition to convert your voice to text." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSAccessibilityUsageDescription -string "$(APP_NAME) needs accessibility access to detect the text cursor position and paste transcribed text." "$(CONTENTS)/Info.plist"
-	@codesign --force --sign $(SIGN_IDENTITY) --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
+	@codesign --force --sign "$(SIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 
 icon: $(ICON_ICNS)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ BUNDLE_ID ?= com.zachlatta.freeflow.dev
 BUILD_DIR = build
 APP_BUNDLE = $(BUILD_DIR)/$(APP_NAME).app
 CODESIGN_IDENTITY ?= FreeFlow Dev
+# Identity used to sign the .app itself. "-" is ad-hoc, which gives the bundle a
+# new code identity on every rebuild and makes macOS quietly invalidate its
+# Accessibility grant. Point this at a stable self-signed identity to keep the
+# grant across rebuilds:
+#   make SIGN_IDENTITY="FreeFlow Local Signing" install
+SIGN_IDENTITY ?= -
 CONTENTS = $(APP_BUNDLE)/Contents
 MACOS_DIR = $(CONTENTS)/MacOS
 empty :=
@@ -65,7 +71,7 @@ endif
 	@plutil -replace NSMicrophoneUsageDescription -string "$(APP_NAME) needs microphone access to transcribe your speech." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSSpeechRecognitionUsageDescription -string "$(APP_NAME) needs speech recognition to convert your voice to text." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSAccessibilityUsageDescription -string "$(APP_NAME) needs accessibility access to detect the text cursor position and paste transcribed text." "$(CONTENTS)/Info.plist"
-	@codesign --force --sign - --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
+	@codesign --force --sign $(SIGN_IDENTITY) --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 
 icon: $(ICON_ICNS)

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,12 @@ notarize:
 		--keychain-profile "$(NOTARIZE_PROFILE)" --wait
 	xcrun stapler staple "$(BUILD_DIR)/$(APP_NAME).dmg"
 
+install: all
+	@rm -rf "$(HOME)/Applications/$(APP_NAME).app"
+	@cp -r "$(APP_BUNDLE)" "$(HOME)/Applications/$(APP_NAME).app"
+	@xattr -dr com.apple.quarantine "$(HOME)/Applications/$(APP_NAME).app" 2>/dev/null || true
+	@echo "Installed $(APP_NAME).app"
+
 clean:
 	rm -rf $(BUILD_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ endif
 	@plutil -replace NSMicrophoneUsageDescription -string "$(APP_NAME) needs microphone access to transcribe your speech." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSSpeechRecognitionUsageDescription -string "$(APP_NAME) needs speech recognition to convert your voice to text." "$(CONTENTS)/Info.plist"
 	@plutil -replace NSAccessibilityUsageDescription -string "$(APP_NAME) needs accessibility access to detect the text cursor position and paste transcribed text." "$(CONTENTS)/Info.plist"
-	@codesign --force --sign "$(SIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
+	@codesign --force --sign "$(SIGN_IDENTITY)" --identifier "$(BUNDLE_ID)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 	@echo "Built $(APP_BUNDLE)"
 
 icon: $(ICON_ICNS)

--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -30,6 +30,7 @@ struct MenuBarLabel: View {
         if AppBuild.isDevBundle && !appState.isRecording && !appState.isTranscribing {
             Image(nsImage: StampedMenuBarIcon.templateImage)
                 .renderingMode(.template)
+                .opacity(0.4)
         } else {
             Image(systemName: iconName)
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -556,6 +556,53 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var transcriptionAlertShown = false
     // App that was frontmost when the user pressed stop — paste target for async delivery.
     private var pasteTargetApp: NSRunningApplication?
+    // Element the user was writing in when they pressed stop. Delivery goes
+    // back to this element, so switching app, window or Space while the
+    // transcription runs does not send the text somewhere else.
+    private var pendingDeliveryTarget: DeliveryTarget?
+    private let deliveryService = TextDeliveryService()
+    @Published var lastDeliveryDiagnostics: String = ""
+
+    // Overlapping dictations. Each stop opens an independent transcription
+    // session with its own delivery target, so a second recording can start
+    // while the first is still being transcribed.
+    private var liveTranscriptionSessions: Set<UUID> = []
+    // With overlapping dictations several transcripts sit on the clipboard in
+    // turn. Only the first one may snapshot it — a later snapshot would
+    // capture an earlier transcript and restore that as "the user's clipboard".
+    private var outstandingClipboardSnapshot: PreservedPasteboardSnapshot?
+    private var outstandingClipboardRestores = 0
+    private var transcriptionTasksBySession: [UUID: Task<Void, Never>] = [:]
+
+    /// Allow starting a new recording while earlier transcriptions are still
+    /// running. Each one delivers to the element it was dictated into.
+    @Published var overlappingDictationEnabled: Bool = UserDefaults.standard.object(forKey: "overlapping_dictation_enabled") == nil
+        ? true
+        : UserDefaults.standard.bool(forKey: "overlapping_dictation_enabled") {
+        didSet { UserDefaults.standard.set(overlappingDictationEnabled, forKey: "overlapping_dictation_enabled") }
+    }
+
+    /// Deliver transcripts back to the pinned element instead of pasting into
+    /// whatever happens to be focused when the text is ready.
+    @Published var asyncDeliveryEnabled: Bool = UserDefaults.standard.object(forKey: "async_delivery_enabled") == nil
+        ? true
+        : UserDefaults.standard.bool(forKey: "async_delivery_enabled") {
+        didSet { UserDefaults.standard.set(asyncDeliveryEnabled, forKey: "async_delivery_enabled") }
+    }
+
+    /// Last resort: bring the target app forward and press Cmd-V. Off by
+    /// default because it drags the user back to that app and its Space.
+    @Published var asyncDeliveryAllowFocusSteal: Bool = UserDefaults.standard.bool(forKey: "async_delivery_focus_steal") {
+        didSet { UserDefaults.standard.set(asyncDeliveryAllowFocusSteal, forKey: "async_delivery_focus_steal") }
+    }
+
+    /// Middle tier: synthesised key events addressed to the target process.
+    /// Needed for terminals, which never accept Accessibility text writes.
+    @Published var asyncDeliveryAllowProcessKeystroke: Bool = UserDefaults.standard.object(forKey: "async_delivery_pid_keystroke") == nil
+        ? true
+        : UserDefaults.standard.bool(forKey: "async_delivery_pid_keystroke") {
+        didSet { UserDefaults.standard.set(asyncDeliveryAllowProcessKeystroke, forKey: "async_delivery_pid_keystroke") }
+    }
     @Published var retryingItemIDs: Set<UUID> = []
     @Published var lastTranscript: String = ""
     @Published var errorMessage: String?
@@ -598,7 +645,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var audioLevelCancellable: AnyCancellable?
     private var debugOverlayTimer: Timer?
     private var recordingInitializationTimer: DispatchSourceTimer?
-    private var transcriptionTask: Task<Void, Never>?
     private var transcribingAudioFileName: String?
     private var contextService: AppContextService
     private var contextCaptureTask: Task<AppContext?, Never>?
@@ -1685,7 +1731,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
 
-        guard let action = shortcutSessionController.handle(event: event, isTranscribing: isTranscribing) else {
+        guard let action = shortcutSessionController.handle(
+            event: event,
+            isTranscribing: overlappingDictationEnabled ? false : isTranscribing
+        ) else {
             return
         }
 
@@ -1786,8 +1835,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func cancelTranscription() {
         guard isTranscribing else { return }
 
-        transcriptionTask?.cancel()
-        transcriptionTask = nil
+        cancelAllTranscriptionSessions()
         contextCaptureTask?.cancel()
         contextCaptureTask = nil
         capturedContext = nil
@@ -1928,7 +1976,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func startRecording(triggerMode: RecordingTriggerMode) {
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
-        guard !isRecording && !isTranscribing else { return }
+        guard !isRecording else { return }
+        guard overlappingDictationEnabled || !isTranscribing else { return }
         let scheduledSelectionSnapshot = pendingSelectionSnapshot
         let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
@@ -2122,6 +2171,41 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Tears the shared recorder down only when no dictation is running. An
+    /// earlier transcript finishing must not cut off the recording the user
+    /// started in the meantime.
+    private func cleanupAudioRecorderIfIdle() {
+        guard !isRecording else { return }
+        audioRecorder.cleanup()
+        refreshAvailableMicrophonesIfNeeded()
+    }
+
+    private func beginTranscriptionSession() -> UUID {
+        let id = UUID()
+        liveTranscriptionSessions.insert(id)
+        isTranscribing = true
+        return id
+    }
+
+    private func isSessionLive(_ id: UUID) -> Bool {
+        liveTranscriptionSessions.contains(id)
+    }
+
+    private func endTranscriptionSession(_ id: UUID) {
+        liveTranscriptionSessions.remove(id)
+        transcriptionTasksBySession[id] = nil
+        isTranscribing = !liveTranscriptionSessions.isEmpty
+    }
+
+    private func cancelAllTranscriptionSessions() {
+        for task in transcriptionTasksBySession.values {
+            task.cancel()
+        }
+        transcriptionTasksBySession.removeAll()
+        liveTranscriptionSessions.removeAll()
+        isTranscribing = false
+    }
+
     private func beginCriticalDictationActivity() {
         guard !automaticTerminationDisabled else { return }
         ProcessInfo.processInfo.disableAutomaticTermination("FreeFlow dictation in progress")
@@ -2237,8 +2321,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         restoreAudioInterruptionIfNeeded()
         isRecording = false
         isTranscribing = false
-        transcriptionTask?.cancel()
-        transcriptionTask = nil
+        cancelAllTranscriptionSessions()
         // Keep the saved audio file — it's available in the run log for retry.
         self.transcribingAudioFileName = nil
         activeRecordingTriggerMode = nil
@@ -2491,6 +2574,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         // app; fall back to the session-start context only when FreeFlow is already
         // frontmost (i.e. the user opened the menu to click stop).
         let stopTimeFrontmost = NSWorkspace.shared.frontmostApplication
+        pendingDeliveryTarget = TextDeliveryService.captureTarget(
+            ownBundleIdentifier: Bundle.main.bundleIdentifier,
+            fallbackBundleIdentifier: capturedContext?.bundleIdentifier
+        )
         if let front = stopTimeFrontmost, front.bundleIdentifier != Bundle.main.bundleIdentifier {
             pasteTargetApp = front
         } else if let bundleId = capturedContext?.bundleIdentifier, bundleId != Bundle.main.bundleIdentifier {
@@ -2525,7 +2612,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         lastContextScreenshotStatus = "No screenshot"
         isRecording = false
         restoreAudioInterruptionIfNeeded()
-        isTranscribing = true
+        let transcriptionSessionID = beginTranscriptionSession()
+        // Each session keeps its own target so a later dictation cannot
+        // redirect an earlier transcript.
+        let sessionDeliveryTarget = pendingDeliveryTarget
+        pendingDeliveryTarget = nil
         statusText = "Preparing audio..."
         errorMessage = nil
         playAlertSound(named: "Pop")
@@ -2533,7 +2624,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioRecorder.stopRecording { [weak self] fileURL in
             guard let self else { return }
             guard let fileURL else {
-                self.isTranscribing = false
+                self.endTranscriptionSession(transcriptionSessionID)
                 self.audioRecorder.cleanup()
                 self.endCriticalDictationActivity()
                 self.errorMessage = "No audio recorded"
@@ -2543,7 +2634,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return
             }
 
-            guard self.isTranscribing else {
+            guard self.isSessionLive(transcriptionSessionID) else {
                 self.tearDownRealtimeService()
                 self.audioRecorder.cleanup()
                 self.refreshAvailableMicrophonesIfNeeded()
@@ -2569,8 +2660,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             let activePrefetch = self.prefetchTranscriber
             self.prefetchTranscriber = nil
             self.audioRecorder.onPCM16Samples = nil
-            self.transcriptionTask?.cancel()
-            guard self.isTranscribing else {
+            guard self.isSessionLive(transcriptionSessionID) else {
                 // Transcription was cancelled mid-flight. Keep the saved audio
                 // file so it remains available in the run log for retry.
                 self.transcribingAudioFileName = nil
@@ -2580,7 +2670,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.refreshAvailableMicrophonesIfNeeded()
                 return
             }
-            self.transcriptionTask = Task {
+            let sessionTask = Task {
                 defer {
                     activeRealtime?.cancel()
                 }
@@ -2662,10 +2752,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             intent: sessionIntent,
                             audioFileName: savedAudioFile?.fileName
                         )
-                        self.transcriptionTask = nil
+                        self.endTranscriptionSession(transcriptionSessionID)
                         self.transcribingAudioFileName = nil
                         self.lastTranscript = trimmedFinalTranscript
-                        self.isTranscribing = false
                         self.endCriticalDictationActivity()
                         self.debugStatusMessage = "Done"
                         let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
@@ -2701,7 +2790,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             }
 
                             let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
-                            self.pasteAtCursorWhenShortcutReleased {
+                            let afterDelivery: () -> Void = {
                                 if shouldPressEnterAfterPaste {
                                     self.pressEnterAfterPaste {
                                         self.restoreClipboardIfNeeded(pendingClipboardRestore)
@@ -2710,16 +2799,34 @@ final class AppState: ObservableObject, @unchecked Sendable {
                                     self.restoreClipboardIfNeeded(pendingClipboardRestore)
                                 }
                             }
+                            if self.asyncDeliveryEnabled {
+                                self.deliverTranscriptToPinnedTarget(
+                                    trimmedFinalTranscript,
+                                    target: sessionDeliveryTarget,
+                                    pressReturnAfter: shouldPressEnterAfterPaste
+                                ) {
+                                    self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                                }
+                            } else {
+                                self.pasteAtCursorWhenShortcutReleased(completion: afterDelivery)
+                            }
                         }
 
-                        self.audioRecorder.cleanup()
-                        self.refreshAvailableMicrophonesIfNeeded()
+                        self.cleanupAudioRecorderIfIdle()
 
-                        self.scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe", enterOnlyStatusText])
+                        self.scheduleReadyStatusReset(
+                            after: 3,
+                            matching: [
+                                completionStatusText,
+                                "Nothing to transcribe",
+                                enterOnlyStatusText,
+                                Self.clipboardWaitingStatusText
+                            ]
+                        )
                     }
                 } catch is CancellationError {
                     await MainActor.run {
-                        self.transcriptionTask = nil
+                        self.endTranscriptionSession(transcriptionSessionID)
                         self.endCriticalDictationActivity()
                     }
                 } catch {
@@ -2732,11 +2839,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         resolvedContext = self.fallbackContextAtStop()
                     }
                     await MainActor.run {
-                        guard self.isTranscribing else { return }
-                        self.transcriptionTask = nil
+                        guard self.isSessionLive(transcriptionSessionID) else { return }
+                        self.endTranscriptionSession(transcriptionSessionID)
                         self.transcribingAudioFileName = nil
                         self.errorMessage = error.localizedDescription
-                        self.isTranscribing = false
                         self.endCriticalDictationActivity()
                         self.statusText = "Error"
                         self.overlayManager.dismiss()
@@ -2758,11 +2864,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             intent: sessionIntent,
                             audioFileName: savedAudioFile?.fileName
                         )
-                        self.audioRecorder.cleanup()
-                        self.refreshAvailableMicrophonesIfNeeded()
+                        self.cleanupAudioRecorderIfIdle()
                     }
                 }
             }
+            self.transcriptionTasksBySession[transcriptionSessionID] = sessionTask
         }
     }
 
@@ -3147,6 +3253,58 @@ final class AppState: ObservableObject, @unchecked Sendable {
         NotificationCenter.default.post(name: .showSettings, object: nil)
     }
 
+    static let clipboardWaitingStatusText = "On clipboard — press Cmd-V"
+
+    /// Delivers a finished transcript back to the element the user was writing
+    /// in when they stopped dictating. Never changes the frontmost app unless
+    /// the focus-steal fallback is explicitly enabled.
+    private func deliverTranscriptToPinnedTarget(
+        _ text: String,
+        target: DeliveryTarget?,
+        pressReturnAfter: Bool,
+        completion: @escaping () -> Void
+    ) {
+        pasteTargetApp = nil
+        deliveryService.allowFocusStealFallback = asyncDeliveryAllowFocusSteal
+        deliveryService.allowProcessKeystroke = asyncDeliveryAllowProcessKeystroke
+        deliveryService.deliver(text, to: target) { [weak self] outcome in
+            guard let self else { return }
+            let apply = {
+                self.lastDeliveryDiagnostics = outcome.attempts.joined(separator: " | ")
+                self.debugStatusMessage = "Delivery: \(outcome.summary)"
+                if outcome.succeeded {
+                    if pressReturnAfter, let target {
+                        self.deliveryService.pressReturn(target: target, tier: outcome.tier)
+                    }
+                } else {
+                    self.statusText = Self.clipboardWaitingStatusText
+                }
+
+                switch outcome.tier {
+                case .accessibilityInsert, .activateAndPaste:
+                    // The text is demonstrably in the target, so the previous
+                    // clipboard can come back.
+                    completion()
+                case .processKeystroke:
+                    // Key events were posted but nothing confirms the app
+                    // consumed them. Leave the transcript on the clipboard so
+                    // Cmd-V still recovers it.
+                    let keystrokeStatus = "Sent to \(outcome.target) — still on clipboard"
+                    self.statusText = keystrokeStatus
+                    self.scheduleReadyStatusReset(after: 3, matching: [keystrokeStatus])
+                    self.releaseClipboardSnapshotHold()
+                case .clipboardOnly:
+                    self.releaseClipboardSnapshotHold()
+                }
+            }
+            if Thread.isMainThread {
+                apply()
+            } else {
+                DispatchQueue.main.async(execute: apply)
+            }
+        }
+    }
+
     private func pasteAtCursor(completion: (() -> Void)? = nil) {
         guard let target = pasteTargetApp, !target.isTerminated else {
             pasteTargetApp = nil
@@ -3231,7 +3389,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
     /// - Returns: A `PendingClipboardRestore` object if clipboard preservation is enabled, otherwise nil.
     private func writeTranscriptToPasteboard(_ transcript: String) -> PendingClipboardRestore? {
         let pasteboard = NSPasteboard.general
-        let snapshot = preserveClipboard ? PreservedPasteboardSnapshot(pasteboard: pasteboard) : nil
+        let snapshot: PreservedPasteboardSnapshot?
+        if preserveClipboard {
+            if let existing = outstandingClipboardSnapshot {
+                snapshot = existing
+            } else {
+                let fresh = PreservedPasteboardSnapshot(pasteboard: pasteboard)
+                outstandingClipboardSnapshot = fresh
+                snapshot = fresh
+            }
+            outstandingClipboardRestores += 1
+        } else {
+            snapshot = nil
+        }
 
         // Append a space when ending with sentence-ending punctuation so the
         // next dictation does not jam against the prior period.
@@ -3280,6 +3450,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func restoreClipboardIfNeeded(_ pendingRestore: PendingClipboardRestore?) {
         guard let pendingRestore else { return }
+        releaseClipboardSnapshotHold()
 
         // Some apps consume Cmd-V asynchronously, so restoring too quickly can paste
         // the pre-dictation clipboard instead of the transcript.
@@ -3296,6 +3467,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard pasteboard.changeCount == pendingRestore.expectedChangeCount
                 || clipboardStillHoldsTranscript else { return }
             pendingRestore.snapshot.restore(to: pasteboard)
+        }
+    }
+
+    /// Called once per pasteboard write, whether or not that write is actually
+    /// restored, so the shared snapshot is dropped when nothing is pending.
+    private func releaseClipboardSnapshotHold() {
+        outstandingClipboardRestores = max(0, outstandingClipboardRestores - 1)
+        if outstandingClipboardRestores == 0 {
+            outstandingClipboardSnapshot = nil
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3330,8 +3330,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
+        let recordingDuration: String? = {
+            guard let url = URL(string: "file://" + audioPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!),
+                  let file = try? AVAudioFile(forReading: url) else { return nil }
+            let seconds = Int(Double(file.length) / file.fileFormat.sampleRate)
+            guard seconds > 0 else { return nil }
+            return seconds >= 60 ? "\(seconds / 60)m \(seconds % 60)s" : "\(seconds)s"
+        }()
+
         let hostingView = NSHostingView(rootView: TranscriptionProgressPanel(
             audioPath: audioPath,
+            recordingDuration: recordingDuration,
             onDismiss: { [weak panel] in panel?.orderOut(nil) },
             onCancel: { [weak self, weak panel] in
                 panel?.orderOut(nil)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3286,7 +3286,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         transcriptionElapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self, self.isTranscribing, let start = self.transcriptionStartTime else { return }
             let elapsed = Int(-start.timeIntervalSinceNow)
-            if elapsed == 10 && !self.transcriptionAlertShown {
+            if elapsed >= 10 && !self.transcriptionAlertShown {
                 self.transcriptionAlertShown = true
                 self.showTranscriptionStillRunningAlert(elapsed: elapsed)
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -538,6 +538,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
     private var transcriptionStartTime: Date?
     private var transcriptionElapsedTimer: Timer?
+    // App that was frontmost when the user pressed stop — paste target for async delivery.
+    private var pasteTargetApp: NSRunningApplication?
     @Published var retryingItemIDs: Set<UUID> = []
     @Published var lastTranscript: String = ""
     @Published var errorMessage: String?
@@ -2455,6 +2457,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func stopAndTranscribe() {
+        // Capture the app the user was working in when they pressed stop.
+        // Must happen before any focus changes. Prefer the true stop-time frontmost
+        // app; fall back to the session-start context only when FreeFlow is already
+        // frontmost (i.e. the user opened the menu to click stop).
+        let stopTimeFrontmost = NSWorkspace.shared.frontmostApplication
+        if let front = stopTimeFrontmost, front.bundleIdentifier != Bundle.main.bundleIdentifier {
+            pasteTargetApp = front
+        } else if let bundleId = capturedContext?.bundleIdentifier, bundleId != Bundle.main.bundleIdentifier {
+            pasteTargetApp = NSWorkspace.shared.runningApplications.first {
+                $0.bundleIdentifier == bundleId && $0.activationPolicy == .regular
+            }
+        } else {
+            pasteTargetApp = nil
+        }
+
         cancelPendingShortcutStart()
         cancelRecordingInitializationTimer()
         shortcutSessionController.reset()
@@ -3071,7 +3088,33 @@ final class AppState: ObservableObject, @unchecked Sendable {
         NotificationCenter.default.post(name: .showSettings, object: nil)
     }
 
-    private func pasteAtCursor() {
+    private func pasteAtCursor(completion: (() -> Void)? = nil) {
+        guard let target = pasteTargetApp, !target.isTerminated else {
+            pasteTargetApp = nil
+            sendCmdV()
+            completion?()
+            return
+        }
+        pasteTargetApp = nil
+        target.activate(options: [.activateIgnoringOtherApps])
+        // Poll until the target is actually frontmost before sending Cmd-V —
+        // a fixed delay is unreliable under CPU load (local model inference).
+        waitUntilFrontmost(target, attemptsLeft: 20, completion: completion)
+    }
+
+    private func waitUntilFrontmost(_ target: NSRunningApplication, attemptsLeft: Int, completion: (() -> Void)?) {
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == target.processIdentifier
+            || attemptsLeft <= 0 {
+            sendCmdV()
+            completion?()
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.waitUntilFrontmost(target, attemptsLeft: attemptsLeft - 1, completion: completion)
+        }
+    }
+
+    private func sendCmdV() {
         let source = CGEventSource(stateID: .hidSystemState)
         let vKeyCode = keyCodeForCharacter("v") ?? 9
 
@@ -3213,8 +3256,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func pasteAtCursorWhenShortcutReleased(completion: (() -> Void)? = nil) {
         performAfterShortcutReleased { [weak self] in
-            self?.pasteAtCursor()
-            completion?()
+            self?.pasteAtCursor(completion: completion)
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -582,6 +582,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         didSet { UserDefaults.standard.set(overlappingDictationEnabled, forKey: "overlapping_dictation_enabled") }
     }
 
+    /// Show a scrolling loudness meter while recording instead of the
+    /// decorative waveform, so it is obvious mid-sentence that the microphone
+    /// is actually picking you up.
+    @Published var loudnessMeterEnabled: Bool = UserDefaults.standard.object(forKey: "loudness_meter_enabled") == nil
+        ? true
+        : UserDefaults.standard.bool(forKey: "loudness_meter_enabled") {
+        didSet {
+            UserDefaults.standard.set(loudnessMeterEnabled, forKey: "loudness_meter_enabled")
+            overlayManager.setShowsLoudnessMeter(loudnessMeterEnabled)
+        }
+    }
+
     /// Deliver transcripts back to the pinned element instead of pasting into
     /// whatever happens to be focused when the text is ready.
     @Published var asyncDeliveryEnabled: Bool = UserDefaults.standard.object(forKey: "async_delivery_enabled") == nil
@@ -2251,6 +2263,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         errorMessage = nil
 
         isRecording = true
+        overlayManager.setShowsLoudnessMeter(loudnessMeterEnabled)
         refreshPendingSessionCount()
         statusText = "Starting..."
         hasShownScreenshotPermissionAlert = false

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3253,7 +3253,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         NotificationCenter.default.post(name: .showSettings, object: nil)
     }
 
-    static let clipboardWaitingStatusText = "On clipboard — press Cmd-V"
+    static let clipboardWaitingStatusText = "On clipboard, press Cmd-V"
 
     /// Delivers a finished transcript back to the element the user was writing
     /// in when they stopped dictating. Never changes the frontmost app unless
@@ -3289,7 +3289,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     // Key events were posted but nothing confirms the app
                     // consumed them. Leave the transcript on the clipboard so
                     // Cmd-V still recovers it.
-                    let keystrokeStatus = "Sent to \(outcome.target) — still on clipboard"
+                    let keystrokeStatus = "Sent to \(outcome.target), still on clipboard"
                     self.statusText = keystrokeStatus
                     self.scheduleReadyStatusReset(after: 3, matching: [keystrokeStatus])
                     self.releaseClipboardSnapshotHold()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1818,6 +1818,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         capturedContext = nil
         currentSessionIntent = .dictation
         isRecording = false
+        refreshPendingSessionCount()
         errorMessage = nil
         debugStatusMessage = "Cancelled"
         statusText = "Cancelled"
@@ -2184,7 +2185,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let id = UUID()
         liveTranscriptionSessions.insert(id)
         isTranscribing = true
-        overlayManager.setPendingTranscriptionCount(liveTranscriptionSessions.count)
+        refreshPendingSessionCount()
         return id
     }
 
@@ -2196,12 +2197,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
         liveTranscriptionSessions.remove(id)
         transcriptionTasksBySession[id] = nil
         isTranscribing = !liveTranscriptionSessions.isEmpty
-        overlayManager.setPendingTranscriptionCount(liveTranscriptionSessions.count)
+        refreshPendingSessionCount()
         // An earlier transcript finishing must not take the overlay away from
         // the ones still running behind it.
         if isTranscribing {
             overlayManager.showTranscribing()
         }
+    }
+
+    /// How many dictations are in flight at once: every transcription still
+    /// running, plus the one being recorded right now. That is the number that
+    /// matters while speaking a second one over the top of the first.
+    private func refreshPendingSessionCount() {
+        let inFlight = liveTranscriptionSessions.count + (isRecording ? 1 : 0)
+        overlayManager.setPendingTranscriptionCount(inFlight)
     }
 
     /// Takes the overlay down only when nothing is still being transcribed.
@@ -2220,7 +2229,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         transcriptionTasksBySession.removeAll()
         liveTranscriptionSessions.removeAll()
         isTranscribing = false
-        overlayManager.setPendingTranscriptionCount(0)
+        refreshPendingSessionCount()
     }
 
     private func beginCriticalDictationActivity() {
@@ -2242,6 +2251,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         errorMessage = nil
 
         isRecording = true
+        refreshPendingSessionCount()
         statusText = "Starting..."
         hasShownScreenshotPermissionAlert = false
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import AppKit
+import SwiftUI
 import AVFoundation
 import ServiceManagement
 import ApplicationServices
@@ -3301,28 +3302,54 @@ final class AppState: ObservableObject, @unchecked Sendable {
         transcriptionElapsedTimer = nil
         transcriptionStartTime = nil
         transcriptionAlertShown = false
+        dismissTranscriptionAlertPanelIfShowing()
     }
+
+    private weak var transcriptionAlertPanel: NSPanel?
 
     private func showTranscriptionStillRunningAlert(elapsed: Int) {
         guard isTranscribing else { return }
-        let audioNote: String
+        guard transcriptionAlertPanel == nil else { return }  // already showing
+
+        let audioPath: String
         if let fileName = transcribingAudioFileName {
-            let path = Self.audioStorageDirectory().appendingPathComponent(fileName).path
-            audioNote = "Audio saved to:\n\(path)"
+            audioPath = Self.audioStorageDirectory().appendingPathComponent(fileName).path
         } else {
-            audioNote = "Audio saved to:\n~/Library/Application Support/FreeFlow Dev/audio/"
+            audioPath = Self.audioStorageDirectory().path
         }
-        let alert = NSAlert()
-        alert.messageText = "Still transcribing (\(elapsed)s elapsed)"
-        alert.informativeText = "With local processing, this can take as long as your recording — or longer under load.\n\nYour audio is already saved. If you cancel, it will remain on disk and you can retry transcription from the recording history.\n\n\(audioNote)"
-        alert.addButton(withTitle: "Keep Waiting")
-        alert.addButton(withTitle: "Cancel Transcription")
-        if let icon = NSImage(systemSymbolName: "waveform.badge.exclamationmark", accessibilityDescription: nil) {
-            alert.icon = icon
-        }
-        let response = alert.runModal()
-        guard response == .alertSecondButtonReturn, isTranscribing else { return }
-        cancelTranscription()
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 1),
+            styleMask: [.titled, .closable, .nonactivatingPanel, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Still transcribing (\(elapsed)s elapsed)"
+        panel.level = .floating
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        let hostingView = NSHostingView(rootView: TranscriptionProgressPanel(
+            audioPath: audioPath,
+            onDismiss: { [weak panel] in panel?.orderOut(nil) },
+            onCancel: { [weak self, weak panel] in
+                panel?.orderOut(nil)
+                guard self?.isTranscribing == true else { return }
+                self?.cancelTranscription()
+            }
+        ))
+        hostingView.frame = NSRect(x: 0, y: 0, width: 440, height: hostingView.fittingSize.height)
+        panel.contentView = hostingView
+        panel.setContentSize(hostingView.fittingSize)
+        panel.center()
+        panel.orderFront(nil)
+        transcriptionAlertPanel = panel
+    }
+
+    private func dismissTranscriptionAlertPanelIfShowing() {
+        transcriptionAlertPanel?.orderOut(nil)
+        transcriptionAlertPanel = nil
     }
 
     private func scheduleReadyStatusReset(after delay: TimeInterval, matching statuses: Set<String>? = nil) {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2184,6 +2184,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let id = UUID()
         liveTranscriptionSessions.insert(id)
         isTranscribing = true
+        overlayManager.setPendingTranscriptionCount(liveTranscriptionSessions.count)
         return id
     }
 
@@ -2195,6 +2196,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         liveTranscriptionSessions.remove(id)
         transcriptionTasksBySession[id] = nil
         isTranscribing = !liveTranscriptionSessions.isEmpty
+        overlayManager.setPendingTranscriptionCount(liveTranscriptionSessions.count)
+        // An earlier transcript finishing must not take the overlay away from
+        // the ones still running behind it.
+        if isTranscribing {
+            overlayManager.showTranscribing()
+        }
+    }
+
+    /// Takes the overlay down only when nothing is still being transcribed.
+    private func dismissOverlayIfIdle() {
+        guard liveTranscriptionSessions.isEmpty else {
+            overlayManager.showTranscribing()
+            return
+        }
+        overlayManager.dismiss()
     }
 
     private func cancelAllTranscriptionSessions() {
@@ -2204,6 +2220,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         transcriptionTasksBySession.removeAll()
         liveTranscriptionSessions.removeAll()
         isTranscribing = false
+        overlayManager.setPendingTranscriptionCount(0)
     }
 
     private func beginCriticalDictationActivity() {
@@ -2629,7 +2646,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.endCriticalDictationActivity()
                 self.errorMessage = "No audio recorded"
                 self.statusText = "Error"
-                self.overlayManager.dismiss()
+                self.dismissOverlayIfIdle()
                 self.refreshAvailableMicrophonesIfNeeded()
                 return
             }
@@ -2773,7 +2790,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             self.statusText = shouldPressEnterAfterPaste ? enterOnlyStatusText : "Nothing to transcribe"
                             self.clearPendingOverlayDismissToken()
                             if !self.showPostTranscriptionUpdateReminderIfNeeded() {
-                                self.overlayManager.dismiss()
+                                self.dismissOverlayIfIdle()
                             }
                             if shouldPressEnterAfterPaste {
                                 self.pressEnterWhenShortcutReleased()
@@ -2785,7 +2802,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             } else {
                                 self.clearPendingOverlayDismissToken()
                                 if !self.showPostTranscriptionUpdateReminderIfNeeded() {
-                                    self.overlayManager.dismiss()
+                                    self.dismissOverlayIfIdle()
                                 }
                             }
 
@@ -2845,7 +2862,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.errorMessage = error.localizedDescription
                         self.endCriticalDictationActivity()
                         self.statusText = "Error"
-                        self.overlayManager.dismiss()
+                        self.dismissOverlayIfIdle()
                         self.lastPostProcessedTranscript = ""
                         self.lastRawTranscript = ""
                         self.lastContextSummary = ""
@@ -3199,7 +3216,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         DispatchQueue.main.asyncAfter(deadline: .now() + postTranscriptionUpdateReminderDuration) { [weak self] in
             guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
             self.pendingOverlayDismissToken = nil
-            self.overlayManager.dismiss()
+            self.dismissOverlayIfIdle()
         }
 
         return true
@@ -3219,7 +3236,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         DispatchQueue.main.asyncAfter(deadline: .now() + postTranscriptionUpdateReminderDuration) { [weak self] in
             guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
             self.pendingOverlayDismissToken = nil
-            self.overlayManager.dismiss()
+            self.dismissOverlayIfIdle()
         }
     }
 
@@ -3244,7 +3261,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
             self.pendingOverlayDismissToken = nil
-            self.overlayManager.dismiss()
+            self.dismissOverlayIfIdle()
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3295,6 +3295,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     self.releaseClipboardSnapshotHold()
                 case .clipboardOnly:
                     self.releaseClipboardSnapshotHold()
+                    self.showClipboardWaitingPanel(outcome: outcome, transcript: text)
                 }
             }
             if Thread.isMainThread {
@@ -3591,6 +3592,48 @@ final class AppState: ObservableObject, @unchecked Sendable {
         panel.center()
         panel.orderFront(nil)
         transcriptionAlertPanel = panel
+    }
+
+    private weak var clipboardWaitingPanel: NSPanel?
+
+    /// Same presentation as the "still transcribing" panel: floating,
+    /// non-activating, visible on whichever Space the user is on now.
+    private func showClipboardWaitingPanel(outcome: DeliveryOutcome, transcript: String) {
+        dismissClipboardWaitingPanelIfShowing()
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 1),
+            styleMask: [.titled, .closable, .nonactivatingPanel, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Transcript on the clipboard"
+        panel.level = .floating
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        let preview = transcript.count > 240
+            ? String(transcript.prefix(240)) + "..."
+            : transcript
+
+        let hostingView = NSHostingView(rootView: ClipboardWaitingPanel(
+            targetDescription: outcome.target,
+            reason: outcome.attempts.last,
+            transcriptPreview: preview,
+            onDismiss: { [weak panel] in panel?.orderOut(nil) }
+        ))
+        hostingView.frame = NSRect(x: 0, y: 0, width: 440, height: hostingView.fittingSize.height)
+        panel.contentView = hostingView
+        panel.setContentSize(hostingView.fittingSize)
+        panel.center()
+        panel.orderFront(nil)
+        clipboardWaitingPanel = panel
+    }
+
+    private func dismissClipboardWaitingPanelIfShowing() {
+        clipboardWaitingPanel?.orderOut(nil)
+        clipboardWaitingPanel = nil
     }
 
     private func dismissTranscriptionAlertPanelIfShowing() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -529,7 +529,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             AppState.writeRecordingStateFlag(isRecording)
         }
     }
-    @Published var isTranscribing = false
+    @Published var isTranscribing = false {
+        didSet {
+            if !isTranscribing && oldValue {
+                stopTranscriptionElapsedTimer()
+            }
+        }
+    }
+    private var transcriptionStartTime: Date?
+    private var transcriptionElapsedTimer: Timer?
     @Published var retryingItemIDs: Set<UUID> = []
     @Published var lastTranscript: String = ""
     @Published var errorMessage: String?
@@ -1770,10 +1778,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         statusText = "Cancelled"
         overlayManager.dismiss()
         audioRecorder.cleanup()
-        if let transcribingAudioFileName {
-            Self.deleteAudioFile(transcribingAudioFileName)
-            self.transcribingAudioFileName = nil
-        }
+        // Keep the saved audio file — it's available in the run log for retry.
+        self.transcribingAudioFileName = nil
         endCriticalDictationActivity()
         refreshAvailableMicrophonesIfNeeded()
         if !isRecording && !isTranscribing && statusText == "Cancelled" {
@@ -2209,10 +2215,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isTranscribing = false
         transcriptionTask?.cancel()
         transcriptionTask = nil
-        if let transcribingAudioFileName {
-            Self.deleteAudioFile(transcribingAudioFileName)
-            self.transcribingAudioFileName = nil
-        }
+        // Keep the saved audio file — it's available in the run log for retry.
+        self.transcribingAudioFileName = nil
         activeRecordingTriggerMode = nil
         currentSessionIntent = .dictation
         shortcutSessionController.reset()
@@ -2505,6 +2509,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.transcribingAudioFileName = savedAudioFile?.fileName
             self.statusText = "Transcribing..."
             self.debugStatusMessage = "Transcribing audio"
+            self.startTranscriptionElapsedTimer()
 
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
@@ -2518,9 +2523,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.audioRecorder.onPCM16Samples = nil
             self.transcriptionTask?.cancel()
             guard self.isTranscribing else {
-                if let savedAudioFile {
-                    Self.deleteAudioFile(savedAudioFile.fileName)
-                }
+                // Transcription was cancelled mid-flight. Keep the saved audio
+                // file so it remains available in the run log for retry.
                 self.transcribingAudioFileName = nil
                 activeRealtime?.cancel()
                 self.audioRecorder.cleanup()
@@ -3231,6 +3235,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func cancelRecordingInitializationTimer() {
         recordingInitializationTimer?.cancel()
         recordingInitializationTimer = nil
+    }
+
+    private func startTranscriptionElapsedTimer() {
+        transcriptionStartTime = Date()
+        transcriptionElapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self, self.isTranscribing, let start = self.transcriptionStartTime else { return }
+            let elapsed = Int(-start.timeIntervalSinceNow)
+            guard elapsed >= 20 else { return }
+            let prefix = elapsed >= 60 ? "Still processing" : "Transcribing"
+            self.statusText = "\(prefix)... (\(elapsed)s)"
+        }
+    }
+
+    private func stopTranscriptionElapsedTimer() {
+        transcriptionElapsedTimer?.invalidate()
+        transcriptionElapsedTimer = nil
+        transcriptionStartTime = nil
     }
 
     private func scheduleReadyStatusReset(after delay: TimeInterval, matching statuses: Set<String>? = nil) {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -233,6 +233,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let outputLanguageStorageKey = "output_language"
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
+    private let prefetchTranscriptionEnabledStorageKey = "prefetch_transcription_enabled"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -480,6 +481,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// When true, audio is transcribed in 28-second background chunks while
+    /// recording so only the tail needs processing after the user stops.
+    /// Ignored when ``realtimeStreamingEnabled`` is also true (realtime takes
+    /// priority). Works with any HTTP transcription provider.
+    @Published var prefetchTranscriptionEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(
+                prefetchTranscriptionEnabled,
+                forKey: prefetchTranscriptionEnabledStorageKey
+            )
+        }
+    }
+
     @Published var dictationAudioInterruptionEnabled: Bool {
         didSet {
             UserDefaults.standard.set(
@@ -601,6 +615,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
     private var realtimeService: RealtimeTranscriptionService?
+    private var prefetchTranscriber: PrefetchTranscriber?
     private var automaticTerminationDisabled = false
     private var activeAudioInterruption: ActiveAudioInterruption?
     private var pendingOverlayDismissToken: UUID?
@@ -668,6 +683,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
+        let prefetchTranscriptionEnabled = UserDefaults.standard.bool(forKey: prefetchTranscriptionEnabledStorageKey)
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
@@ -740,6 +756,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.preserveClipboard = preserveClipboard
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
+        self.prefetchTranscriptionEnabled = prefetchTranscriptionEnabled
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
@@ -2176,6 +2193,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         startRealtimeStreamingIfEnabled()
+        startPrefetchTranscriberIfEnabled()
 
         // Start engine on background thread so UI isn't blocked
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -2431,12 +2449,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    /// Await the realtime WebSocket's final transcript. If it errors out (or
-    /// was never started) fall back to the file-based POST so the user still
-    /// gets a transcript. Runs the realtime commit and file upload in that
-    /// strict order to avoid paying for both when realtime succeeds.
+    /// Resolve the final transcript, trying sources in priority order:
+    ///   1. realtime WebSocket (`realtimeService`) — lowest latency when available
+    ///   2. HTTP pre-fetch (`prefetchTranscriber`) — background chunks already done
+    ///   3. plain file upload (`fileService`) — universal fallback
     private static func resolveRawTranscript(
         realtimeService: RealtimeTranscriptionService?,
+        prefetchTranscriber: PrefetchTranscriber?,
         fileService: TranscriptionService,
         fileURL: URL
     ) async throws -> String {
@@ -2452,8 +2471,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 throw CancellationError()
             } catch {
                 try Task.checkCancellation()
-                return try await fileService.transcribe(fileURL: fileURL)
+                // Realtime failed; fall through to prefetch or file upload.
             }
+        }
+        if let prefetchTranscriber {
+            try Task.checkCancellation()
+            let merged = await prefetchTranscriber.commitAndAwaitFinal()
+            if !merged.isEmpty { return merged }
+            // Empty result: fall through to file upload.
         }
         return try await fileService.transcribe(fileURL: fileURL)
     }
@@ -2539,6 +2564,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
             let activeRealtime = self.realtimeService
             self.realtimeService = nil
+            let activePrefetch = self.prefetchTranscriber
+            self.prefetchTranscriber = nil
             self.audioRecorder.onPCM16Samples = nil
             self.transcriptionTask?.cancel()
             guard self.isTranscribing else {
@@ -2559,6 +2586,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     let transcriptionService = try self.makeTranscriptionService()
                     async let transcript = Self.resolveRawTranscript(
                         realtimeService: activeRealtime,
+                        prefetchTranscriber: activePrefetch,
                         fileService: transcriptionService,
                         fileURL: transcriptionFileURL
                     )
@@ -2817,6 +2845,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioRecorder.onPCM16Samples = nil
         realtimeService?.cancel()
         realtimeService = nil
+        prefetchTranscriber = nil   // discard any in-progress accumulation
+    }
+
+    /// Start background HTTP pre-transcription if enabled and realtime is off.
+    /// PCM16 samples (24 kHz mono) are accumulated and transcribed in 28-second
+    /// chunks in the background, so the majority of a long recording is already
+    /// processed by the time the user presses stop.
+    private func startPrefetchTranscriberIfEnabled() {
+        guard prefetchTranscriptionEnabled, !realtimeStreamingEnabled else { return }
+        guard let service = try? makeTranscriptionService() else { return }
+        let transcriber = PrefetchTranscriber(service: service)
+        prefetchTranscriber = transcriber
+        audioRecorder.onPCM16Samples = { [weak transcriber] data in
+            transcriber?.appendPCM16(data)
+        }
+    }
+
+    private func tearDownPrefetchTranscriber() {
+        audioRecorder.onPCM16Samples = nil
+        prefetchTranscriber = nil
     }
 
     private func startContextCapture() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -538,6 +538,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
     private var transcriptionStartTime: Date?
     private var transcriptionElapsedTimer: Timer?
+    private var transcriptionAlertShown = false
     // App that was frontmost when the user pressed stop — paste target for async delivery.
     private var pasteTargetApp: NSRunningApplication?
     @Published var retryingItemIDs: Set<UUID> = []
@@ -3281,9 +3282,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func startTranscriptionElapsedTimer() {
         transcriptionStartTime = Date()
+        transcriptionAlertShown = false
         transcriptionElapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self, self.isTranscribing, let start = self.transcriptionStartTime else { return }
             let elapsed = Int(-start.timeIntervalSinceNow)
+            if elapsed == 10 && !self.transcriptionAlertShown {
+                self.transcriptionAlertShown = true
+                self.showTranscriptionStillRunningAlert(elapsed: elapsed)
+            }
             guard elapsed >= 20 else { return }
             let prefix = elapsed >= 60 ? "Still processing" : "Transcribing"
             self.statusText = "\(prefix)... (\(elapsed)s)"
@@ -3294,6 +3300,29 @@ final class AppState: ObservableObject, @unchecked Sendable {
         transcriptionElapsedTimer?.invalidate()
         transcriptionElapsedTimer = nil
         transcriptionStartTime = nil
+        transcriptionAlertShown = false
+    }
+
+    private func showTranscriptionStillRunningAlert(elapsed: Int) {
+        guard isTranscribing else { return }
+        let audioNote: String
+        if let fileName = transcribingAudioFileName {
+            let path = Self.audioStorageDirectory().appendingPathComponent(fileName).path
+            audioNote = "Audio saved to:\n\(path)"
+        } else {
+            audioNote = "Audio saved to:\n~/Library/Application Support/FreeFlow Dev/audio/"
+        }
+        let alert = NSAlert()
+        alert.messageText = "Still transcribing (\(elapsed)s elapsed)"
+        alert.informativeText = "With local processing, this can take as long as your recording — or longer under load.\n\nYour audio is already saved. If you cancel, it will remain on disk and you can retry transcription from the recording history.\n\n\(audioNote)"
+        alert.addButton(withTitle: "Keep Waiting")
+        alert.addButton(withTitle: "Cancel Transcription")
+        if let icon = NSImage(systemSymbolName: "waveform.badge.exclamationmark", accessibilityDescription: nil) {
+            alert.icon = icon
+        }
+        let response = alert.runModal()
+        guard response == .alertSecondButtonReturn, isTranscribing else { return }
+        cancelTranscription()
     }
 
     private func scheduleReadyStatusReset(after delay: TimeInterval, matching statuses: Set<String>? = nil) {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3272,6 +3272,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     static let clipboardWaitingStatusText = "On clipboard, press Cmd-V"
 
+    /// Appends one line per delivery to a plain text log beside the run log, so
+    /// a misdelivery can be reconstructed after the fact instead of only being
+    /// visible in the live Settings pane.
+    private static func appendDeliveryLog(outcome: DeliveryOutcome, target: DeliveryTarget?) {
+        let stamp = ISO8601DateFormatter().string(from: Date())
+        let role = target?.elementRole ?? "no-element"
+        let bundle = target?.bundleIdentifier ?? "no-bundle"
+        let line = "\(stamp)\t\(outcome.tier.rawValue)\tsucceeded=\(outcome.succeeded)\t\(bundle)\t\(role)\t\(outcome.attempts.joined(separator: " | "))\n"
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
+        let url = appSupport
+            .appendingPathComponent(AppName.displayName, isDirectory: true)
+            .appendingPathComponent("delivery.log")
+        guard let data = line.data(using: .utf8) else { return }
+        if let handle = try? FileHandle(forWritingTo: url) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: data)
+        } else {
+            try? data.write(to: url)
+        }
+    }
+
     /// Delivers a finished transcript back to the element the user was writing
     /// in when they stopped dictating. Never changes the frontmost app unless
     /// the focus-steal fallback is explicitly enabled.
@@ -3288,6 +3310,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let self else { return }
             let apply = {
                 self.lastDeliveryDiagnostics = outcome.attempts.joined(separator: " | ")
+                Self.appendDeliveryLog(outcome: outcome, target: target)
                 self.debugStatusMessage = "Delivery: \(outcome.summary)"
                 if outcome.succeeded {
                     if pressReturnAfter, let target {
@@ -3302,7 +3325,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     // The text is demonstrably in the target, so the previous
                     // clipboard can come back.
                     completion()
-                case .processKeystroke:
+                case .processKeystroke, .processPaste:
                     // Key events were posted but nothing confirms the app
                     // consumed them. Leave the transcript on the clipboard so
                     // Cmd-V still recovers it.

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -683,7 +683,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
-        let prefetchTranscriptionEnabled = UserDefaults.standard.bool(forKey: prefetchTranscriptionEnabledStorageKey)
+        let prefetchTranscriptionEnabled = UserDefaults.standard.object(forKey: prefetchTranscriptionEnabledStorageKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: prefetchTranscriptionEnabledStorageKey)
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
@@ -2855,7 +2857,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func startPrefetchTranscriberIfEnabled() {
         guard prefetchTranscriptionEnabled, !realtimeStreamingEnabled else { return }
         guard let service = try? makeTranscriptionService() else { return }
-        let transcriber = PrefetchTranscriber(service: service)
+
+        // Durable transcript file: one chunk appended per 28 s as it completes.
+        // Named by Unix timestamp so recordings don't collide.
+        let ts = Int(Date().timeIntervalSince1970)
+        let saveURL = Self.audioStorageDirectory()
+            .appendingPathComponent("prefetch_transcript_\(ts).txt")
+
+        let transcriber = PrefetchTranscriber(service: service, saveURL: saveURL)
         prefetchTranscriber = transcriber
         audioRecorder.onPCM16Samples = { [weak transcriber] data in
             transcriber?.appendPCM16(data)

--- a/Sources/ClipboardWaitingPanel.swift
+++ b/Sources/ClipboardWaitingPanel.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// Shown when a transcript could not be delivered to the element it was
+/// dictated into and is waiting on the clipboard instead. Deliberately the
+/// same shape as `TranscriptionProgressPanel`: a floating, non-activating
+/// panel that appears on whichever Space the user is on, without taking focus.
+struct ClipboardWaitingPanel: View {
+    let targetDescription: String
+    let reason: String?
+    let transcriptPreview: String
+    let onDismiss: () -> Void
+
+    private var explanation: String {
+        "The text could not be placed in \(targetDescription), so it is waiting on your clipboard. Put the cursor where you want it and press Cmd-V. Nothing was typed anywhere else."
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Transcript on the clipboard", systemImage: "doc.on.clipboard")
+                .font(.headline)
+
+            Text(explanation)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Waiting text:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(transcriptPreview)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                    .textSelection(.enabled)
+
+                if let reason {
+                    Text("Why: \(reason)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(3)
+                        .textSelection(.enabled)
+                        .padding(.top, 2)
+                }
+            }
+
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Button("Got It", action: onDismiss)
+                        .keyboardShortcut(.defaultAction)
+                    Text("the text stays on the clipboard either way")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(.top, 4)
+        }
+        .padding(20)
+        .frame(width: 440)
+    }
+}

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -148,7 +148,8 @@ final class GlobalShortcutBackend {
 
     private func handleKeyDown(_ event: NSEvent) -> Bool {
         if event.keyCode == 53 {
-            guard !event.isARepeat else { return false }
+            // Require Fn to be held so bare Esc in other apps isn't intercepted.
+            guard !event.isARepeat, fnKeyIsDown else { return false }
             return onEscapeKeyPressed?() ?? false
         }
 

--- a/Sources/LLMAPITransport.swift
+++ b/Sources/LLMAPITransport.swift
@@ -9,8 +9,8 @@ enum LLMAPITransport {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         configuration.urlCache = nil
-        configuration.timeoutIntervalForRequest = 20
-        configuration.timeoutIntervalForResource = 30
+        configuration.timeoutIntervalForRequest = 120   // 2 min to start receiving each packet
+        configuration.timeoutIntervalForResource = 300  // 5 min total per request (local LLMs are slow)
         return URLSession(configuration: configuration)
     }
 
@@ -24,9 +24,14 @@ enum LLMAPITransport {
         for request: URLRequest,
         from bodyData: Data
     ) async throws -> (Data, URLResponse) {
-        // Use a fresh session for each upload so a bad reused connection cannot
-        // poison subsequent transcription uploads.
-        let session = makeEphemeralSession()
+        // Fresh session per upload — no poisoned connection re-use.
+        // Use generous timeouts: local ASR + chunking can take minutes.
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.timeoutIntervalForRequest = 300   // 5 min to start receiving response
+        configuration.timeoutIntervalForResource = .infinity  // no cap on total transfer
+        let session = URLSession(configuration: configuration)
         defer { session.finishTasksAndInvalidate() }
         return try await session.upload(for: request, from: bodyData)
     }

--- a/Sources/LoudnessMeter.swift
+++ b/Sources/LoudnessMeter.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// A scrolling level meter: every bar is a moment in time and its height is how
+/// loud the microphone actually was then, newest on the right. This is what an
+/// ordinary voice recorder shows, and what the decorative waveform cannot: the
+/// existing `WaveformView` mixes the level with a traveling sine and a shimmer,
+/// so the bars keep moving in silence and barely change when you get louder.
+/// Mid-sentence you want to know the microphone is hearing you, not that an
+/// animation is running.
+struct LoudnessMeterView: View {
+    let levels: [Float]
+    var barCount: Int = 13
+    var height: CGFloat = 24
+    var barWidth: CGFloat = 2.5
+    var spacing: CGFloat = 2.5
+
+    /// Bars below this are drawn dimmed, so "the microphone is picking up
+    /// almost nothing" is visible at a glance rather than inferred.
+    private static let quietThreshold: Float = 0.08
+
+    private var window: [Float] {
+        let tail = levels.suffix(barCount)
+        if tail.count == barCount { return Array(tail) }
+        return Array(repeating: 0, count: barCount - tail.count) + Array(tail)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: spacing) {
+            ForEach(Array(window.enumerated()), id: \.offset) { index, level in
+                LoudnessBar(
+                    level: level,
+                    isNewest: index == barCount - 1,
+                    isQuiet: level < Self.quietThreshold,
+                    maxHeight: height,
+                    width: barWidth
+                )
+            }
+        }
+        .frame(height: height)
+        .animation(.linear(duration: 0.05), value: levels.count)
+    }
+}
+
+private struct LoudnessBar: View {
+    let level: Float
+    let isNewest: Bool
+    let isQuiet: Bool
+    let maxHeight: CGFloat
+    let width: CGFloat
+
+    private var barHeight: CGFloat {
+        // A gentle curve, so ordinary speech uses the middle of the range
+        // instead of pinning the meter at the top.
+        let shaped = pow(CGFloat(max(0, min(level, 1))), 0.65)
+        return max(width, shaped * maxHeight)
+    }
+
+    var body: some View {
+        Capsule()
+            .fill(.white)
+            .frame(width: width, height: barHeight)
+            .opacity(isQuiet ? 0.28 : (isNewest ? 1.0 : 0.85))
+    }
+}

--- a/Sources/PrefetchTranscriber.swift
+++ b/Sources/PrefetchTranscriber.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Transcribes audio in the background while recording is still in progress.
+///
+/// Audio is accumulated as raw PCM16 samples (24 kHz mono, matching
+/// `AudioRecorder.onPCM16Samples`).  Every 28 seconds a WAV file is
+/// written to a temporary location and submitted to the configured
+/// transcription service.  Chunks are processed *serially* so upstream
+/// API rate limits are respected.
+///
+/// Call `appendPCM16(_:)` from any thread while recording, then
+/// `commitAndAwaitFinal()` from an async context when recording stops.
+/// The full merged transcript is returned; individual chunk results are
+/// combined in order.  Falls back gracefully: if a chunk fails, it is
+/// skipped rather than aborting the session.
+final class PrefetchTranscriber: @unchecked Sendable {
+
+    // MARK: Configuration
+
+    private let service: TranscriptionService
+    private static let chunkSeconds: Int = 28
+    private static let sampleRate: Int = 24_000   // matches pcm16TargetFormat
+    private static let bytesPerSample: Int = 2     // PCM16
+    private static let chunkBytes: Int = chunkSeconds * sampleRate * bytesPerSample
+
+    // MARK: State (guarded by lock)
+
+    private let lock = NSLock()
+    private var buffer = Data()
+    private var segments: [String] = []
+
+    /// Serial chain of chunk-transcription Tasks.  Each new chunk task
+    /// awaits the completion of the previous one before starting.
+    private var chainTail: Task<String?, Never> = Task { nil }
+
+    // MARK: Init
+
+    init(service: TranscriptionService) {
+        self.service = service
+    }
+
+    // MARK: Public API
+
+    /// Append raw PCM16 samples. Safe to call from any thread or queue.
+    func appendPCM16(_ data: Data) {
+        let chunk: Data? = lock.withLock {
+            buffer.append(data)
+            guard buffer.count >= Self.chunkBytes else { return nil }
+            let c = Data(buffer.prefix(Self.chunkBytes))
+            buffer = Data(buffer.dropFirst(Self.chunkBytes))
+            return c
+        }
+        guard let chunk else { return }
+        enqueueChunk(chunk, label: "background chunk")
+    }
+
+    /// Wait for all in-flight chunks, transcribe the remaining tail, and
+    /// return the merged transcript.  Must be called from an async context.
+    func commitAndAwaitFinal() async -> String {
+        // Wait for the last enqueued chunk to complete.
+        _ = await chainTail.value
+
+        // Transcribe the tail (< 28 s remaining in the buffer).
+        let tail: Data = lock.withLock {
+            let t = buffer
+            buffer = Data()
+            return t
+        }
+        if !tail.isEmpty {
+            if let text = await transcribeWAV(Self.buildWAV(from: tail)), !text.isEmpty {
+                lock.withLock { segments.append(text) }
+            }
+        }
+
+        return lock.withLock { segments.joined(separator: " ") }
+    }
+
+    // MARK: Private helpers
+
+    private func enqueueChunk(_ chunk: Data, label: String) {
+        let prev = chainTail
+        let newTask: Task<String?, Never> = Task { [weak self] in
+            guard let self else { return nil }
+            // Ensure serial execution: wait for the preceding chunk.
+            _ = await prev.value
+            let wav = Self.buildWAV(from: chunk)
+            return await self.transcribeWAV(wav)
+        }
+        chainTail = newTask
+
+        // Collect the result into `segments` once done.
+        Task { [weak self] in
+            guard let self else { return }
+            if let text = await newTask.value, !text.isEmpty {
+                self.lock.withLock { self.segments.append(text) }
+            }
+        }
+    }
+
+    private func transcribeWAV(_ wav: Data) async -> String? {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("prefetch_\(UUID().uuidString).wav")
+        do {
+            try wav.write(to: url)
+            defer { try? FileManager.default.removeItem(at: url) }
+            return try await service.transcribe(fileURL: url)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Build a minimal WAV container around raw PCM16 mono data.
+    private static func buildWAV(from pcm: Data) -> Data {
+        var wav = Data()
+        func le<T: FixedWidthInteger>(_ v: T) {
+            var x = v.littleEndian
+            wav.append(Data(bytes: &x, count: MemoryLayout<T>.size))
+        }
+        let dataLen = UInt32(pcm.count)
+        wav += "RIFF".data(using: .ascii)!; le(dataLen + 36)
+        wav += "WAVEfmt ".data(using: .ascii)!
+        le(UInt32(16)); le(UInt16(1)); le(UInt16(1))   // fmt, PCM, mono
+        le(UInt32(sampleRate))
+        le(UInt32(sampleRate * bytesPerSample))        // byte rate
+        le(UInt16(bytesPerSample))                     // block align
+        le(UInt16(16))                                 // bits per sample
+        wav += "data".data(using: .ascii)!; le(dataLen)
+        wav += pcm
+        return wav
+    }
+}

--- a/Sources/PrefetchTranscriber.swift
+++ b/Sources/PrefetchTranscriber.swift
@@ -8,6 +8,10 @@ import Foundation
 /// transcription service.  Chunks are processed *serially* so upstream
 /// API rate limits are respected.
 ///
+/// If `saveURL` is provided, each completed chunk's transcript is appended
+/// to that file immediately after transcription — so a crash loses at most
+/// one in-flight chunk rather than the entire session.
+///
 /// Call `appendPCM16(_:)` from any thread while recording, then
 /// `commitAndAwaitFinal()` from an async context when recording stops.
 /// The full merged transcript is returned; individual chunk results are
@@ -23,6 +27,11 @@ final class PrefetchTranscriber: @unchecked Sendable {
     private static let bytesPerSample: Int = 2     // PCM16
     private static let chunkBytes: Int = chunkSeconds * sampleRate * bytesPerSample
 
+    /// Optional file that receives each chunk's transcript as it completes.
+    /// Created (or truncated) at init time; appended after every chunk so
+    /// partial transcripts survive an app crash.
+    private let saveURL: URL?
+
     // MARK: State (guarded by lock)
 
     private let lock = NSLock()
@@ -35,8 +44,12 @@ final class PrefetchTranscriber: @unchecked Sendable {
 
     // MARK: Init
 
-    init(service: TranscriptionService) {
+    init(service: TranscriptionService, saveURL: URL? = nil) {
         self.service = service
+        self.saveURL = saveURL
+        if let url = saveURL {
+            FileManager.default.createFile(atPath: url.path, contents: nil)
+        }
     }
 
     // MARK: Public API
@@ -69,6 +82,7 @@ final class PrefetchTranscriber: @unchecked Sendable {
         if !tail.isEmpty {
             if let text = await transcribeWAV(Self.buildWAV(from: tail)), !text.isEmpty {
                 lock.withLock { segments.append(text) }
+                appendToSaveFile(text)
             }
         }
 
@@ -88,12 +102,26 @@ final class PrefetchTranscriber: @unchecked Sendable {
         }
         chainTail = newTask
 
-        // Collect the result into `segments` once done.
+        // Collect the result into `segments` once done and persist to disk.
         Task { [weak self] in
             guard let self else { return }
             if let text = await newTask.value, !text.isEmpty {
                 self.lock.withLock { self.segments.append(text) }
+                self.appendToSaveFile(text)
             }
+        }
+    }
+
+    /// Appends one chunk's text to the durable save file.
+    /// Uses `FileHandle` for atomic append without reading the whole file.
+    private func appendToSaveFile(_ text: String) {
+        guard let url = saveURL else { return }
+        let line = text + "\n\n"
+        guard let data = line.data(using: .utf8) else { return }
+        if let handle = try? FileHandle(forWritingTo: url) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            handle.write(data)
         }
     }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -15,6 +15,11 @@ final class RecordingOverlayState: ObservableObject {
     /// this reaches zero, so a second dictation started while the first is
     /// still transcribing does not leave you guessing.
     @Published var pendingTranscriptionCount: Int = 0
+    /// Recent input levels, newest last, so the overlay can show loudness over
+    /// time rather than a level-independent animation.
+    @Published var levelHistory: [Float] = []
+    /// Draw the scrolling loudness meter instead of the decorative waveform.
+    @Published var showsLoudnessMeter = true
 }
 
 enum OverlayPhase {
@@ -144,6 +149,7 @@ final class RecordingOverlayManager {
     }
 
     func showRecording(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
+        DispatchQueue.main.async { self.clearLevelHistory() }
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
@@ -171,10 +177,28 @@ final class RecordingOverlayManager {
         }
     }
 
+    private static let levelHistoryLength = 40
+
     func updateAudioLevel(_ level: Float) {
         DispatchQueue.main.async {
             self.overlayState.audioLevel = level
+            var history = self.overlayState.levelHistory
+            history.append(level)
+            if history.count > Self.levelHistoryLength {
+                history.removeFirst(history.count - Self.levelHistoryLength)
+            }
+            self.overlayState.levelHistory = history
         }
+    }
+
+    func setShowsLoudnessMeter(_ enabled: Bool) {
+        DispatchQueue.main.async {
+            self.overlayState.showsLoudnessMeter = enabled
+        }
+    }
+
+    private func clearLevelHistory() {
+        overlayState.levelHistory = []
     }
 
     func showTranscribing() {
@@ -517,10 +541,20 @@ struct WingedRecordingView: View {
                             }
                             HStack(spacing: 4) {
                                 PendingTranscriptionBadge(count: state.pendingTranscriptionCount)
-                                CompactWaveformView(
-                                    audioLevel: state.audioLevel,
-                                    showsActivityPulse: state.phase == .recording
-                                )
+                                if state.showsLoudnessMeter {
+                                    LoudnessMeterView(
+                                        levels: state.levelHistory,
+                                        barCount: 7,
+                                        height: 14,
+                                        barWidth: 2,
+                                        spacing: 2
+                                    )
+                                } else {
+                                    CompactWaveformView(
+                                        audioLevel: state.audioLevel,
+                                        showsActivityPulse: state.phase == .recording
+                                    )
+                                }
                             }
                         }
                         .transition(.opacity)
@@ -1010,10 +1044,14 @@ struct RecordingOverlayView: View {
                         } else if showsLiveRecordingContent {
                             HStack(spacing: 6) {
                                 PendingTranscriptionBadge(count: state.pendingTranscriptionCount)
-                                WaveformView(
-                                    audioLevel: state.audioLevel,
-                                    showsActivityPulse: state.phase == .recording
-                                )
+                                if state.showsLoudnessMeter {
+                                    LoudnessMeterView(levels: state.levelHistory)
+                                } else {
+                                    WaveformView(
+                                        audioLevel: state.audioLevel,
+                                        showsActivityPulse: state.phase == .recording
+                                    )
+                                }
                             }
                                 .transition(.opacity)
                         } else {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -515,10 +515,13 @@ struct WingedRecordingView: View {
                                     .foregroundStyle(.white.opacity(0.92))
                                     .transition(.opacity)
                             }
-                            CompactWaveformView(
-                                audioLevel: state.audioLevel,
-                                showsActivityPulse: state.phase == .recording
-                            )
+                            HStack(spacing: 4) {
+                                PendingTranscriptionBadge(count: state.pendingTranscriptionCount)
+                                CompactWaveformView(
+                                    audioLevel: state.audioLevel,
+                                    showsActivityPulse: state.phase == .recording
+                                )
+                            }
                         }
                         .transition(.opacity)
                     } else {
@@ -1005,10 +1008,13 @@ struct RecordingOverlayView: View {
                             InitializingDotsView()
                                 .transition(.opacity)
                         } else if showsLiveRecordingContent {
-                            WaveformView(
-                                audioLevel: state.audioLevel,
-                                showsActivityPulse: state.phase == .recording
-                            )
+                            HStack(spacing: 6) {
+                                PendingTranscriptionBadge(count: state.pendingTranscriptionCount)
+                                WaveformView(
+                                    audioLevel: state.audioLevel,
+                                    showsActivityPulse: state.phase == .recording
+                                )
+                            }
                                 .transition(.opacity)
                         } else {
                             ProcessingIndicatorView(

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -11,6 +11,10 @@ final class RecordingOverlayState: ObservableObject {
     @Published var updateVersion: String = ""
     @Published var errorMessage: String?
     @Published var toastID: UUID?
+    /// How many transcriptions are still running. The overlay stays up until
+    /// this reaches zero, so a second dictation started while the first is
+    /// still transcribing does not leave you guessing.
+    @Published var pendingTranscriptionCount: Int = 0
 }
 
 enum OverlayPhase {
@@ -176,6 +180,14 @@ final class RecordingOverlayManager {
     func showTranscribing() {
         DispatchQueue.main.async {
             self.setTranscribingPhase()
+        }
+    }
+
+    /// Number of transcriptions still in flight, shown beside the processing
+    /// bars.
+    func setPendingTranscriptionCount(_ count: Int) {
+        DispatchQueue.main.async {
+            self.overlayState.pendingTranscriptionCount = max(0, count)
         }
     }
 
@@ -510,7 +522,9 @@ struct WingedRecordingView: View {
                         }
                         .transition(.opacity)
                     } else {
-                        CompactProcessingIndicatorView()
+                        CompactProcessingIndicatorView(
+                            pendingCount: state.pendingTranscriptionCount
+                        )
                             .transition(.opacity)
                     }
                 }
@@ -737,6 +751,28 @@ struct ProcessingWaveformView: View {
     }
 }
 
+/// The count of transcriptions still running, sitting to the left of the
+/// processing bars. Hidden when nothing is in flight.
+struct PendingTranscriptionBadge: View {
+    let count: Int
+
+    var body: some View {
+        if count > 0 {
+            Text("\(count)")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(.white)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(
+                    Capsule().fill(Color.white.opacity(0.22))
+                )
+                .transition(.opacity)
+                .accessibilityLabel("\(count) transcriptions still running")
+        }
+    }
+}
+
 private struct ProcessingPill: View {
     let amplitude: CGFloat
     let opacity: CGFloat
@@ -753,10 +789,18 @@ private struct ProcessingPill: View {
 }
 
 struct ProcessingIndicatorView: View {
+    var pendingCount: Int = 0
     @State private var showsExtendedSpinner = false
     @State private var rotation: Double = 0
 
     var body: some View {
+        HStack(spacing: 6) {
+            PendingTranscriptionBadge(count: pendingCount)
+            indicator
+        }
+    }
+
+    private var indicator: some View {
         ZStack {
             if showsExtendedSpinner {
                 Circle()
@@ -796,10 +840,18 @@ struct ProcessingIndicatorView: View {
 /// spinner so the indicator stays inside the wing without the jolt to
 /// oversized capsules that the full-size indicator produced.
 struct CompactProcessingIndicatorView: View {
+    var pendingCount: Int = 0
     @State private var showsExtendedSpinner = false
     @State private var rotation: Double = 0
 
     var body: some View {
+        HStack(spacing: 4) {
+            PendingTranscriptionBadge(count: pendingCount)
+            indicator
+        }
+    }
+
+    private var indicator: some View {
         ZStack {
             if showsExtendedSpinner {
                 Circle()
@@ -957,7 +1009,9 @@ struct RecordingOverlayView: View {
                             )
                                 .transition(.opacity)
                         } else {
-                            ProcessingIndicatorView()
+                            ProcessingIndicatorView(
+                                pendingCount: state.pendingTranscriptionCount
+                            )
                                 .transition(.opacity)
                         }
                     }

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -757,7 +757,9 @@ struct PendingTranscriptionBadge: View {
     let count: Int
 
     var body: some View {
-        if count > 0 {
+        // Only worth showing once work is actually queued behind the current
+        // one. A lone "1" is just noise.
+        if count > 1 {
             Text("\(count)")
                 .font(.system(size: 11, weight: .semibold, design: .rounded))
                 .monospacedDigit()

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -273,10 +273,20 @@ struct ProviderSettingsFields: View {
             Divider()
 
             Toggle(
-                "Stream audio while recording (realtime)",
+                "Begin transcribing while recording",
+                isOn: $appState.prefetchTranscriptionEnabled
+            )
+            Text("Submits audio to the transcription provider in 28-second background chunks while you speak. By the time you press stop, most of the transcript is already ready. Works with any HTTP transcription provider — no special server required.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            Toggle(
+                "Stream audio while recording (realtime, requires WebSocket)",
                 isOn: $appState.realtimeStreamingEnabled
             )
-            Text("Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket so transcription runs while you speak.")
+            Text("Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket. Takes priority over background transcription when both are enabled.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -466,7 +466,7 @@ struct GeneralSettingsView: View {
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
     @AppStorage("overlay_display_id") private var overlayDisplayID = 0
     @AppStorage("use_compact_overlay") private var useCompactOverlay = true
-    @AppStorage("transcription_timeout_seconds") private var transcriptionTimeoutRaw: Double = 300
+    @AppStorage("transcription_timeout_seconds") private var transcriptionTimeoutRaw: Double = -1
     @State private var screensVersion = 0
     @State private var apiKeyInput: String = ""
     @State private var apiBaseURLInput: String = ""

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1205,6 +1205,43 @@ struct GeneralSettingsView: View {
 
     private var clipboardSection: some View {
         VStack(alignment: .leading, spacing: 10) {
+            Toggle("Deliver back to where you were dictating", isOn: $appState.asyncDeliveryEnabled)
+
+            Text("The transcript goes to the text field you were writing in when you stopped, even if you have since switched app, window or Desktop. Your focus stays where it is.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("Keep dictating while earlier transcripts finish", isOn: $appState.overlappingDictationEnabled)
+                .disabled(!appState.asyncDeliveryEnabled)
+
+            Text("Start a new recording without waiting for the previous transcription. Each transcript still lands in the field it was dictated into.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("Send keystrokes to background apps", isOn: $appState.asyncDeliveryAllowProcessKeystroke)
+                .disabled(!appState.asyncDeliveryEnabled)
+
+            Text("Needed for terminals and other apps that refuse Accessibility text writes. The keys go to that app's process only, without bringing it forward.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("Last resort: bring the app forward and paste", isOn: $appState.asyncDeliveryAllowFocusSteal)
+                .disabled(!appState.asyncDeliveryEnabled)
+
+            Text("Off by default. When on, a transcript that cannot be delivered any other way pulls you back to the original app and its Desktop. When off, it waits on the clipboard instead.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if !appState.lastDeliveryDiagnostics.isEmpty {
+                Text("Last delivery: \(appState.lastDeliveryDiagnostics)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            Divider()
+                .padding(.vertical, 2)
+
             Toggle("Preserve clipboard after paste", isOn: $appState.preserveClipboard)
 
             Text("\(AppName.displayName) will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, \(AppName.displayName) leaves it alone.")

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1229,6 +1229,15 @@ struct GeneralSettingsView: View {
 
     private var asyncDeliverySection: some View {
         VStack(alignment: .leading, spacing: 10) {
+            Toggle("Show loudness while recording", isOn: $appState.loudnessMeterEnabled)
+
+            Text("Draws a scrolling level meter instead of the decorative waveform, so you can see mid-sentence whether the microphone is actually picking you up.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+                .padding(.vertical, 2)
+
             Toggle("Deliver back to where you were dictating", isOn: $appState.asyncDeliveryEnabled)
 
             Text("The transcript goes to the text field you were writing in when you stopped, even if you have since switched app, window or Desktop. Your focus stays where it is.")

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1205,39 +1205,7 @@ struct GeneralSettingsView: View {
 
     private var clipboardSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Toggle("Deliver back to where you were dictating", isOn: $appState.asyncDeliveryEnabled)
-
-            Text("The transcript goes to the text field you were writing in when you stopped, even if you have since switched app, window or Desktop. Your focus stays where it is.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Toggle("Keep dictating while earlier transcripts finish", isOn: $appState.overlappingDictationEnabled)
-                .disabled(!appState.asyncDeliveryEnabled)
-
-            Text("Start a new recording without waiting for the previous transcription. Each transcript still lands in the field it was dictated into.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Toggle("Send keystrokes to background apps", isOn: $appState.asyncDeliveryAllowProcessKeystroke)
-                .disabled(!appState.asyncDeliveryEnabled)
-
-            Text("Needed for terminals and other apps that refuse Accessibility text writes. The keys go to that app's process only, without bringing it forward.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Toggle("Last resort: bring the app forward and paste", isOn: $appState.asyncDeliveryAllowFocusSteal)
-                .disabled(!appState.asyncDeliveryEnabled)
-
-            Text("Off by default. When on, a transcript that cannot be delivered any other way pulls you back to the original app and its Desktop. When off, it waits on the clipboard instead.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            if !appState.lastDeliveryDiagnostics.isEmpty {
-                Text("Last delivery: \(appState.lastDeliveryDiagnostics)")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-            }
+            asyncDeliverySection
 
             Divider()
                 .padding(.vertical, 2)
@@ -1256,6 +1224,49 @@ struct GeneralSettingsView: View {
             Text("When the transcription ends with \"press enter\", \(AppName.displayName) removes those words before cleanup, pastes the remaining transcript, then presses Return.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    private var asyncDeliverySection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Deliver back to where you were dictating", isOn: $appState.asyncDeliveryEnabled)
+
+            Text("The transcript goes to the text field you were writing in when you stopped, even if you have since switched app, window or Desktop. Your focus stays where it is.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            asyncDeliveryDetailToggles
+        }
+    }
+
+    @ViewBuilder
+    private var asyncDeliveryDetailToggles: some View {
+        Toggle("Keep dictating while earlier transcripts finish", isOn: $appState.overlappingDictationEnabled)
+            .disabled(!appState.asyncDeliveryEnabled)
+
+        Text("Start a new recording without waiting for the previous transcription. Each transcript still lands in the field it was dictated into.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        Toggle("Send keystrokes to background apps", isOn: $appState.asyncDeliveryAllowProcessKeystroke)
+            .disabled(!appState.asyncDeliveryEnabled)
+
+        Text("Needed for terminals and other apps that refuse Accessibility text writes. The keys go to that app's process only, without bringing it forward.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        Toggle("Last resort: bring the app forward and paste", isOn: $appState.asyncDeliveryAllowFocusSteal)
+            .disabled(!appState.asyncDeliveryEnabled)
+
+        Text("Off by default. When on, a transcript that cannot be delivered any other way pulls you back to the original app and its Desktop. When off, it waits on the clipboard instead.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        if !appState.lastDeliveryDiagnostics.isEmpty {
+            Text("Last delivery: \(appState.lastDeliveryDiagnostics)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
         }
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -466,6 +466,7 @@ struct GeneralSettingsView: View {
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
     @AppStorage("overlay_display_id") private var overlayDisplayID = 0
     @AppStorage("use_compact_overlay") private var useCompactOverlay = true
+    @AppStorage("transcription_timeout_seconds") private var transcriptionTimeoutRaw: Double = 300
     @State private var screensVersion = 0
     @State private var apiKeyInput: String = ""
     @State private var apiBaseURLInput: String = ""
@@ -671,6 +672,9 @@ struct GeneralSettingsView: View {
                 }
                 SettingsCard("Sound Volume", icon: "speaker.wave.2.fill") {
                     soundVolumeSection
+                }
+                SettingsCard("Transcription Timeout", icon: "clock.fill") {
+                    transcriptionTimeoutSection
                 }
                 SettingsCard("Custom Vocabulary", icon: "text.book.closed.fill") {
                     vocabularySection
@@ -1284,6 +1288,37 @@ struct GeneralSettingsView: View {
         }
         .onChange(of: appState.alertSoundsEnabled) { enabled in
             if !enabled { showMutedHint = false }
+        }
+    }
+
+    // MARK: Transcription Timeout
+
+    private var noTimeoutBinding: Binding<Bool> {
+        Binding(
+            get: { transcriptionTimeoutRaw < 0 },
+            set: { transcriptionTimeoutRaw = $0 ? -1 : 300 }
+        )
+    }
+
+    private var transcriptionTimeoutSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("No timeout — wait as long as needed", isOn: noTimeoutBinding)
+
+            if !noTimeoutBinding.wrappedValue {
+                HStack {
+                    Text("Timeout after")
+                    Spacer()
+                    TextField("", value: $transcriptionTimeoutRaw, format: .number)
+                        .frame(width: 64)
+                        .multilineTextAlignment(.trailing)
+                        .textFieldStyle(.roundedBorder)
+                    Text("seconds")
+                        .foregroundStyle(.secondary)
+                }
+                Text("Status shows elapsed time after 20 s so you know it's still working.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 

--- a/Sources/ShortcutCore/DictationShortcutSessionController.swift
+++ b/Sources/ShortcutCore/DictationShortcutSessionController.swift
@@ -70,7 +70,10 @@ final class DictationShortcutSessionController {
 
     func beginManual(mode: RecordingTriggerMode) {
         activeMode = mode
-        toggleStopArmed = false
+        // When started without a physical key press/release cycle (e.g. via menu
+        // bar button), arm stop immediately so the first shortcut press stops the
+        // recording rather than being silently swallowed.
+        toggleStopArmed = (mode == .toggle)
     }
 
     func forceToggleMode() {

--- a/Sources/TextDelivery.swift
+++ b/Sources/TextDelivery.swift
@@ -18,6 +18,10 @@ struct DeliveryTarget {
     /// not "whatever is focused now".
     let focusedElement: AXUIElement?
     let elementRole: String?
+    /// Where the caret sat inside that element, so delivery lands on the exact
+    /// spot rather than wherever the caret has since wandered within the same
+    /// document.
+    let selectedRange: AXValue?
     let capturedAt: Date
 
     var describedApp: String {
@@ -99,6 +103,7 @@ final class TextDeliveryService {
         AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
         let focused = Self.copyElement(appElement, kAXFocusedUIElementAttribute as CFString)
         let role = focused.flatMap { Self.copyString($0, kAXRoleAttribute as CFString) }
+        let range = focused.flatMap { Self.copyAXValue($0, kAXSelectedTextRangeAttribute as CFString) }
 
         return DeliveryTarget(
             sessionID: sessionID,
@@ -107,6 +112,7 @@ final class TextDeliveryService {
             appName: app.localizedName,
             focusedElement: focused,
             elementRole: role,
+            selectedRange: range,
             capturedAt: Date()
         )
     }
@@ -275,6 +281,20 @@ final class TextDeliveryService {
             return .failure("selected text not settable (\(Self.describe(settableStatus)))")
         }
 
+        // Put the caret back where it was before writing, so continuing to
+        // work elsewhere in the same document does not move the insertion
+        // point. Best effort: an element that refuses the range still gets the
+        // text at its current caret.
+        if let selectedRange = target.selectedRange {
+            AXUIElementSetAttributeValue(
+                element,
+                kAXSelectedTextRangeAttribute as CFString,
+                selectedRange
+            )
+        }
+
+        let lengthBefore = Self.textLength(of: element)
+
         let setStatus = AXUIElementSetAttributeValue(
             element,
             kAXSelectedTextAttribute as CFString,
@@ -284,7 +304,44 @@ final class TextDeliveryService {
             return .failure("set failed (\(Self.describe(setStatus)))")
         }
 
+        // Chromium and Electron accept the write and report success while the
+        // text never reaches the editable surface, which is how a transcript
+        // silently vanishes. Only call it delivered if the element grew.
+        if let lengthBefore, let lengthAfter = Self.textLength(of: element) {
+            guard lengthAfter > lengthBefore else {
+                return .failure("set reported success but the text did not land")
+            }
+        }
+
         return .success
+    }
+
+    /// Character count of an element's text, when it exposes one. Nil means
+    /// the element gives no way to tell, in which case a write cannot be
+    /// verified either way.
+    private static func textLength(of element: AXUIElement) -> Int? {
+        var value: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXNumberOfCharactersAttribute as CFString, &value) == .success,
+           let number = value as? Int {
+            return number
+        }
+        value = nil
+        if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &value) == .success,
+           let string = value as? String {
+            return string.count
+        }
+        return nil
+    }
+
+    static func copyAXValue(_ element: AXUIElement, _ attribute: CFString) -> AXValue? {
+        var value: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(element, attribute, &value)
+        guard status == .success,
+              let raw = value,
+              CFGetTypeID(raw) == AXValueGetTypeID() else {
+            return nil
+        }
+        return unsafeBitCast(raw, to: AXValue.self)
     }
 
     // MARK: - Tier 2: key events to a process

--- a/Sources/TextDelivery.swift
+++ b/Sources/TextDelivery.swift
@@ -1,0 +1,451 @@
+import AppKit
+import ApplicationServices
+import Carbon
+import Foundation
+
+/// Where a transcript should land, captured at the moment the user stops
+/// dictating. The point of pinning this is that transcription is asynchronous:
+/// by the time text is ready the user may have switched app, window, tab or
+/// Space. Delivery must go back to the element they were writing in, without
+/// dragging their focus along with it.
+struct DeliveryTarget {
+    let sessionID: UUID
+    let processIdentifier: pid_t
+    let bundleIdentifier: String?
+    let appName: String?
+    /// The UI element that had keyboard focus at stop time. Held as a live
+    /// AXUIElement reference so delivery targets that element specifically,
+    /// not "whatever is focused now".
+    let focusedElement: AXUIElement?
+    let elementRole: String?
+    let capturedAt: Date
+
+    var describedApp: String {
+        appName ?? bundleIdentifier ?? "pid \(processIdentifier)"
+    }
+}
+
+/// Ordered delivery strategies, cheapest and least intrusive first.
+enum DeliveryTier: String {
+    /// Accessibility write straight into the pinned text element. No focus
+    /// change, works across Spaces, works while the app is in the background.
+    case accessibilityInsert = "ax-insert"
+    /// Synthesised key events addressed to the target process. No activation,
+    /// but the app only sees them if it processes background key events.
+    case processKeystroke = "pid-keystroke"
+    /// Bring the app forward and press Cmd-V. Steals focus; opt-in only.
+    case activateAndPaste = "activate-paste"
+    /// Leave the text on the clipboard and tell the user it is waiting.
+    case clipboardOnly = "clipboard"
+}
+
+struct DeliveryOutcome {
+    let tier: DeliveryTier
+    let succeeded: Bool
+    let target: String
+    let attempts: [String]
+
+    var summary: String {
+        "\(tier.rawValue) → \(target)"
+    }
+}
+
+/// Delivers transcripts to a pinned target without disturbing the user's
+/// current focus. Stateless apart from configuration; every call carries its
+/// own target so several dictations can be in flight at once.
+final class TextDeliveryService {
+
+    /// Allow the focus-stealing tier (activate + Cmd-V) as a last resort
+    /// before falling back to clipboard-only.
+    var allowFocusStealFallback: Bool
+
+    /// Allow synthesised key events addressed to the target process.
+    var allowProcessKeystroke: Bool
+
+    init(allowFocusStealFallback: Bool = false, allowProcessKeystroke: Bool = true) {
+        self.allowFocusStealFallback = allowFocusStealFallback
+        self.allowProcessKeystroke = allowProcessKeystroke
+    }
+
+    // MARK: - Capture
+
+    /// Pins the currently focused app and text element. Call this at stop time,
+    /// before anything can change focus.
+    ///
+    /// - Parameter fallbackBundleIdentifier: bundle id captured at recording
+    ///   start, used when the app itself is frontmost (the user clicked stop in
+    ///   the menu bar rather than releasing a hotkey).
+    static func captureTarget(
+        sessionID: UUID = UUID(),
+        ownBundleIdentifier: String?,
+        fallbackBundleIdentifier: String?
+    ) -> DeliveryTarget? {
+        var app: NSRunningApplication?
+
+        if let front = NSWorkspace.shared.frontmostApplication,
+           front.bundleIdentifier != ownBundleIdentifier {
+            app = front
+        } else if let fallbackBundleIdentifier, fallbackBundleIdentifier != ownBundleIdentifier {
+            app = NSWorkspace.shared.runningApplications.first {
+                $0.bundleIdentifier == fallbackBundleIdentifier && $0.activationPolicy == .regular
+            }
+        }
+
+        guard let app else { return nil }
+
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        let focused = Self.copyElement(appElement, kAXFocusedUIElementAttribute as CFString)
+        let role = focused.flatMap { Self.copyString($0, kAXRoleAttribute as CFString) }
+
+        return DeliveryTarget(
+            sessionID: sessionID,
+            processIdentifier: app.processIdentifier,
+            bundleIdentifier: app.bundleIdentifier,
+            appName: app.localizedName,
+            focusedElement: focused,
+            elementRole: role,
+            capturedAt: Date()
+        )
+    }
+
+    // MARK: - Delivery
+
+    /// Runs the tier ladder for one transcript. The caller is responsible for
+    /// having placed `text` on the pasteboard already when it wants the
+    /// clipboard tiers to work.
+    @discardableResult
+    func deliver(
+        _ text: String,
+        to target: DeliveryTarget?,
+        completion: @escaping (DeliveryOutcome) -> Void
+    ) -> Bool {
+        var attempts: [String] = []
+
+        guard let target else {
+            attempts.append("no target captured")
+            completion(DeliveryOutcome(
+                tier: .clipboardOnly,
+                succeeded: false,
+                target: "none",
+                attempts: attempts
+            ))
+            return false
+        }
+
+        let describedApp = target.describedApp
+        // Terminals expose an AXTextArea that can report kAXSelectedText as
+        // settable while the write only touches the display and never reaches
+        // the tty. Send keys there first and treat the AX path as the fallback.
+        let preferKeystroke = Self.isTerminalLike(target)
+
+        if isTerminated(target) {
+            attempts.append("target app no longer running")
+            completion(DeliveryOutcome(
+                tier: .clipboardOnly,
+                succeeded: false,
+                target: describedApp,
+                attempts: attempts
+            ))
+            return false
+        }
+
+        if preferKeystroke, allowProcessKeystroke {
+            if postUnicode(text, toProcess: target.processIdentifier) {
+                attempts.append("pid-keystroke posted (terminal-like target)")
+                completion(DeliveryOutcome(
+                    tier: .processKeystroke,
+                    succeeded: true,
+                    target: describedApp,
+                    attempts: attempts
+                ))
+                return true
+            }
+            attempts.append("pid-keystroke could not be posted")
+        }
+
+        // Tier 1 — Accessibility insert into the pinned element.
+        switch insertViaAccessibility(text, target: target) {
+        case .success:
+            attempts.append("ax-insert ok")
+            completion(DeliveryOutcome(
+                tier: .accessibilityInsert,
+                succeeded: true,
+                target: describedApp,
+                attempts: attempts
+            ))
+            return true
+        case .failure(let reason):
+            attempts.append("ax-insert failed: \(reason)")
+        }
+
+        // Tier 2 — key events posted to the process, no activation.
+        if allowProcessKeystroke && !preferKeystroke {
+            if postUnicode(text, toProcess: target.processIdentifier) {
+                attempts.append("pid-keystroke posted")
+                completion(DeliveryOutcome(
+                    tier: .processKeystroke,
+                    succeeded: true,
+                    target: describedApp,
+                    attempts: attempts
+                ))
+                return true
+            }
+            attempts.append("pid-keystroke could not be posted")
+        } else {
+            attempts.append("pid-keystroke disabled")
+        }
+
+        // Tier 3 — focus steal, opt-in only.
+        if allowFocusStealFallback, let app = runningApplication(for: target) {
+            attempts.append("activating \(describedApp)")
+            app.activate(options: [.activateIgnoringOtherApps])
+            waitUntilFrontmost(app, attemptsLeft: 20) { [weak self] in
+                self?.sendCmdV()
+                completion(DeliveryOutcome(
+                    tier: .activateAndPaste,
+                    succeeded: true,
+                    target: describedApp,
+                    attempts: attempts
+                ))
+            }
+            return true
+        }
+
+        // Tier 4 — leave it on the clipboard.
+        attempts.append("left on clipboard")
+        completion(DeliveryOutcome(
+            tier: .clipboardOnly,
+            succeeded: false,
+            target: describedApp,
+            attempts: attempts
+        ))
+        return false
+    }
+
+    /// Terminal emulators and other apps whose text area is a rendered view
+    /// rather than a real editable field.
+    static func isTerminalLike(_ target: DeliveryTarget) -> Bool {
+        let terminalBundles: Set<String> = [
+            "com.apple.Terminal",
+            "com.googlecode.iterm2",
+            "dev.warp.Warp-Stable",
+            "dev.warp.Warp-Preview",
+            "net.kovidgoyal.kitty",
+            "io.alacritty",
+            "com.mitchellh.ghostty",
+            "com.github.wez.wezterm",
+            "co.zeit.hyper",
+            "com.tabby.app"
+        ]
+        if let bundle = target.bundleIdentifier, terminalBundles.contains(bundle) {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Tier 1: Accessibility
+
+    private enum InsertResult {
+        case success
+        case failure(String)
+    }
+
+    private func insertViaAccessibility(_ text: String, target: DeliveryTarget) -> InsertResult {
+        guard let element = target.focusedElement else {
+            return .failure("no focused element captured")
+        }
+
+        // A stale reference reports kAXErrorInvalidUIElement on any read.
+        var roleValue: CFTypeRef?
+        let roleStatus = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleValue)
+        guard roleStatus == .success else {
+            return .failure("element gone (\(Self.describe(roleStatus)))")
+        }
+
+        var settable: DarwinBoolean = false
+        let settableStatus = AXUIElementIsAttributeSettable(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            &settable
+        )
+        guard settableStatus == .success, settable.boolValue else {
+            return .failure("selected text not settable (\(Self.describe(settableStatus)))")
+        }
+
+        let setStatus = AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            text as CFTypeRef
+        )
+        guard setStatus == .success else {
+            return .failure("set failed (\(Self.describe(setStatus)))")
+        }
+
+        return .success
+    }
+
+    // MARK: - Tier 2: key events to a process
+
+    /// Posts `text` as unicode key events addressed to a single process, so no
+    /// activation and no Space switch is needed. Chunked because a single
+    /// event's unicode payload is not reliably honoured beyond a short string.
+    private func postUnicode(_ text: String, toProcess pid: pid_t) -> Bool {
+        guard !text.isEmpty else { return false }
+        guard let source = CGEventSource(stateID: .hidSystemState) else { return false }
+
+        let units = Array(text.utf16)
+        let chunkSize = 16
+        var index = 0
+
+        while index < units.count {
+            let end = min(index + chunkSize, units.count)
+            var chunk = Array(units[index..<end])
+
+            guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+                  let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
+                return false
+            }
+
+            keyDown.flags = []
+            keyUp.flags = []
+            keyDown.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: &chunk)
+            keyUp.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: &chunk)
+
+            keyDown.postToPid(pid)
+            keyUp.postToPid(pid)
+
+            index = end
+        }
+
+        return true
+    }
+
+    /// Presses Return in the target, matching however the text got there.
+    func pressReturn(target: DeliveryTarget, tier: DeliveryTier) {
+        switch tier {
+        case .accessibilityInsert, .processKeystroke:
+            guard let source = CGEventSource(stateID: .hidSystemState) else { return }
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true)
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false)
+            keyDown?.postToPid(target.processIdentifier)
+            keyUp?.postToPid(target.processIdentifier)
+        case .activateAndPaste:
+            guard let source = CGEventSource(stateID: .hidSystemState) else { return }
+            CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true)?
+                .post(tap: .cgSessionEventTap)
+            CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false)?
+                .post(tap: .cgSessionEventTap)
+        case .clipboardOnly:
+            break
+        }
+    }
+
+    // MARK: - Tier 3: activate and paste
+
+    private func waitUntilFrontmost(
+        _ app: NSRunningApplication,
+        attemptsLeft: Int,
+        completion: @escaping () -> Void
+    ) {
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
+            || attemptsLeft <= 0 {
+            completion()
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.waitUntilFrontmost(app, attemptsLeft: attemptsLeft - 1, completion: completion)
+        }
+    }
+
+    private func sendCmdV() {
+        guard let source = CGEventSource(stateID: .hidSystemState) else { return }
+        let vKeyCode = Self.keyCodeForCharacter("v") ?? 9
+
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
+        keyDown?.flags = .maskCommand
+        keyDown?.post(tap: .cgSessionEventTap)
+
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
+        keyUp?.flags = .maskCommand
+        keyUp?.post(tap: .cgSessionEventTap)
+    }
+
+    // MARK: - Helpers
+
+    private func runningApplication(for target: DeliveryTarget) -> NSRunningApplication? {
+        NSRunningApplication(processIdentifier: target.processIdentifier)
+    }
+
+    private func isTerminated(_ target: DeliveryTarget) -> Bool {
+        guard let app = runningApplication(for: target) else { return true }
+        return app.isTerminated
+    }
+
+    static func copyElement(_ element: AXUIElement, _ attribute: CFString) -> AXUIElement? {
+        var value: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(element, attribute, &value)
+        guard status == .success,
+              let raw = value,
+              CFGetTypeID(raw) == AXUIElementGetTypeID() else {
+            return nil
+        }
+        return unsafeBitCast(raw, to: AXUIElement.self)
+    }
+
+    static func copyString(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(element, attribute, &value)
+        guard status == .success, let string = value as? String else { return nil }
+        return string
+    }
+
+    static func describe(_ error: AXError) -> String {
+        switch error {
+        case .success: return "success"
+        case .failure: return "failure"
+        case .illegalArgument: return "illegalArgument"
+        case .invalidUIElement: return "invalidUIElement"
+        case .invalidUIElementObserver: return "invalidUIElementObserver"
+        case .cannotComplete: return "cannotComplete"
+        case .attributeUnsupported: return "attributeUnsupported"
+        case .actionUnsupported: return "actionUnsupported"
+        case .notificationUnsupported: return "notificationUnsupported"
+        case .notImplemented: return "notImplemented"
+        case .notificationAlreadyRegistered: return "notificationAlreadyRegistered"
+        case .notificationNotRegistered: return "notificationNotRegistered"
+        case .apiDisabled: return "apiDisabled"
+        case .noValue: return "noValue"
+        case .parameterizedAttributeUnsupported: return "parameterizedAttributeUnsupported"
+        case .notEnoughPrecision: return "notEnoughPrecision"
+        @unknown default: return "unknown(\(error.rawValue))"
+        }
+    }
+
+    static func keyCodeForCharacter(_ character: String) -> CGKeyCode? {
+        guard let char = character.lowercased().utf16.first else { return nil }
+        let source = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
+        guard let layoutDataRef = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+        let layoutData = unsafeBitCast(layoutDataRef, to: CFData.self) as Data
+        return layoutData.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> CGKeyCode? in
+            guard let layout = ptr.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else {
+                return nil
+            }
+            for keyCode in UInt16(0)..<UInt16(128) {
+                var chars = [UniChar](repeating: 0, count: 4)
+                var charCount = 0
+                var deadKeyState: UInt32 = 0
+                let status = UCKeyTranslate(
+                    layout, keyCode, UInt16(kUCKeyActionDisplay), 0,
+                    UInt32(LMGetKbdType()), OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                    &deadKeyState, 4, &charCount, &chars
+                )
+                if status == noErr, charCount > 0, chars[0] == char {
+                    return CGKeyCode(keyCode)
+                }
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/TextDelivery.swift
+++ b/Sources/TextDelivery.swift
@@ -94,6 +94,9 @@ final class TextDeliveryService {
         guard let app else { return nil }
 
         let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        // Chromium and Electron keep their accessibility tree switched off
+        // until something asks for it. Harmless everywhere else.
+        AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
         let focused = Self.copyElement(appElement, kAXFocusedUIElementAttribute as CFString)
         let role = focused.flatMap { Self.copyString($0, kAXRoleAttribute as CFString) }
 

--- a/Sources/TextDelivery.swift
+++ b/Sources/TextDelivery.swift
@@ -37,6 +37,9 @@ enum DeliveryTier: String {
     /// Synthesised key events addressed to the target process. No activation,
     /// but the app only sees them if it processes background key events.
     case processKeystroke = "pid-keystroke"
+    /// Cmd-V addressed to the target process. No activation, and it leaves the
+    /// app to interpret its own paste rather than trusting injected unicode.
+    case processPaste = "pid-paste"
     /// Bring the app forward and press Cmd-V. Steals focus; opt-in only.
     case activateAndPaste = "activate-paste"
     /// Leave the text on the clipboard and tell the user it is waiting.
@@ -146,6 +149,7 @@ final class TextDeliveryService {
         // settable while the write only touches the display and never reaches
         // the tty. Send keys there first and treat the AX path as the fallback.
         let preferKeystroke = Self.isTerminalLike(target)
+        let chromiumLike = Self.isChromiumLike(target)
 
         if isTerminated(target) {
             attempts.append("target app no longer running")
@@ -187,6 +191,18 @@ final class TextDeliveryService {
             attempts.append("ax-insert failed: \(reason)")
         }
 
+        // Chromium and Electron mangle injected unicode, so paste first.
+        if chromiumLike, postCommandV(toProcess: target.processIdentifier) {
+            attempts.append("pid-paste posted (chromium-like target)")
+            completion(DeliveryOutcome(
+                tier: .processPaste,
+                succeeded: true,
+                target: describedApp,
+                attempts: attempts
+            ))
+            return true
+        }
+
         // Tier 2 — key events posted to the process, no activation.
         if allowProcessKeystroke && !preferKeystroke {
             if postUnicode(text, toProcess: target.processIdentifier) {
@@ -203,6 +219,21 @@ final class TextDeliveryService {
         } else {
             attempts.append("pid-keystroke disabled")
         }
+
+        // Paste addressed to the process. No activation, and unlike unicode
+        // injection it survives apps that read the virtual key code rather
+        // than the attached characters.
+        if postCommandV(toProcess: target.processIdentifier) {
+            attempts.append("pid-paste posted")
+            completion(DeliveryOutcome(
+                tier: .processPaste,
+                succeeded: true,
+                target: describedApp,
+                attempts: attempts
+            ))
+            return true
+        }
+        attempts.append("pid-paste could not be posted")
 
         // Tier 3 — focus steal, opt-in only.
         if allowFocusStealFallback, let app = runningApplication(for: target) {
@@ -228,6 +259,34 @@ final class TextDeliveryService {
             target: describedApp,
             attempts: attempts
         ))
+        return false
+    }
+
+    /// Chromium-based apps, including Electron. Their editable surfaces are
+    /// rendered rather than real AppKit text views, and they interpret a
+    /// synthesised key event by its virtual key code rather than the unicode
+    /// payload attached to it, which is how injected text arrives as a stray
+    /// keypress instead of characters.
+    static func isChromiumLike(_ target: DeliveryTarget) -> Bool {
+        let chromiumBundles: Set<String> = [
+            "inc.tana.desktop",
+            "com.brave.Browser",
+            "com.brave.Browser.beta",
+            "com.google.Chrome",
+            "com.microsoft.edgemac",
+            "com.microsoft.VSCode",
+            "com.todesktop.230313mzl4w4u92",  // Cursor
+            "md.obsidian",
+            "com.tinyspeck.slackmacgap",
+            "com.hnc.Discord",
+            "notion.id",
+            "com.spotify.client",
+            "com.electron.logseq",
+            "com.logseq.logseq"
+        ]
+        if let bundle = target.bundleIdentifier, chromiumBundles.contains(bundle) {
+            return true
+        }
         return false
     }
 
@@ -383,7 +442,7 @@ final class TextDeliveryService {
     /// Presses Return in the target, matching however the text got there.
     func pressReturn(target: DeliveryTarget, tier: DeliveryTier) {
         switch tier {
-        case .accessibilityInsert, .processKeystroke:
+        case .accessibilityInsert, .processKeystroke, .processPaste:
             guard let source = CGEventSource(stateID: .hidSystemState) else { return }
             let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true)
             let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false)
@@ -398,6 +457,23 @@ final class TextDeliveryService {
         case .clipboardOnly:
             break
         }
+    }
+
+    /// Sends Cmd-V to one process without bringing it forward. The transcript
+    /// must already be on the pasteboard.
+    private func postCommandV(toProcess pid: pid_t) -> Bool {
+        guard let source = CGEventSource(stateID: .hidSystemState) else { return false }
+        let vKeyCode = Self.keyCodeForCharacter("v") ?? 9
+
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
+            return false
+        }
+        keyDown.flags = .maskCommand
+        keyUp.flags = .maskCommand
+        keyDown.postToPid(pid)
+        keyUp.postToPid(pid)
+        return true
     }
 
     // MARK: - Tier 3: activate and paste

--- a/Sources/TextDelivery.swift
+++ b/Sources/TextDelivery.swift
@@ -193,7 +193,7 @@ final class TextDeliveryService {
             attempts.append("ax-insert unverified: \(reason)")
             // The host lied about the write, so treat it as Chromium-like even
             // if its bundle id is not on the list.
-            if postCommandV(toProcess: target.processIdentifier) {
+            if canPasteInBackground(target), postCommandV(toProcess: target.processIdentifier) {
                 attempts.append("pid-paste posted (unverified ax host)")
                 completion(DeliveryOutcome(
                     tier: .processPaste,
@@ -207,7 +207,9 @@ final class TextDeliveryService {
         }
 
         // Chromium and Electron mangle injected unicode, so paste first.
-        if chromiumLike, postCommandV(toProcess: target.processIdentifier) {
+        if chromiumLike, !canPasteInBackground(target) {
+            attempts.append("pid-paste skipped: \(describedApp) is not frontmost and ignores background keys")
+        } else if chromiumLike, postCommandV(toProcess: target.processIdentifier) {
             attempts.append("pid-paste posted (chromium-like target)")
             completion(DeliveryOutcome(
                 tier: .processPaste,
@@ -238,7 +240,7 @@ final class TextDeliveryService {
         // Paste addressed to the process. No activation, and unlike unicode
         // injection it survives apps that read the virtual key code rather
         // than the attached characters.
-        if postCommandV(toProcess: target.processIdentifier) {
+        if canPasteInBackground(target), postCommandV(toProcess: target.processIdentifier) {
             attempts.append("pid-paste posted")
             completion(DeliveryOutcome(
                 tier: .processPaste,
@@ -478,6 +480,15 @@ final class TextDeliveryService {
         case .clipboardOnly:
             break
         }
+    }
+
+    /// Chromium only handles key events while it is the active application, so
+    /// a paste addressed to a backgrounded one is swallowed without a trace.
+    /// Better to say the text is on the clipboard than to claim a delivery that
+    /// did not happen.
+    private func canPasteInBackground(_ target: DeliveryTarget) -> Bool {
+        guard Self.isChromiumLike(target) else { return true }
+        return NSWorkspace.shared.frontmostApplication?.processIdentifier == target.processIdentifier
     }
 
     /// Sends Cmd-V to one process without bringing it forward. The transcript

--- a/Sources/TextDelivery.swift
+++ b/Sources/TextDelivery.swift
@@ -189,6 +189,21 @@ final class TextDeliveryService {
             return true
         case .failure(let reason):
             attempts.append("ax-insert failed: \(reason)")
+        case .unverified(let reason):
+            attempts.append("ax-insert unverified: \(reason)")
+            // The host lied about the write, so treat it as Chromium-like even
+            // if its bundle id is not on the list.
+            if postCommandV(toProcess: target.processIdentifier) {
+                attempts.append("pid-paste posted (unverified ax host)")
+                completion(DeliveryOutcome(
+                    tier: .processPaste,
+                    succeeded: true,
+                    target: describedApp,
+                    attempts: attempts
+                ))
+                return true
+            }
+            attempts.append("pid-paste could not be posted")
         }
 
         // Chromium and Electron mangle injected unicode, so paste first.
@@ -282,7 +297,8 @@ final class TextDeliveryService {
             "notion.id",
             "com.spotify.client",
             "com.electron.logseq",
-            "com.logseq.logseq"
+            "com.logseq.logseq",
+            "com.anthropic.claudefordesktop"
         ]
         if let bundle = target.bundleIdentifier, chromiumBundles.contains(bundle) {
             return true
@@ -316,6 +332,11 @@ final class TextDeliveryService {
     private enum InsertResult {
         case success
         case failure(String)
+        /// The write returned success and the element did not grow. Only a
+        /// Chromium-style host does that, so paste rather than inject unicode:
+        /// such a host reads a synthesised event by its virtual key code and
+        /// turns injected characters into a stray keypress.
+        case unverified(String)
     }
 
     private func insertViaAccessibility(_ text: String, target: DeliveryTarget) -> InsertResult {
@@ -368,7 +389,7 @@ final class TextDeliveryService {
         // silently vanishes. Only call it delivered if the element grew.
         if let lengthBefore, let lengthAfter = Self.textLength(of: element) {
             guard lengthAfter > lengthBefore else {
-                return .failure("set reported success but the text did not land")
+                return .unverified("set reported success but the text did not land")
             }
         }
 

--- a/Sources/TranscriptionProgressPanel.swift
+++ b/Sources/TranscriptionProgressPanel.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct TranscriptionProgressPanel: View {
+    let audioPath: String
+    let onDismiss: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Transcribing in background", systemImage: "waveform.badge.exclamationmark")
+                .font(.headline)
+
+            Text("With local processing, this can take as long as the recording — or longer under load. You can keep working; the result will paste when ready.")
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Audio already saved — safe to cancel if needed:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(audioPath)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                    .textSelection(.enabled)
+            }
+
+            HStack {
+                Button("Keep Waiting", action: onDismiss)
+                    .keyboardShortcut(.defaultAction)
+                Spacer()
+                Button("Cancel Transcription", role: .destructive, action: onCancel)
+            }
+            .padding(.top, 4)
+        }
+        .padding(20)
+        .frame(width: 440)
+    }
+}

--- a/Sources/TranscriptionProgressPanel.swift
+++ b/Sources/TranscriptionProgressPanel.swift
@@ -2,15 +2,23 @@ import SwiftUI
 
 struct TranscriptionProgressPanel: View {
     let audioPath: String
+    let recordingDuration: String?
     let onDismiss: () -> Void
     let onCancel: () -> Void
+
+    private var durationNote: String {
+        if let d = recordingDuration {
+            return "With local processing, this can take as long as your recording (\(d)) — or longer under load. You can keep working; the result will paste when ready."
+        }
+        return "With local processing, this can take as long as the recording — or longer under load. You can keep working; the result will paste when ready."
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             Label("Transcribing in background", systemImage: "waveform.badge.exclamationmark")
                 .font(.headline)
 
-            Text("With local processing, this can take as long as the recording — or longer under load. You can keep working; the result will paste when ready.")
+            Text(durationNote)
                 .font(.body)
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -27,9 +35,14 @@ struct TranscriptionProgressPanel: View {
                     .textSelection(.enabled)
             }
 
-            HStack {
-                Button("Keep Waiting", action: onDismiss)
-                    .keyboardShortcut(.defaultAction)
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Button("Keep Waiting", action: onDismiss)
+                        .keyboardShortcut(.defaultAction)
+                    Text("dismiss this notification")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
                 Spacer()
                 Button("Cancel Transcription", role: .destructive, action: onCancel)
             }

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -11,8 +11,8 @@ class TranscriptionService {
     private let transcriptionResponseFormat = "verbose_json"
     private var transcriptionTimeoutSeconds: TimeInterval {
         let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
-        if override < 0 { return .infinity }   // -1 = no timeout
-        return override > 0 ? override : 300   // default: 5 min
+        if override < 0 { return .infinity }   // -1 = no timeout (default)
+        return override > 0 ? override : .infinity
     }
 
     init(

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -11,7 +11,8 @@ class TranscriptionService {
     private let transcriptionResponseFormat = "verbose_json"
     private var transcriptionTimeoutSeconds: TimeInterval {
         let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
-        return override > 0 ? override : 20
+        if override < 0 { return .infinity }   // -1 = no timeout
+        return override > 0 ? override : 300   // default: 5 min
     }
 
     init(
@@ -75,17 +76,20 @@ class TranscriptionService {
                     }
                 }
 
-                let timeoutTask = Task {
-                    do {
-                        try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
-                        raceState.finish(.failure(TranscriptionError.transcriptionTimedOut(timeoutSeconds)))
-                    } catch is CancellationError {
-                    } catch {
-                        raceState.finish(.failure(error))
+                if timeoutSeconds.isFinite {
+                    let timeoutTask = Task {
+                        do {
+                            try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                            raceState.finish(.failure(TranscriptionError.transcriptionTimedOut(timeoutSeconds)))
+                        } catch is CancellationError {
+                        } catch {
+                            raceState.finish(.failure(error))
+                        }
                     }
+                    raceState.setTasks([transcriptionTask, timeoutTask])
+                } else {
+                    raceState.setTasks([transcriptionTask])
                 }
-
-                raceState.setTasks([transcriptionTask, timeoutTask])
             }
         } onCancel: {
             raceState.cancel()

--- a/fork.md
+++ b/fork.md
@@ -1,0 +1,412 @@
+# FreeFlow Fork Patch Memory
+
+## Header
+
+- **Upstream repo:** https://github.com/zachlatta/freeflow
+- **Fork location:** /Users/personal/Documents/code/freeflow-fork
+- **Built app:** /Users/personal/Applications/FreeFlow Dev.app
+- **Bundle ID:** com.zachlatta.freeflow.dev
+- **Build command:** `cd /Users/personal/Documents/code/freeflow-fork && make`
+- **Install command:** `cp -r "build/FreeFlow Dev.app" "/Users/personal/Applications/FreeFlow Dev.app" && xattr -dr com.apple.quarantine "/Users/personal/Applications/FreeFlow Dev.app"`
+
+---
+
+## Patches
+
+Each patch has a unique ID, the relative file path, a description of what it does and why, and verbatim Search/Replace blocks. The consumer does literal string matching: indentation and spacing must match exactly.
+
+---
+
+### P1
+
+- **File:** `Sources/ShortcutCore/DictationShortcutSessionController.swift`
+- **Description:** Fix silent swallow of first toggle-stop press when recording started via menu bar button. `beginManual()` set `toggleStopArmed = false` but the stop handler requires it to be true. Fix: set it to `(mode == .toggle)` so the first shortcut press stops immediately rather than being silently ignored.
+
+**Search:**
+```
+    func beginManual(mode: RecordingTriggerMode) {
+        activeMode = mode
+        toggleStopArmed = false
+    }
+```
+
+**Replace:**
+```
+    func beginManual(mode: RecordingTriggerMode) {
+        activeMode = mode
+        // When started without a physical key press/release cycle (e.g. via menu
+        // bar button), arm stop immediately so the first shortcut press stops the
+        // recording rather than being silently swallowed.
+        toggleStopArmed = (mode == .toggle)
+    }
+```
+
+---
+
+### P2
+
+- **File:** `Sources/AppState.swift`
+- **Description:** Preserve saved audio file when transcription is cancelled mid-flight (cancelTranscription path). Upstream deletes the file silently; fork keeps it for retry.
+
+**Search:**
+```
+        audioRecorder.cleanup()
+        if let transcribingAudioFileName {
+            Self.deleteAudioFile(transcribingAudioFileName)
+            self.transcribingAudioFileName = nil
+        }
+        endCriticalDictationActivity()
+        refreshAvailableMicrophonesIfNeeded()
+        if !isRecording && !isTranscribing && statusText == "Cancelled" {
+            scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
+```
+
+**Replace:**
+```
+        audioRecorder.cleanup()
+        // Keep the saved audio file — it's available in the run log for retry.
+        self.transcribingAudioFileName = nil
+        endCriticalDictationActivity()
+        refreshAvailableMicrophonesIfNeeded()
+        if !isRecording && !isTranscribing && statusText == "Cancelled" {
+            scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
+```
+
+---
+
+### P3
+
+- **File:** `Sources/AppState.swift`
+- **Description:** Preserve saved audio file in recording-start-error teardown path. Upstream deletes it on recording-start failure; fork keeps it for retry.
+
+**Search:**
+```
+        if let transcribingAudioFileName {
+            Self.deleteAudioFile(transcribingAudioFileName)
+            self.transcribingAudioFileName = nil
+        }
+        activeRecordingTriggerMode = nil
+        currentSessionIntent = .dictation
+        shortcutSessionController.reset()
+        endCriticalDictationActivity()
+        errorMessage = formattedRecordingStartError(error)
+```
+
+**Replace:**
+```
+        // Keep the saved audio file — it's available in the run log for retry.
+        self.transcribingAudioFileName = nil
+        activeRecordingTriggerMode = nil
+        currentSessionIntent = .dictation
+        shortcutSessionController.reset()
+        endCriticalDictationActivity()
+        errorMessage = formattedRecordingStartError(error)
+```
+
+---
+
+### P4
+
+- **File:** `Sources/AppState.swift`
+- **Description:** Preserve saved audio when isTranscribing resets mid-flight in stopAndTranscribe completion. Upstream deletes the just-saved file silently; fork keeps it for retry.
+
+**Search:**
+```
+            guard self.isTranscribing else {
+                if let savedAudioFile {
+                    Self.deleteAudioFile(savedAudioFile.fileName)
+                }
+                self.transcribingAudioFileName = nil
+                activeRealtime?.cancel()
+                self.audioRecorder.cleanup()
+                self.endCriticalDictationActivity()
+                self.refreshAvailableMicrophonesIfNeeded()
+                return
+            }
+```
+
+**Replace:**
+```
+            guard self.isTranscribing else {
+                // Transcription was cancelled mid-flight. Keep the saved audio
+                // file so it remains available in the run log for retry.
+                self.transcribingAudioFileName = nil
+                activeRealtime?.cancel()
+                self.audioRecorder.cleanup()
+                self.endCriticalDictationActivity()
+                self.refreshAvailableMicrophonesIfNeeded()
+                return
+            }
+```
+
+---
+
+### P5
+
+- **File:** `Sources/TranscriptionService.swift`
+- **Description:** Change default timeout from 20s to 300s (5 min); support -1 for no timeout. Local ASR (Qwen3-ASR-1.7B) takes 15–20s for 35s of audio; the 20s default caused silent failures on long recordings.
+
+**Search:**
+```
+    private var transcriptionTimeoutSeconds: TimeInterval {
+        let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
+        return override > 0 ? override : 20
+    }
+```
+
+**Replace:**
+```
+    private var transcriptionTimeoutSeconds: TimeInterval {
+        let override = UserDefaults.standard.double(forKey: "transcription_timeout_seconds")
+        if override < 0 { return .infinity }   // -1 = no timeout
+        return override > 0 ? override : 300   // default: 5 min
+    }
+```
+
+---
+
+### P6
+
+- **File:** `Sources/TranscriptionService.swift`
+- **Description:** Skip the timeout task entirely when timeout is infinite (no-timeout mode). Without this guard, `UInt64(.infinity * 1e9)` overflows and the timeout fires immediately.
+
+**Search:**
+```
+                let timeoutTask = Task {
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                        raceState.finish(.failure(TranscriptionError.transcriptionTimedOut(timeoutSeconds)))
+                    } catch is CancellationError {
+                    } catch {
+                        raceState.finish(.failure(error))
+                    }
+                }
+
+                raceState.setTasks([transcriptionTask, timeoutTask])
+```
+
+**Replace:**
+```
+                if timeoutSeconds.isFinite {
+                    let timeoutTask = Task {
+                        do {
+                            try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                            raceState.finish(.failure(TranscriptionError.transcriptionTimedOut(timeoutSeconds)))
+                        } catch is CancellationError {
+                        } catch {
+                            raceState.finish(.failure(error))
+                        }
+                    }
+                    raceState.setTasks([transcriptionTask, timeoutTask])
+                } else {
+                    raceState.setTasks([transcriptionTask])
+                }
+```
+
+---
+
+### P7
+
+- **File:** `Sources/AppState.swift`
+- **Description:** Add elapsed-time warning in status text while transcribing. After 20s shows "Transcribing... (Xs)"; after 60s shows "Still processing... (Xs)". Uses didSet on isTranscribing to auto-stop the timer when transcription ends.
+
+This patch has three sub-parts applied in order: P7a (add stored properties with didSet), P7b (add timer methods before scheduleReadyStatusReset), P7c (start the timer when transcription begins).
+
+**P7a — Add didSet + timer properties after `@Published var isTranscribing = false`**
+
+Search:
+```
+    @Published var isTranscribing = false
+```
+
+Replace:
+```
+    @Published var isTranscribing = false {
+        didSet {
+            if !isTranscribing && oldValue {
+                stopTranscriptionElapsedTimer()
+            }
+        }
+    }
+    private var transcriptionStartTime: Date?
+    private var transcriptionElapsedTimer: Timer?
+```
+
+**P7b — Add timer methods before `scheduleReadyStatusReset`**
+
+Search:
+```
+    private func scheduleReadyStatusReset(after delay: TimeInterval, matching statuses: Set<String>? = nil) {
+```
+
+Replace:
+```
+    private func startTranscriptionElapsedTimer() {
+        transcriptionStartTime = Date()
+        transcriptionElapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self, self.isTranscribing, let start = self.transcriptionStartTime else { return }
+            let elapsed = Int(-start.timeIntervalSinceNow)
+            guard elapsed >= 20 else { return }
+            let prefix = elapsed >= 60 ? "Still processing" : "Transcribing"
+            self.statusText = "\(prefix)... (\(elapsed)s)"
+        }
+    }
+
+    private func stopTranscriptionElapsedTimer() {
+        transcriptionElapsedTimer?.invalidate()
+        transcriptionElapsedTimer = nil
+        transcriptionStartTime = nil
+    }
+
+    private func scheduleReadyStatusReset(after delay: TimeInterval, matching statuses: Set<String>? = nil) {
+```
+
+**P7c — Start the timer when transcription status is set**
+
+Search:
+```
+            self.statusText = "Transcribing..."
+            self.debugStatusMessage = "Transcribing audio"
+```
+
+Replace:
+```
+            self.statusText = "Transcribing..."
+            self.debugStatusMessage = "Transcribing audio"
+            self.startTranscriptionElapsedTimer()
+```
+
+---
+
+### P8
+
+- **File:** `Sources/App.swift`
+- **Description:** Shade the dev-build menu bar icon to 40% opacity at idle so the user can distinguish the fork from the production build at a glance.
+
+**Search:**
+```
+        if AppBuild.isDevBundle && !appState.isRecording && !appState.isTranscribing {
+            Image(nsImage: StampedMenuBarIcon.templateImage)
+                .renderingMode(.template)
+        } else {
+```
+
+**Replace:**
+```
+        if AppBuild.isDevBundle && !appState.isRecording && !appState.isTranscribing {
+            Image(nsImage: StampedMenuBarIcon.templateImage)
+                .renderingMode(.template)
+                .opacity(0.4)
+        } else {
+```
+
+---
+
+### P9
+
+- **File:** `Sources/SettingsView.swift`
+- **Description:** Add Transcription Timeout settings card — toggle for no-timeout and a seconds input field. Lets the user configure or disable the timeout via the Settings UI rather than `defaults write`. Three additive sub-patches: P9a adds the `@AppStorage` property, P9b inserts the `SettingsCard` into the card list, P9c adds the `transcriptionTimeoutSection` computed property.
+
+**P9a — Add `@AppStorage` property for timeout after `use_compact_overlay` line**
+
+Search:
+```
+    @AppStorage("use_compact_overlay") private var useCompactOverlay = true
+    @State private var screensVersion = 0
+```
+
+Replace:
+```
+    @AppStorage("use_compact_overlay") private var useCompactOverlay = true
+    @AppStorage("transcription_timeout_seconds") private var transcriptionTimeoutRaw: Double = 300
+    @State private var screensVersion = 0
+```
+
+**P9b — Insert SettingsCard for Transcription Timeout after Sound Volume card**
+
+Search:
+```
+                SettingsCard("Sound Volume", icon: "speaker.wave.2.fill") {
+                    soundVolumeSection
+                }
+                SettingsCard("Custom Vocabulary", icon: "text.book.closed.fill") {
+                    vocabularySection
+                }
+```
+
+Replace:
+```
+                SettingsCard("Sound Volume", icon: "speaker.wave.2.fill") {
+                    soundVolumeSection
+                }
+                SettingsCard("Transcription Timeout", icon: "clock.fill") {
+                    transcriptionTimeoutSection
+                }
+                SettingsCard("Custom Vocabulary", icon: "text.book.closed.fill") {
+                    vocabularySection
+                }
+```
+
+**P9c — Add `transcriptionTimeoutSection` computed property before `// MARK: Custom Vocabulary`**
+
+Search:
+```
+    // MARK: Custom Vocabulary
+
+    private var vocabularySection: some View {
+```
+
+Replace:
+```
+    // MARK: Transcription Timeout
+
+    private var noTimeoutBinding: Binding<Bool> {
+        Binding(
+            get: { transcriptionTimeoutRaw < 0 },
+            set: { transcriptionTimeoutRaw = $0 ? -1 : 300 }
+        )
+    }
+
+    private var transcriptionTimeoutSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("No timeout — wait as long as needed", isOn: noTimeoutBinding)
+
+            if !noTimeoutBinding.wrappedValue {
+                HStack {
+                    Text("Timeout after")
+                    Spacer()
+                    TextField("", value: $transcriptionTimeoutRaw, format: .number)
+                        .frame(width: 64)
+                        .multilineTextAlignment(.trailing)
+                        .textFieldStyle(.roundedBorder)
+                    Text("seconds")
+                        .foregroundStyle(.secondary)
+                }
+                Text("Status shows elapsed time after 20 s so you know it's still working.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: Custom Vocabulary
+
+    private var vocabularySection: some View {
+```
+
+---
+
+### P10
+
+- **File:** `Makefile`
+- **Description:** Use ad-hoc signing (`-`) instead of requiring a named "FreeFlow Dev" certificate. Allows local builds without a matching code-signing identity in the keychain.
+
+**Search:**
+```
+	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
+```
+
+**Replace:**
+```
+	@codesign --force --sign - --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
+```

--- a/fork.md
+++ b/fork.md
@@ -410,3 +410,158 @@ Replace:
 ```
 	@codesign --force --sign - --entitlements FreeFlow.entitlements "$(APP_BUNDLE)"
 ```
+
+---
+
+### P11
+
+- **File:** `Sources/AppState.swift`
+- **Description:** Async paste — capture the frontmost app at stop time and activate it before sending Cmd-V, so the paste lands in the right window even if the user has switched away during transcription. Uses poll-until-frontmost instead of a fixed delay, because local model inference saturates CPU and a fixed 100ms races. Prefers stop-time frontmost over session-start context; falls back to session-start context only when FreeFlow itself is frontmost (menu-bar-stop case).
+
+**Sub-patch P11a** — add `pasteTargetApp` property after `transcriptionElapsedTimer`:
+
+**Search:**
+```
+    private var transcriptionStartTime: Date?
+    private var transcriptionElapsedTimer: Timer?
+```
+
+**Replace:**
+```
+    private var transcriptionStartTime: Date?
+    private var transcriptionElapsedTimer: Timer?
+    // App that was frontmost when the user pressed stop — paste target for async delivery.
+    private var pasteTargetApp: NSRunningApplication?
+```
+
+**Sub-patch P11b** — capture paste target at top of `stopAndTranscribe()`:
+
+**Search:**
+```
+    private func stopAndTranscribe() {
+        cancelPendingShortcutStart()
+        cancelRecordingInitializationTimer()
+        shortcutSessionController.reset()
+        activeRecordingTriggerMode = nil
+        let sessionIntent = currentSessionIntent
+        currentSessionIntent = .dictation
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
+        audioLevelCancellable?.cancel()
+        audioLevelCancellable = nil
+        debugStatusMessage = "Preparing audio"
+        let sessionContext = capturedContext
+```
+
+**Replace:**
+```
+    private func stopAndTranscribe() {
+        // Capture the app the user was working in when they pressed stop.
+        // Must happen before any focus changes. Prefer the true stop-time frontmost
+        // app; fall back to the session-start context only when FreeFlow is already
+        // frontmost (i.e. the user opened the menu to click stop).
+        let stopTimeFrontmost = NSWorkspace.shared.frontmostApplication
+        if let front = stopTimeFrontmost, front.bundleIdentifier != Bundle.main.bundleIdentifier {
+            pasteTargetApp = front
+        } else if let bundleId = capturedContext?.bundleIdentifier, bundleId != Bundle.main.bundleIdentifier {
+            pasteTargetApp = NSWorkspace.shared.runningApplications.first {
+                $0.bundleIdentifier == bundleId && $0.activationPolicy == .regular
+            }
+        } else {
+            pasteTargetApp = nil
+        }
+
+        cancelPendingShortcutStart()
+        cancelRecordingInitializationTimer()
+        shortcutSessionController.reset()
+        activeRecordingTriggerMode = nil
+        let sessionIntent = currentSessionIntent
+        currentSessionIntent = .dictation
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
+        audioLevelCancellable?.cancel()
+        audioLevelCancellable = nil
+        debugStatusMessage = "Preparing audio"
+        let sessionContext = capturedContext
+```
+
+**Sub-patch P11c** — replace `pasteAtCursor()` with activation-aware version, extract `sendCmdV`, add `waitUntilFrontmost`:
+
+**Search:**
+```
+    private func pasteAtCursor() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let vKeyCode = keyCodeForCharacter("v") ?? 9
+
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
+        keyDown?.flags = .maskCommand
+        keyDown?.post(tap: .cgSessionEventTap)
+
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
+        keyUp?.flags = .maskCommand
+        keyUp?.post(tap: .cgSessionEventTap)
+    }
+```
+
+**Replace:**
+```
+    private func pasteAtCursor(completion: (() -> Void)? = nil) {
+        guard let target = pasteTargetApp, !target.isTerminated else {
+            pasteTargetApp = nil
+            sendCmdV()
+            completion?()
+            return
+        }
+        pasteTargetApp = nil
+        target.activate(options: [.activateIgnoringOtherApps])
+        // Poll until the target is actually frontmost before sending Cmd-V —
+        // a fixed delay is unreliable under CPU load (local model inference).
+        waitUntilFrontmost(target, attemptsLeft: 20, completion: completion)
+    }
+
+    private func waitUntilFrontmost(_ target: NSRunningApplication, attemptsLeft: Int, completion: (() -> Void)?) {
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == target.processIdentifier
+            || attemptsLeft <= 0 {
+            sendCmdV()
+            completion?()
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.waitUntilFrontmost(target, attemptsLeft: attemptsLeft - 1, completion: completion)
+        }
+    }
+
+    private func sendCmdV() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let vKeyCode = keyCodeForCharacter("v") ?? 9
+
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
+        keyDown?.flags = .maskCommand
+        keyDown?.post(tap: .cgSessionEventTap)
+
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
+        keyUp?.flags = .maskCommand
+        keyUp?.post(tap: .cgSessionEventTap)
+    }
+```
+
+**Sub-patch P11d** — thread completion through `pasteAtCursorWhenShortcutReleased`:
+
+**Search:**
+```
+    private func pasteAtCursorWhenShortcutReleased(completion: (() -> Void)? = nil) {
+        performAfterShortcutReleased { [weak self] in
+            self?.pasteAtCursor()
+            completion?()
+        }
+    }
+```
+
+**Replace:**
+```
+    private func pasteAtCursorWhenShortcutReleased(completion: (() -> Void)? = nil) {
+        performAfterShortcutReleased { [weak self] in
+            self?.pasteAtCursor(completion: completion)
+        }
+    }
+```

--- a/fork.md
+++ b/fork.md
@@ -565,3 +565,125 @@ Replace:
         }
     }
 ```
+
+---
+
+### P12
+
+- **Files:** `Sources/AppState.swift`, `Sources/SettingsView.swift`, `Sources/TranscriptionService.swift`
+- **Description:** No timeout by default + "still processing" alert at 10s. Default timeout changed from 300s to infinity (-1). If transcription takes longer than 10s, an NSAlert appears telling the user the audio is saved, showing the file path, and offering "Keep Waiting" or "Cancel Transcription". Cancel preserves the audio (P2 already ensures this). Alert shown at most once per transcription session.
+
+**Sub-patch P12a** — `Sources/TranscriptionService.swift` — default timeout to infinity:
+
+**Search:**
+```
+        if override < 0 { return .infinity }   // -1 = no timeout
+        return override > 0 ? override : 300   // default: 5 min
+```
+
+**Replace:**
+```
+        if override < 0 { return .infinity }   // -1 = no timeout (default)
+        return override > 0 ? override : .infinity
+```
+
+**Sub-patch P12b** — `Sources/SettingsView.swift` — @AppStorage default to -1:
+
+**Search:**
+```
+    @AppStorage("transcription_timeout_seconds") private var transcriptionTimeoutRaw: Double = 300
+```
+
+**Replace:**
+```
+    @AppStorage("transcription_timeout_seconds") private var transcriptionTimeoutRaw: Double = -1
+```
+
+**Sub-patch P12c** — `Sources/AppState.swift` — add `transcriptionAlertShown` flag near timer vars:
+
+**Search:**
+```
+    private var transcriptionStartTime: Date?
+    private var transcriptionElapsedTimer: Timer?
+    // App that was frontmost when the user pressed stop — paste target for async delivery.
+    private var pasteTargetApp: NSRunningApplication?
+```
+
+**Replace:**
+```
+    private var transcriptionStartTime: Date?
+    private var transcriptionElapsedTimer: Timer?
+    private var transcriptionAlertShown = false
+    // App that was frontmost when the user pressed stop — paste target for async delivery.
+    private var pasteTargetApp: NSRunningApplication?
+```
+
+**Sub-patch P12d** — `Sources/AppState.swift` — update `startTranscriptionElapsedTimer` and `stopTranscriptionElapsedTimer`, add `showTranscriptionStillRunningAlert`:
+
+**Search:**
+```
+    private func startTranscriptionElapsedTimer() {
+        transcriptionStartTime = Date()
+        transcriptionElapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self, self.isTranscribing, let start = self.transcriptionStartTime else { return }
+            let elapsed = Int(-start.timeIntervalSinceNow)
+            guard elapsed >= 20 else { return }
+            let prefix = elapsed >= 60 ? "Still processing" : "Transcribing"
+            self.statusText = "\(prefix)... (\(elapsed)s)"
+        }
+    }
+
+    private func stopTranscriptionElapsedTimer() {
+        transcriptionElapsedTimer?.invalidate()
+        transcriptionElapsedTimer = nil
+        transcriptionStartTime = nil
+    }
+```
+
+**Replace:**
+```
+    private func startTranscriptionElapsedTimer() {
+        transcriptionStartTime = Date()
+        transcriptionAlertShown = false
+        transcriptionElapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self, self.isTranscribing, let start = self.transcriptionStartTime else { return }
+            let elapsed = Int(-start.timeIntervalSinceNow)
+            if elapsed == 10 && !self.transcriptionAlertShown {
+                self.transcriptionAlertShown = true
+                self.showTranscriptionStillRunningAlert(elapsed: elapsed)
+            }
+            guard elapsed >= 20 else { return }
+            let prefix = elapsed >= 60 ? "Still processing" : "Transcribing"
+            self.statusText = "\(prefix)... (\(elapsed)s)"
+        }
+    }
+
+    private func stopTranscriptionElapsedTimer() {
+        transcriptionElapsedTimer?.invalidate()
+        transcriptionElapsedTimer = nil
+        transcriptionStartTime = nil
+        transcriptionAlertShown = false
+    }
+
+    private func showTranscriptionStillRunningAlert(elapsed: Int) {
+        guard isTranscribing else { return }
+        let audioNote: String
+        if let fileName = transcribingAudioFileName {
+            let path = Self.audioStorageDirectory().appendingPathComponent(fileName).path
+            audioNote = "Audio saved to:\n\(path)"
+        } else {
+            audioNote = "Audio saved to:\n~/Library/Application Support/FreeFlow Dev/audio/"
+        }
+        let alert = NSAlert()
+        alert.messageText = "Still transcribing (\(elapsed)s elapsed)"
+        alert.informativeText = "With local processing, this can take as long as your recording — or longer under load.\n\nYour audio is already saved. If you cancel, it will remain on disk and you can retry transcription from the recording history.\n\n\(audioNote)"
+        alert.addButton(withTitle: "Keep Waiting")
+        alert.addButton(withTitle: "Cancel Transcription")
+        if let icon = NSImage(systemSymbolName: "waveform.badge.exclamationmark", accessibilityDescription: nil) {
+            alert.icon = icon
+        }
+        let response = alert.runModal()
+        guard response == .alertSecondButtonReturn, isTranscribing else { return }
+        cancelTranscription()
+    }
+```

--- a/watcher/update-watcher.sh
+++ b/watcher/update-watcher.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# update-watcher.sh — FreeFlow fork upstream watcher
+#
+# 1. Checks the latest upstream release via GitHub API
+# 2. Compares against .last-version in the fork root
+# 3. If newer: clones the new tag, uses pi to apply fork.md patches, builds & installs
+# 4. Pipes the git diff of applied changes to claude for review
+# 5. Saves the review to watcher/last-review.md
+# 6. Records the new version in .last-version
+#
+# Run standalone or via launchd (see plist template at the bottom of this file).
+#
+# Dependencies: git, curl, pi (~/.local/bin/pi or in PATH), claude (in PATH)
+# Note: If curl fails with "Bad file descriptor" or similar socket errors,
+#       temporarily disable LuLu (outbound firewall) and re-run.
+
+set -euo pipefail
+
+FORK_DIR="/Users/personal/Documents/code/freeflow-fork"
+FORK_MD="$FORK_DIR/fork.md"
+LAST_VERSION_FILE="$FORK_DIR/.last-version"
+WATCHER_DIR="$FORK_DIR/watcher"
+REVIEW_FILE="$WATCHER_DIR/last-review.md"
+UPSTREAM_API="https://api.github.com/repos/zachlatta/freeflow/releases/latest"
+UPSTREAM_CLONE_BASE="https://github.com/zachlatta/freeflow"
+CLONE_SCRATCH="/tmp/freeflow-upstream-update"
+
+# Resolve pi binary
+PI_BIN=""
+if command -v pi &>/dev/null; then
+    PI_BIN="pi"
+elif [[ -x "$HOME/.local/bin/pi" ]]; then
+    PI_BIN="$HOME/.local/bin/pi"
+else
+    echo "ERROR: pi not found in PATH or ~/.local/bin/pi" >&2
+    exit 1
+fi
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# ── Step 1: Fetch latest upstream version ────────────────────────────────────
+
+log "Fetching latest upstream release from GitHub API..."
+
+# curl may fail with socket errors if LuLu (outbound firewall) is active.
+# If you see "Bad file descriptor" or similar, disable LuLu temporarily.
+RELEASE_JSON=$(curl --silent --fail --max-time 30 "$UPSTREAM_API" 2>&1) || {
+    echo "ERROR: curl failed fetching $UPSTREAM_API" >&2
+    echo "If you see 'Bad file descriptor' or network errors, disable LuLu temporarily." >&2
+    exit 1
+}
+
+# Parse tag_name — try jq first, fall back to python3, then grep/sed
+if command -v jq &>/dev/null; then
+    LATEST_VERSION=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
+elif command -v python3 &>/dev/null; then
+    LATEST_VERSION=$(echo "$RELEASE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])")
+else
+    # Last-resort: grep for "tag_name" field
+    LATEST_VERSION=$(echo "$RELEASE_JSON" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"//;s/"//')
+fi
+
+if [[ -z "$LATEST_VERSION" || "$LATEST_VERSION" == "null" ]]; then
+    echo "ERROR: Could not parse tag_name from GitHub API response." >&2
+    echo "Response was: $RELEASE_JSON" >&2
+    exit 1
+fi
+
+log "Latest upstream version: $LATEST_VERSION"
+
+# ── Step 2: Compare against stored version ────────────────────────────────────
+
+STORED_VERSION=""
+if [[ -f "$LAST_VERSION_FILE" ]]; then
+    STORED_VERSION=$(cat "$LAST_VERSION_FILE")
+fi
+
+log "Stored version: ${STORED_VERSION:-<none>}"
+
+if [[ "$LATEST_VERSION" == "$STORED_VERSION" ]]; then
+    log "Already up to date ($LATEST_VERSION). Nothing to do."
+    exit 0
+fi
+
+log "New upstream version detected: $STORED_VERSION -> $LATEST_VERSION"
+
+# ── Step 3: Clone new tag and apply patches via pi ────────────────────────────
+
+NEW_SRC_DIR="$CLONE_SCRATCH/$LATEST_VERSION"
+
+if [[ -d "$NEW_SRC_DIR" ]]; then
+    log "Removing stale clone at $NEW_SRC_DIR..."
+    rm -rf "$NEW_SRC_DIR"
+fi
+
+mkdir -p "$CLONE_SCRATCH"
+log "Cloning $UPSTREAM_CLONE_BASE at tag $LATEST_VERSION..."
+git clone --depth 1 --branch "$LATEST_VERSION" "$UPSTREAM_CLONE_BASE" "$NEW_SRC_DIR" 2>&1 || {
+    echo "ERROR: git clone failed. If network errors, disable LuLu temporarily." >&2
+    exit 1
+}
+
+log "Applying fork patches via pi..."
+"$PI_BIN" --model qwen2.5-coder:7b \
+    "Read $FORK_MD. For each patch P1-P10 (and sub-patches P7a/P7b/P7c, P9a/P9b/P9c), apply the Search→Replace to the corresponding file in $NEW_SRC_DIR. Report which patches applied cleanly and which had conflicts."
+
+log "Patches applied (see pi output above)."
+
+# ── Step 4: Build and install ─────────────────────────────────────────────────
+
+log "Building in $NEW_SRC_DIR..."
+(cd "$NEW_SRC_DIR" && make) || {
+    echo "ERROR: Build failed in $NEW_SRC_DIR" >&2
+    exit 1
+}
+
+log "Installing app..."
+cp -r "$NEW_SRC_DIR/build/FreeFlow Dev.app" "/Users/personal/Applications/FreeFlow Dev.app"
+xattr -dr com.apple.quarantine "/Users/personal/Applications/FreeFlow Dev.app"
+log "Installed: /Users/personal/Applications/FreeFlow Dev.app"
+
+# ── Step 5: Review applied patches via claude ─────────────────────────────────
+
+log "Generating review of applied patches..."
+mkdir -p "$WATCHER_DIR"
+
+DIFF_OUTPUT=$(git -C "$NEW_SRC_DIR" diff 2>/dev/null || true)
+
+if [[ -z "$DIFF_OUTPUT" ]]; then
+    log "WARNING: git diff returned empty — patches may not have been applied."
+    REVIEW="WARNING: git diff was empty. pi may not have applied the patches, or they were already present.\n\nNo review generated."
+    printf '%b' "$REVIEW" > "$REVIEW_FILE"
+else
+    REVIEW=$(echo "$DIFF_OUTPUT" | claude --print \
+        "Review these fork patches for correctness: do they apply cleanly and preserve the intended behavior?" \
+        2>&1) || {
+        REVIEW="ERROR: claude review failed. Diff was:\n\n$DIFF_OUTPUT"
+    }
+
+    {
+        echo "# Fork Patch Review — $LATEST_VERSION"
+        echo ""
+        echo "Generated: $(date '+%Y-%m-%d %H:%M:%S')"
+        echo ""
+        echo "## Claude Review"
+        echo ""
+        echo "$REVIEW"
+        echo ""
+        echo "## Raw Diff"
+        echo ""
+        echo '```diff'
+        echo "$DIFF_OUTPUT"
+        echo '```'
+    } > "$REVIEW_FILE"
+fi
+
+log "Review saved to $REVIEW_FILE"
+
+# ── Step 6: Record new version ────────────────────────────────────────────────
+
+echo "$LATEST_VERSION" > "$LAST_VERSION_FILE"
+log "Version updated to $LATEST_VERSION in $LAST_VERSION_FILE"
+log "Done."
+
+# ── Cleanup scratch dir ───────────────────────────────────────────────────────
+
+rm -rf "$NEW_SRC_DIR"
+log "Cleaned up $NEW_SRC_DIR"
+
+: <<'LAUNCHD_PLIST_EXAMPLE'
+# ── launchd plist example ─────────────────────────────────────────────────────
+#
+# Save as ~/Library/LaunchAgents/com.personal.freeflow-update-watcher.plist
+# then: launchctl load ~/Library/LaunchAgents/com.personal.freeflow-update-watcher.plist
+#
+# <?xml version="1.0" encoding="UTF-8"?>
+# <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+#   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+# <plist version="1.0">
+# <dict>
+#     <key>Label</key>
+#     <string>com.personal.freeflow-update-watcher</string>
+#
+#     <key>ProgramArguments</key>
+#     <array>
+#         <string>/bin/bash</string>
+#         <string>/Users/personal/Documents/code/freeflow-fork/watcher/update-watcher.sh</string>
+#     </array>
+#
+#     <!-- Run once daily at 09:00 -->
+#     <key>StartCalendarInterval</key>
+#     <dict>
+#         <key>Hour</key>
+#         <integer>9</integer>
+#         <key>Minute</key>
+#         <integer>0</integer>
+#     </dict>
+#
+#     <key>StandardOutPath</key>
+#     <string>/Users/personal/Documents/code/freeflow-fork/watcher/update-watcher.log</string>
+#     <key>StandardErrorPath</key>
+#     <string>/Users/personal/Documents/code/freeflow-fork/watcher/update-watcher.log</string>
+#
+#     <!-- Keep the agent alive on failure -->
+#     <key>KeepAlive</key>
+#     <false/>
+#
+#     <!-- Run immediately on load if the scheduled time was missed -->
+#     <key>RunAtLoad</key>
+#     <false/>
+# </dict>
+# </plist>
+LAUNCHD_PLIST_EXAMPLE


### PR DESCRIPTION
> **Human notes**
>
> <!-- Jakob: write here -->

&nbsp;

---

**Everything below this line is AI generated.**

I also opened #250, which you merged, and #252, which is still open. This pull request implements the work described in issues #308 to #314.

---

## What this does

Dictation no longer makes you stand still while it transcribes.

**Delivery goes back to where the words came from.** At stop time the fork pins the focused `AXUIElement` and its `kAXSelectedTextRange`, then walks an ordered ladder to put the transcript there: an Accessibility write into that exact element, a Cmd-V addressed to the process, unicode key events addressed to the process, and finally the clipboard with a panel saying so. Only the opt-in rung activates anything, so switching window, app or Desktop mid-transcription is safe. Today's `activate` plus Cmd-V survives as that opt-in rung.

**Dictations can overlap.** `isTranscribing` was a single boolean and `transcriptionTask` a single task, so the next dictation had to wait. Sessions are now keyed by UUID, each carrying its own delivery target, with `isTranscribing` derived from the live set. Against a local model that removes a 10 to 25 second wait per 30 seconds of speech.

**The overlay tells the truth about what is still running.** It stays up until the last transcription has delivered, with a count badge covering every transcription in flight plus the recording in progress, shown from two onwards.

**The recording indicator shows loudness.** A scrolling meter rather than a waveform whose motion is independent of the level.

## Things found along the way that may matter to you regardless of this PR

- An Accessibility write into a Chromium or Electron host returns `.success` while the text never reaches the editable surface. Very likely the same root cause as #237. The insert now verifies by measuring the element before and after.
- Chromium reads a synthesised key event by its virtual key code and ignores the attached unicode, so injected text arrives as a stray keypress.
- Chromium only handles key events while it is the active application, so there is no way to deliver into a backgrounded Electron app without stealing focus. The fork stops pretending otherwise and falls through to the clipboard.
- Three hazards that only exist once dictations can overlap: the shared `AudioRecorder` being cleaned up by an earlier session's completion, the clipboard snapshot capturing a previous transcript, and `endCriticalDictationActivity()` firing early.

## Honest limits

- Caret-exact insertion cannot work in terminals: no editable Accessibility element, so no range to restore. Written up in #308 with what I tried, including `TIOCSTI`, which macOS refuses for non-root.
- Backgrounded Chromium hosts fall through to the clipboard, by design rather than by accident.

## How it was built and tested

Written with AI assistance, then used daily against a local Qwen3 ASR server. Verified in Claude Code, pi, Brave, Terminal, Tana and native text fields, across windows, applications and Spaces. Every delivery writes its whole ladder to a `delivery.log` beside the run log, which is where most of the findings above came from.

Happy to split this into smaller pieces if that suits review better. #314 in particular is a one-line fix that stands entirely on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous transcript delivery to the original target using accessibility insertion, keystrokes, paste, or clipboard fallback.
  * Added support for overlapping dictation sessions and transcription prefetching.
  * Added loudness meter, transcription progress, and clipboard-waiting panels.
  * Added settings for delivery behavior, background transcription, overlapping dictation, focus handling, and transcription timeouts.

* **Bug Fixes**
  * Fixed missed first toggle-stop presses and improved delivery failure detection.
  * Bare Escape now passes through unless Fn is held.

* **Performance**
  * Increased transcription request time limits for longer recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->